### PR TITLE
Add observable bot brain status and spot decisions

### DIFF
--- a/src/GameServer/Bot/AI/BotDecisionService.js
+++ b/src/GameServer/Bot/AI/BotDecisionService.js
@@ -1,0 +1,116 @@
+const SpotService = invoke('GameServer/Bot/AI/SpotService');
+
+const MOVE_TO_SPOT_COOLDOWN = 15000;
+
+function now() {
+    return Date.now();
+}
+
+function canMoveToSpot(session) {
+    return !session.lastSpotMoveAt || (now() - session.lastSpotMoveAt) > MOVE_TO_SPOT_COOLDOWN;
+}
+
+const BotDecisionService = {
+    suggest(status, session) {
+        if (!status || !status.available) {
+            return {
+                action: 'idle',
+                reason: 'missing_status'
+            };
+        }
+
+        if (status.blockers.includes('dead')) {
+            return {
+                action: 'wait_for_revive',
+                reason: 'dead'
+            };
+        }
+
+        if (status.mode === 'resting') {
+            return {
+                action: 'recover',
+                reason: 'already_resting'
+            };
+        }
+
+        if (status.blockers.includes('low_hp') || status.blockers.includes('low_mp')) {
+            return {
+                action: 'rest',
+                reason: status.blockers.includes('low_hp') ? 'low_hp' : 'low_mp'
+            };
+        }
+
+        if (status.mode === 'following') {
+            if (status.blockers.includes('too_far_from_leader')) {
+                return {
+                    action: 'catch_up_to_leader',
+                    reason: 'too_far_from_leader',
+                    leader: status.party?.leader || null
+                };
+            }
+
+            if (status.target) {
+                return {
+                    action: 'assist_leader',
+                    reason: 'leader_has_target',
+                    target: status.target
+                };
+            }
+
+            return {
+                action: status.party?.stance === 'stay' ? 'hold_position' : 'follow_leader',
+                reason: 'party_stance'
+            };
+        }
+
+        if (status.target && status.target.dead === false) {
+            return {
+                action: status.mode === 'pk_hunting' ? 'attack_player' : 'attack_target',
+                reason: 'active_target',
+                target: status.target
+            };
+        }
+
+        if (status.mode === 'hunting' && status.nearby.attackableNpcs === 0) {
+            if (!canMoveToSpot(session)) {
+                return {
+                    action: 'search_locally',
+                    reason: 'spot_move_cooldown'
+                };
+            }
+
+            const candidate = SpotService.findBestSpot(status);
+            if (candidate) {
+                return {
+                    action: 'move_to_spot',
+                    reason: 'no_targets_nearby',
+                    spot: candidate.spot,
+                    score: candidate.score,
+                    distance: candidate.distance,
+                    levelGap: candidate.levelGap
+                };
+            }
+        }
+
+        if (status.mode === 'hunting' && status.blockers.includes('no_targets_nearby')) {
+            const candidate = canMoveToSpot(session) ? SpotService.findBestSpot(status, { minDensity: 2 }) : null;
+            if (candidate) {
+                return {
+                    action: 'move_to_spot',
+                    reason: 'search_exhausted',
+                    spot: candidate.spot,
+                    score: candidate.score,
+                    distance: candidate.distance,
+                    levelGap: candidate.levelGap
+                };
+            }
+        }
+
+        return {
+            action: 'search_locally',
+            reason: 'default'
+        };
+    }
+};
+
+module.exports = BotDecisionService;

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -1,0 +1,218 @@
+const SpeckMath = invoke('GameServer/SpeckMath');
+
+const ROLE_CLASSES = {
+    healer: [15, 16, 17, 29, 30, 42, 43],
+    tank: [4, 5, 6, 19, 20, 32, 33],
+    archer: [8, 9, 22, 23, 35, 36, 37],
+    mage: [10, 11, 12, 13, 14, 15, 16, 17, 25, 26, 27, 28, 29, 30, 38, 39, 40, 41, 42, 43, 49, 50, 51, 52]
+};
+
+function ratio(value, max) {
+    if (!max) return 0;
+    return Math.max(0, Math.min(1, value / max));
+}
+
+function distance2d(a, b) {
+    if (!a || !b) return null;
+    const dx = a.locX - b.locX;
+    const dy = a.locY - b.locY;
+    return Math.sqrt(dx * dx + dy * dy);
+}
+
+function actorLocation(actor) {
+    if (!actor) return null;
+    return {
+        locX: actor.fetchLocX(),
+        locY: actor.fetchLocY(),
+        locZ: actor.fetchLocZ()
+    };
+}
+
+function actorSummary(actor, fromActor) {
+    if (!actor) return null;
+    const loc = actorLocation(actor);
+    return {
+        id: actor.fetchId(),
+        name: actor.fetchName(),
+        level: actor.fetchLevel(),
+        loc,
+        distance: fromActor ? distance2d(loc, actorLocation(fromActor)) : null,
+        dead: actor.state ? actor.state.fetchDead() : actor.isDead(),
+        karma: typeof actor.fetchKarma === 'function' ? actor.fetchKarma() : 0
+    };
+}
+
+function findTarget(session, bot) {
+    if (!session.currentTargetId) return null;
+
+    const World = invoke('GameServer/World/World');
+    const userSession = World.user.sessions.find((ob) => ob.actor && ob.actor.fetchId() === session.currentTargetId);
+    if (userSession && userSession.actor) {
+        return { type: 'user', ...actorSummary(userSession.actor, bot) };
+    }
+
+    const npc = World.npc.spawns.find((ob) => ob.fetchId() === session.currentTargetId);
+    if (npc) {
+        return {
+            type: 'npc',
+            ...actorSummary(npc, bot),
+            attackable: npc.fetchAttackable()
+        };
+    }
+
+    return {
+        type: 'unknown',
+        id: session.currentTargetId
+    };
+}
+
+function inferRole(bot) {
+    const classId = bot.fetchClassId();
+    if (ROLE_CLASSES.healer.includes(classId)) return 'healer';
+    if (ROLE_CLASSES.tank.includes(classId)) return 'tank';
+    if (ROLE_CLASSES.archer.includes(classId)) return 'archer';
+    if (ROLE_CLASSES.mage.includes(classId)) return 'mage';
+    return 'dps';
+}
+
+function inferIntent(session, bot, vitals, target) {
+    if (bot.state.fetchDead()) return 'revive';
+    if (session.plan === 'resting') return 'recover';
+    if (session.plan === 'shopping') return 'restock';
+    if (session.plan === 'getting_buffed') return 'refresh_buffs';
+    if (session.plan === 'fleeing' || session.plan === 'pk_fleeing') return 'escape_threat';
+    if (session.plan === 'merchant') return 'trade';
+    if (session.plan === 'following') {
+        if (target) return 'assist_leader';
+        if (session.botStay) return 'hold_position';
+        return 'follow_leader';
+    }
+    if (session.plan === 'pk_hunting') {
+        return target ? 'hunt_player' : 'find_player';
+    }
+    if (vitals.hpPct < 0.35 || vitals.mpPct < 0.20) return 'recover';
+    return target ? 'fight_target' : 'find_target';
+}
+
+function collectBlockers(session, bot, vitals, party) {
+    const blockers = [];
+
+    if (bot.state.fetchDead()) blockers.push('dead');
+    if (vitals.hpPct < 0.35) blockers.push('low_hp');
+    if (vitals.mpPct < 0.20) blockers.push('low_mp');
+    if (session.stuckTicks >= 3) blockers.push('stuck');
+    if (party && party.leader && party.leader.distance > 1000) blockers.push('too_far_from_leader');
+    if (session.plan === 'hunting' && session.noTargetTicks >= 3) blockers.push('no_targets_nearby');
+
+    return blockers;
+}
+
+function nearbySnapshot(bot) {
+    const World = invoke('GameServer/World/World');
+    const loc = actorLocation(bot);
+    let realPlayers = 0;
+    let friendlyBots = 0;
+    let hostilePlayers = 0;
+    let attackableNpcs = 0;
+
+    World.user.sessions.forEach((session) => {
+        const actor = session.actor;
+        if (!actor || actor === bot || !actor.fetchIsOnline()) return;
+        if (distance2d(actorLocation(actor), loc) > 1500) return;
+
+        if (session.accountId && session.accountId.startsWith('bot_')) {
+            friendlyBots++;
+        } else {
+            realPlayers++;
+        }
+
+        if (typeof actor.fetchKarma === 'function' && actor.fetchKarma() > 0) {
+            hostilePlayers++;
+        }
+    });
+
+    World.fetchNpcsInRadius(bot.fetchLocX(), bot.fetchLocY(), 1500).forEach((npc) => {
+        if (npc.fetchAttackable() && !npc.isDead()) {
+            attackableNpcs++;
+        }
+    });
+
+    return { realPlayers, friendlyBots, hostilePlayers, attackableNpcs };
+}
+
+const BotStatus = {
+    getStatus(session) {
+        const bot = session.actor;
+        if (!bot) {
+            return {
+                available: false,
+                reason: 'missing_actor'
+            };
+        }
+
+        const vitals = {
+            hp: bot.fetchHp(),
+            maxHp: bot.fetchMaxHp(),
+            hpPct: ratio(bot.fetchHp(), bot.fetchMaxHp()),
+            mp: bot.fetchMp(),
+            maxMp: bot.fetchMaxMp(),
+            mpPct: ratio(bot.fetchMp(), bot.fetchMaxMp())
+        };
+
+        const target = findTarget(session, bot);
+        const party = session.followPlayerSession ? {
+            leader: actorSummary(session.followPlayerSession.actor, bot),
+            role: inferRole(bot),
+            stance: session.botStay ? 'stay' : 'follow',
+            autoTaunt: session.autoTaunt !== false
+        } : null;
+
+        const status = {
+            available: true,
+            id: bot.fetchId(),
+            name: bot.fetchName(),
+            level: bot.fetchLevel(),
+            classId: bot.fetchClassId(),
+            mode: session.plan || 'hunting',
+            intent: undefined,
+            role: inferRole(bot),
+            loc: actorLocation(bot),
+            vitals,
+            target,
+            party,
+            spot: session.currentSpot || null,
+            movement: {
+                moving: !!session.moveTimer || !!bot.state.fetchTowards(),
+                towards: bot.state.fetchTowards() || false,
+                stuckTicks: session.stuckTicks || 0
+            },
+            timers: {
+                deathStartedAt: session.deathTimerStart || null,
+                fleeStartedAt: session.fleeStart || null,
+                shopStartedAt: session.shopTimer || null
+            },
+            nearby: nearbySnapshot(bot),
+            blockers: []
+        };
+
+        status.intent = inferIntent(session, bot, vitals, target);
+        status.blockers = collectBlockers(session, bot, vitals, party);
+        return status;
+    },
+
+    summarize(status) {
+        if (!status || !status.available) return 'Bot status unavailable.';
+
+        const hp = Math.round(status.vitals.hpPct * 100);
+        const mp = Math.round(status.vitals.mpPct * 100);
+        const target = status.target && status.target.name ? ` target=${status.target.name}` : '';
+        const spot = status.spot && status.spot.name ? ` spot=${status.spot.name}` : '';
+        const blockers = status.blockers.length > 0 ? ` blockers=${status.blockers.join(',')}` : '';
+
+        return `${status.name}: mode=${status.mode} intent=${status.intent} role=${status.role} hp=${hp}% mp=${mp}%${target}${spot}${blockers}`;
+    }
+};
+
+BotStatus.ROLE_CLASSES = ROLE_CLASSES;
+
+module.exports = BotStatus;

--- a/src/GameServer/Bot/AI/SpotService.js
+++ b/src/GameServer/Bot/AI/SpotService.js
@@ -1,0 +1,186 @@
+const GRID_SIZE = 6000;
+const DEFAULT_LEVEL_RANGE = 3;
+
+function distance2d(a, b) {
+    if (!a || !b) return 0;
+    const dx = a.locX - b.locX;
+    const dy = a.locY - b.locY;
+    return Math.sqrt(dx * dx + dy * dy);
+}
+
+function locFromActor(actor) {
+    return {
+        locX: actor.fetchLocX(),
+        locY: actor.fetchLocY(),
+        locZ: actor.fetchLocZ()
+    };
+}
+
+function spotName(spot) {
+    const primary = spot.npcNames[0] || 'Hunting Ground';
+    if (spot.npcNames.length <= 1) return primary;
+    return `${primary} fields`;
+}
+
+const SpotService = {
+    spots: null,
+
+    reset() {
+        this.spots = null;
+    },
+
+    ensureIndexed() {
+        if (this.spots) return this.spots;
+
+        const World = invoke('GameServer/World/World');
+        const sectors = {};
+
+        World.npc.spawns.forEach((npc) => {
+            if (!npc.fetchAttackable || !npc.fetchAttackable()) return;
+
+            const gx = Math.floor(npc.fetchLocX() / GRID_SIZE);
+            const gy = Math.floor(npc.fetchLocY() / GRID_SIZE);
+            const key = `${gx}_${gy}`;
+
+            if (!sectors[key]) {
+                sectors[key] = {
+                    id: key,
+                    count: 0,
+                    sumX: 0,
+                    sumY: 0,
+                    sumZ: 0,
+                    minLevel: Infinity,
+                    maxLevel: 0,
+                    levels: {},
+                    names: {}
+                };
+            }
+
+            const sector = sectors[key];
+            const level = npc.fetchLevel();
+            const name = npc.fetchName();
+
+            sector.count++;
+            sector.sumX += npc.fetchLocX();
+            sector.sumY += npc.fetchLocY();
+            sector.sumZ += npc.fetchLocZ();
+            sector.minLevel = Math.min(sector.minLevel, level);
+            sector.maxLevel = Math.max(sector.maxLevel, level);
+            sector.levels[level] = (sector.levels[level] || 0) + 1;
+            sector.names[name] = (sector.names[name] || 0) + 1;
+        });
+
+        this.spots = Object.values(sectors).map((sector) => {
+            const levelEntries = Object.entries(sector.levels)
+                .map(([level, count]) => ({ level: Number(level), count }))
+                .sort((a, b) => b.count - a.count);
+            const nameEntries = Object.entries(sector.names)
+                .map(([name, count]) => ({ name, count }))
+                .sort((a, b) => b.count - a.count);
+            const avgLevel = levelEntries.reduce((sum, item) => sum + item.level * item.count, 0) / sector.count;
+
+            const spot = {
+                id: sector.id,
+                name: '',
+                center: {
+                    locX: Math.round(sector.sumX / sector.count),
+                    locY: Math.round(sector.sumY / sector.count),
+                    locZ: Math.round(sector.sumZ / sector.count)
+                },
+                minLevel: sector.minLevel,
+                maxLevel: sector.maxLevel,
+                avgLevel: Math.round(avgLevel * 10) / 10,
+                density: sector.count,
+                npcNames: nameEntries.slice(0, 3).map((item) => item.name),
+                dominantLevels: levelEntries.slice(0, 3)
+            };
+
+            spot.name = spotName(spot);
+            return spot;
+        });
+
+        return this.spots;
+    },
+
+    findById(id) {
+        return this.ensureIndexed().find((spot) => spot.id === id) || null;
+    },
+
+    findCurrentSpot(loc) {
+        const gx = Math.floor(loc.locX / GRID_SIZE);
+        const gy = Math.floor(loc.locY / GRID_SIZE);
+        return this.findById(`${gx}_${gy}`);
+    },
+
+    findBestSpot(status, options = {}) {
+        const loc = status.loc;
+        const targetLevel = options.level || status.level || 1;
+        const levelRange = options.levelRange || DEFAULT_LEVEL_RANGE;
+        const currentSpotId = status.spot?.id;
+        const minDistance = options.minDistance || 1200;
+        const maxDistance = options.maxDistance || 90000;
+
+        const candidates = this.ensureIndexed()
+            .filter((spot) => spot.density >= (options.minDensity || 4))
+            .filter((spot) => spot.minLevel <= targetLevel + levelRange && spot.maxLevel >= targetLevel - levelRange)
+            .filter((spot) => {
+                const dist = distance2d(loc, spot.center);
+                return dist >= minDistance && dist <= maxDistance;
+            })
+            .map((spot) => {
+                const levelGap = Math.abs(spot.avgLevel - targetLevel);
+                const dist = distance2d(loc, spot.center);
+                const sameSpotPenalty = currentSpotId && currentSpotId === spot.id ? 100 : 0;
+                const peacePenalty = utils.isInPeaceZone(spot.center.locX, spot.center.locY) ? 40 : 0;
+
+                return {
+                    spot,
+                    score: (spot.density * 3) - (levelGap * 18) - (dist / 2500) - sameSpotPenalty - peacePenalty,
+                    distance: dist,
+                    levelGap
+                };
+            })
+            .sort((a, b) => b.score - a.score);
+
+        return candidates[0] || null;
+    },
+
+    assignSpot(session, spot) {
+        if (!spot) return null;
+        session.currentSpot = {
+            id: spot.id,
+            name: spot.name,
+            center: { ...spot.center },
+            minLevel: spot.minLevel,
+            maxLevel: spot.maxLevel,
+            avgLevel: spot.avgLevel,
+            density: spot.density,
+            npcNames: [...spot.npcNames]
+        };
+        return session.currentSpot;
+    },
+
+    randomPointNear(spot, radius = 900) {
+        const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
+        const angle = Math.random() * Math.PI * 2;
+        const dist = Math.random() * radius;
+        const locX = Math.round(spot.center.locX + Math.cos(angle) * dist);
+        const locY = Math.round(spot.center.locY + Math.sin(angle) * dist);
+
+        return {
+            locX,
+            locY,
+            locZ: GeodataEngine.getHeight(locX, locY, spot.center.locZ)
+        };
+    },
+
+    describe(spot) {
+        if (!spot) return 'unknown spot';
+        return `${spot.name} (Lv ${spot.minLevel}-${spot.maxLevel}, density ${spot.density})`;
+    },
+
+    distance2d,
+    locFromActor
+};
+
+module.exports = SpotService;

--- a/src/GameServer/Bot/AI/States/HuntingState.js
+++ b/src/GameServer/Bot/AI/States/HuntingState.js
@@ -2,6 +2,8 @@ const SpeckMath      = invoke('GameServer/SpeckMath');
 const World          = invoke('GameServer/World/World');
 const ServerResponse = invoke('GameServer/Network/Response');
 const GeodataEngine  = invoke('GameServer/Geodata/GeodataEngine');
+const SpotService    = invoke('GameServer/Bot/AI/SpotService');
+const DecisionService = invoke('GameServer/Bot/AI/BotDecisionService');
 
 module.exports = {
     tick(session, bot, Generics, BotAI) {
@@ -178,14 +180,62 @@ module.exports = {
             });
 
             if (closestMonster) {
+                session.noTargetTicks = 0;
                 session.currentTargetId = closestMonster.fetchId();
                 bot.select({ id: closestMonster.fetchId() });
+
+                if (!session.currentSpot) {
+                    const spot = SpotService.findCurrentSpot({
+                        locX: bot.fetchLocX(),
+                        locY: bot.fetchLocY(),
+                        locZ: bot.fetchLocZ()
+                    });
+                    SpotService.assignSpot(session, spot);
+                }
 
                 if (Math.random() < 0.15) {
                     BotAI.say(session, BotAI.getRandomPhrase('foundTarget', closestMonster.fetchName()));
                 }
                 BotAI.executeCombat(session, bot, closestMonster, Generics);
             } else {
+                session.noTargetTicks = (session.noTargetTicks || 0) + 1;
+
+                const currentSpot = SpotService.findCurrentSpot({
+                    locX: bot.fetchLocX(),
+                    locY: bot.fetchLocY(),
+                    locZ: bot.fetchLocZ()
+                });
+                if (!session.currentSpot && currentSpot) {
+                    SpotService.assignSpot(session, currentSpot);
+                }
+
+                const decision = DecisionService.suggest(BotAI.getStatus(session), session);
+                session.lastDecision = {
+                    action: decision.action,
+                    reason: decision.reason,
+                    spotId: decision.spot?.id || null,
+                    spotName: decision.spot?.name || null
+                };
+
+                if (decision.action === 'move_to_spot' && decision.spot) {
+                    const assignedSpot = SpotService.assignSpot(session, decision.spot);
+                    const targetLoc = SpotService.randomPointNear(decision.spot);
+
+                    session.initialSpawnCoord = { ...assignedSpot.center };
+                    session.lastSpotMoveAt = Date.now();
+                    session.noTargetTicks = 0;
+
+                    if (Math.random() < 0.65) {
+                        BotAI.say(session, `No good mobs here. Moving to ${SpotService.describe(decision.spot)}.`);
+                    }
+
+                    bot.moveTo({
+                        from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
+                        to: targetLoc
+                    });
+                    return;
+                }
+
                 // Wandering to search for monsters in starting zones if none nearby
                 if (Math.random() < 0.50) {
                     if (!session.initialSpawnCoord) {

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -273,7 +273,7 @@ const BotAI = {
             });
         }
 
-        if (minDist > 1500 && !isCompanion) {
+        if (onlinePlayers.length > 0 && minDist > 1500 && !isCompanion) {
             // Far-away bot: light background event processing, skip everything else
             if (Math.random() < 0.05) {
                 this.triggerFarAwayChatEvent(session, bot);

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -2,6 +2,7 @@ const World          = invoke('GameServer/World/World');
 const ServerResponse = invoke('GameServer/Network/Response');
 const SpeckMath      = invoke('GameServer/SpeckMath');
 const GeodataEngine  = invoke('GameServer/Geodata/GeodataEngine');
+const BotStatus      = invoke('GameServer/Bot/AI/BotStatus');
 
 const CHAT_PHRASES = {
     foundTarget: [
@@ -246,6 +247,8 @@ const BotAI = {
         const bot = session.actor;
         if (!bot) return;
 
+        session.botStatus = BotStatus.getStatus(session);
+
         const isCompanion = !!session.followPlayerSession;
         const World = invoke('GameServer/World/World');
         const onlinePlayers = World.user.sessions.filter(s => 
@@ -365,6 +368,7 @@ const BotAI = {
         if (state) {
             try {
                 state.tick(session, bot, Generics, BotAI);
+                session.botStatus = BotStatus.getStatus(session);
             } catch (err) {
                 console.error(`Error in Bot AI State (${session.plan}) tick:`, err);
             }
@@ -474,6 +478,16 @@ const BotAI = {
                 session.actor
             );
         }
+    },
+
+    getStatus(session) {
+        const status = BotStatus.getStatus(session);
+        session.botStatus = status;
+        return status;
+    },
+
+    summarizeStatus(session) {
+        return BotStatus.summarize(this.getStatus(session));
     }
 };
 

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -43,6 +43,10 @@ const BotManager = {
         return this.sessions.find((session) => session.actor && session.actor.fetchName().toLowerCase() === lookup);
     },
 
+    findSessionById(id) {
+        return this.sessions.find((session) => session.actor && session.actor.fetchId() === id);
+    },
+
     getBotStatus(sessionOrName) {
         const session = typeof sessionOrName === 'string' ? this.findSessionByName(sessionOrName) : sessionOrName;
         if (!session) return null;
@@ -53,6 +57,57 @@ const BotManager = {
         return this.sessions
             .filter((session) => session.actor)
             .map((session) => BotAI.getStatus(session));
+    },
+
+    renderBotStatusPanel(playerSession, botSession = null) {
+        if (!playerSession.actor) return;
+
+        const ServerResponse = invoke('GameServer/Network/Response');
+        const pct = (value) => `${Math.round((value || 0) * 100)}%`;
+        const row = (label, value) => `<tr><td width=80><font color="LEVEL">${label}</font></td><td width=190>${value}</td></tr>`;
+
+        if (!botSession) {
+            const statuses = this.getAllBotStatuses().slice(0, 14);
+            let html = `<html><body><title>Bot Status</title><font color="LEVEL">Bot Runtime Status</font><br><br>`;
+            statuses.forEach((status) => {
+                const blockers = status.blockers.length > 0 ? ` / ${status.blockers.join(',')}` : '';
+                html += `<a action="bypass -h bot-status ${status.name}">${status.name}</a>: ${status.mode}, ${status.intent}, HP ${pct(status.vitals.hpPct)}, MP ${pct(status.vitals.mpPct)}${blockers}<br>`;
+            });
+            html += `</body></html>`;
+            playerSession.dataSendToMe(ServerResponse.npcHtml(playerSession.actor.fetchId(), html));
+            return;
+        }
+
+        const status = this.getBotStatus(botSession);
+        if (!status || !status.available) {
+            playerSession.dataSendToMe(ServerResponse.npcHtml(playerSession.actor.fetchId(), `<html><body><title>Bot Status</title>Bot status unavailable.</body></html>`));
+            return;
+        }
+
+        const spot = status.spot ? `${status.spot.name} / Lv ${status.spot.minLevel}-${status.spot.maxLevel} / density ${status.spot.density}` : 'none';
+        const target = status.target ? `${status.target.type}:${status.target.name || status.target.id}` : 'none';
+        const party = status.party ? `${status.party.role}, ${status.party.stance}, leader ${status.party.leader?.name || 'unknown'}` : 'none';
+        const blockers = status.blockers.length > 0 ? status.blockers.join(', ') : 'none';
+        const decision = botSession.lastDecision ? `${botSession.lastDecision.action} / ${botSession.lastDecision.reason}${botSession.lastDecision.spotName ? ` / ${botSession.lastDecision.spotName}` : ''}` : 'none';
+
+        let html = `<html><body><title>Bot Status</title><font color="LEVEL">${status.name}</font><br><br>`;
+        html += `<table width=270>`;
+        html += row('Mode', status.mode);
+        html += row('Intent', status.intent);
+        html += row('Role', status.role);
+        html += row('Vitals', `HP ${pct(status.vitals.hpPct)} / MP ${pct(status.vitals.mpPct)}`);
+        html += row('Target', target);
+        html += row('Party', party);
+        html += row('Spot', spot);
+        html += row('Nearby', `players ${status.nearby.realPlayers}, bots ${status.nearby.friendlyBots}, mobs ${status.nearby.attackableNpcs}`);
+        html += row('Move', status.movement.moving ? `moving (${status.movement.towards})` : 'idle');
+        html += row('Blockers', blockers);
+        html += row('Decision', decision);
+        html += `</table><br>`;
+        html += `<a action="bypass -h bot-status ${status.name}">Refresh</a>`;
+        html += `</body></html>`;
+
+        playerSession.dataSendToMe(ServerResponse.npcHtml(playerSession.actor.fetchId(), html));
     },
 
     init() {

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -136,6 +136,7 @@ const BotManager = {
                 this.provisionAndSpawn(botData, idx);
             });
             this.startDynamicScalingMonitor();
+            this.startStatusLogMonitor();
         }, 5000);
     },
 
@@ -570,6 +571,29 @@ const BotManager = {
                 console.error("Dynamic Scaling Monitor Error:", err);
             }
         }, 5000); // Check and scale bots every 5 seconds
+    },
+
+    startStatusLogMonitor() {
+        if (process.env.BOT_STATUS_LOGS === '0') return;
+
+        setInterval(() => {
+            try {
+                const summaries = this.sessions
+                    .filter((session) => session.actor && session.plan !== 'merchant')
+                    .slice(0, 10)
+                    .map((session) => {
+                        const summary = BotAI.summarizeStatus(session);
+                        if (!session.lastDecision) return summary;
+                        return `${summary} decision=${session.lastDecision.action}/${session.lastDecision.reason}`;
+                    });
+
+                if (summaries.length > 0) {
+                    console.info("BotStatus :: %s", summaries.join(" | "));
+                }
+            } catch (err) {
+                console.error("Bot Status Monitor Error:", err);
+            }
+        }, 30000);
     },
 
     monitorAndScaleBots() {

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -38,6 +38,23 @@ const BOT_COMBINATIONS = [
 const BotManager = {
     sessions: [],
 
+    findSessionByName(name) {
+        const lookup = String(name || '').toLowerCase();
+        return this.sessions.find((session) => session.actor && session.actor.fetchName().toLowerCase() === lookup);
+    },
+
+    getBotStatus(sessionOrName) {
+        const session = typeof sessionOrName === 'string' ? this.findSessionByName(sessionOrName) : sessionOrName;
+        if (!session) return null;
+        return BotAI.getStatus(session);
+    },
+
+    getAllBotStatuses() {
+        return this.sessions
+            .filter((session) => session.actor)
+            .map((session) => BotAI.getStatus(session));
+    },
+
     init() {
         console.info("BotManager :: Initializing automated SimPlayers...");
         

--- a/src/GameServer/Network/Request/Speak.js
+++ b/src/GameServer/Network/Request/Speak.js
@@ -40,6 +40,12 @@ function consume(session, data) {
             CompanionControl.render(session);
             return;
         }
+        if (data.text === '.botstatus' || data.text.startsWith('.botstatus ')) {
+            const BotStatus = invoke('GameServer/World/Generics/NpcBypasses/BotStatus');
+            const parts = data.text.split(/\s+/);
+            BotStatus(session, ['bot-status', parts[1]]);
+            return;
+        }
     }
 
     if (data.kind === 1) { // Shout

--- a/src/GameServer/World/Generics/NpcBypasses/BotStatus.js
+++ b/src/GameServer/World/Generics/NpcBypasses/BotStatus.js
@@ -1,0 +1,16 @@
+const BotManager = invoke('GameServer/Bot/BotManager');
+
+function botStatus(session, parts) {
+    const name = parts[1];
+    let targetSession = null;
+
+    if (name) {
+        targetSession = BotManager.findSessionByName(name);
+    } else if (session.actor && session.actor.fetchDestId()) {
+        targetSession = BotManager.findSessionById(session.actor.fetchDestId());
+    }
+
+    BotManager.renderBotStatusPanel(session, targetSession);
+}
+
+module.exports = botStatus;

--- a/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
+++ b/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
@@ -98,6 +98,10 @@ function renderCompanionPanel(session) {
 
         const stayActive = companionSession.botStay === true;
         const tauntActive = companionSession.autoTaunt !== false; // default true for tanks
+        const status = BotManager.getBotStatus(companionSession);
+        const hpPct = status ? Math.round(status.vitals.hpPct * 100) : 0;
+        const mpPct = status ? Math.round(status.vitals.mpPct * 100) : 0;
+        const spotName = status?.spot?.name || 'no spot';
 
         html += `<font color="00FF00">${bot.fetchName()}</font>: `;
 
@@ -118,7 +122,10 @@ function renderCompanionPanel(session) {
             }
         }
 
-        html += ` | <a action="bypass -h companion-control summon ${bot.fetchName()}">Summon</a> | <a action="bypass -h companion-control dismiss ${bot.fetchName()}"><font color="FF5555">Dismiss</font></a><br>`;
+        html += ` | <a action="bypass -h companion-control summon ${bot.fetchName()}">Summon</a> | <a action="bypass -h bot-status ${bot.fetchName()}">Status</a> | <a action="bypass -h companion-control dismiss ${bot.fetchName()}"><font color="FF5555">Dismiss</font></a><br>`;
+        if (status) {
+            html += `<font color="777777">${status.intent} / HP ${hpPct}% / MP ${mpPct}% / ${spotName}</font><br>`;
+        }
         html += `<img src="L2UI.SquareBlank" width=270 height=4><br>`;
     });
 


### PR DESCRIPTION
## Summary

- Add a runtime bot status API that exposes mode, intent, role, vitals, target, party state, current spot, movement, blockers, and last decision context.
- Add spot indexing and decision services so hunting bots can pick better hunting grounds when their current area has no viable targets.
- Expose bot status through the in-game companion/status UI and `.botstatus` chat command.
- Enable offline bot simulation visibility by letting bots continue AI ticks when no real players are online and logging compact `BotStatus` snapshots.

## Why

Bots had useful behavior, but their state was spread across session fields and hard to reason about. This creates a shared status/decision contract that both gameplay code and external analysis can use to answer what a bot is doing and what it should do next.

## Validation

- Started the server and observed bot spawn, hunting/resting/PK states, spot decisions, and periodic `BotStatus` logs without runtime errors.
- Ran `node --check` on changed JavaScript files.
- Ran `node tests/test_pathfinder_astar.js`.
- Ran `node tests/test_path_obstacle.js`.