### PR TITLE
Add trading bots and merchant trade flow

### DIFF
--- a/src/GameServer/Actor/Generics/Select.js
+++ b/src/GameServer/Actor/Generics/Select.js
@@ -32,7 +32,7 @@ function select(session, actor, data) {
                     const BuyMerchantItem = invoke('GameServer/World/Generics/NpcBypasses/BuyMerchantItem');
                     BuyMerchantItem(session, ["buy-merchant-item"]);
                 } else {
-                    session.dataSendToMe(ServerResponse.privateStoreMsg(session.actor, user));
+                    session.dataSendToMe(ServerResponse.privateStoreMsg(user, user.fetchTitle()));
                     session.dataSendToMe(ServerResponse.privateStoreListSell(user, session.actor));
                 }
             } else if (user.fetchPrivateStoreType() === 3) {
@@ -75,7 +75,7 @@ function select(session, actor, data) {
                     if (user.fetchPrivateStoreType && user.fetchPrivateStoreType() !== 0) {
                         session.viewedPrivateStoreSeller = user;
                         if (user.fetchPrivateStoreType() === 1) {
-                            session.dataSendToMe(ServerResponse.privateStoreMsg(session.actor, user));
+                            session.dataSendToMe(ServerResponse.privateStoreMsg(user, user.fetchTitle()));
                             session.dataSendToMe(ServerResponse.privateStoreListSell(user, session.actor));
                         } else if (user.fetchPrivateStoreType() === 3) {
                             session.dataSendToMe(ServerResponse.privateStoreListBuy(session.actor, user));

--- a/src/GameServer/Actor/Generics/UpdateEnvironment.js
+++ b/src/GameServer/Actor/Generics/UpdateEnvironment.js
@@ -16,11 +16,13 @@ function updateEnvironment(session, actor) {
             session.dataSendToMe(ServerResponse.charInfo(user.actor));
             session.dataSendToMe(ServerResponse.relationChanged(user.actor));
 
-            // Send store nameplate: both Sell (type=1) and Buy (type=2) use opcode 0x8c in C2
+            // Merchant bots already expose their store state through CharInfo.
+            // Sending a custom 0x8c text for them is client-unstable on C2.
             const visibleStoreType = user.actor.fetchPrivateStoreType && user.actor.fetchPrivateStoreType();
-            if (visibleStoreType === 1) {
+            const isMerchantBot = user.constructor.name === 'BotSession' && user.plan === 'merchant';
+            if (!isMerchantBot && visibleStoreType === 1) {
                 session.dataSendToMe(ServerResponse.privateStoreMsg(user.actor, user.actor.fetchTitle()));
-            } else if (visibleStoreType === 3) {
+            } else if (!isMerchantBot && visibleStoreType === 3) {
                 session.dataSendToMe(ServerResponse.privateStoreBuyMsg(user.actor, user.actor.fetchTitle()));
             }
 

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -1,5 +1,3 @@
-const SpeckMath = invoke('GameServer/SpeckMath');
-
 const ROLE_CLASSES = {
     healer: [15, 16, 17, 29, 30, 42, 43],
     tank: [4, 5, 6, 19, 20, 32, 33],
@@ -140,6 +138,20 @@ function nearbySnapshot(bot) {
     return { realPlayers, friendlyBots, hostilePlayers, attackableNpcs };
 }
 
+function tradeSnapshot(session, bot) {
+    const store = bot.fetchPrivateStore && bot.fetchPrivateStore();
+    return {
+        store: store ? {
+            type: store.storeType === 3 ? 'buy' : 'sell',
+            title: store.title || '',
+            town: store.town || null,
+            items: store.items ? store.items.length : 0
+        } : null,
+        shoppingTarget: session.shoppingTarget || null,
+        last: session.lastTradeSummary || null
+    };
+}
+
 const BotStatus = {
     getStatus(session) {
         const bot = session.actor;
@@ -192,6 +204,7 @@ const BotStatus = {
                 shopStartedAt: session.shopTimer || null
             },
             nearby: nearbySnapshot(bot),
+            trade: tradeSnapshot(session, bot),
             blockers: []
         };
 

--- a/src/GameServer/Bot/AI/States/HuntingState.js
+++ b/src/GameServer/Bot/AI/States/HuntingState.js
@@ -122,7 +122,8 @@ module.exports = {
             session.preShopLocation = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
             session.plan = 'shopping';
             session.shopTimer = Date.now();
-            BotAI.say(session, `My bags are full of keltir skins! Walking back to ${closestTown.name} to sell and restock.`);
+            session.shoppingTarget = undefined;
+            BotAI.say(session, `My bags are full of loot. Walking back to ${closestTown.name} to sell and restock.`);
             bot.moveTo({
                 from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
                 to: { locX: closestTown.x, locY: closestTown.y, locZ: closestTown.z }

--- a/src/GameServer/Bot/AI/States/MerchantState.js
+++ b/src/GameServer/Bot/AI/States/MerchantState.js
@@ -1,0 +1,30 @@
+const TradeService = invoke('GameServer/Bot/TradeService');
+
+const AD_COOLDOWN = 8 * 60 * 1000;
+
+module.exports = {
+    tick(session, bot, Generics, BotAI) {
+        const store = bot.fetchPrivateStore && bot.fetchPrivateStore();
+        if (!store || !store.items.length) return;
+
+        const now = Date.now();
+        if (session.lastMerchantAdAt && now - session.lastMerchantAdAt < AD_COOLDOWN) return;
+        if (Math.random() > 0.035) return;
+
+        session.lastMerchantAdAt = now;
+
+        const town = store.town || BotAI.getClosestTownName(bot.fetchLocX(), bot.fetchLocY());
+        const names = TradeService.describeStoreItems(store.items, 3);
+        const phrases = store.storeType === 3 ? [
+            `WTB ${names}. Buying near ${town}.`,
+            `Buying ${names} around ${town}. Paying fair adena.`,
+            `WTB local drops: ${names}. Find me in ${town}.`
+        ] : [
+            `WTS ${names} below shop price. I'm near ${town}.`,
+            `Fresh stock: ${names}. Find me in ${town}.`,
+            `Selling ${names} around ${town}. Prices are below regular shops.`
+        ];
+
+        BotAI.trade(session, phrases[Math.floor(Math.random() * phrases.length)]);
+    }
+};

--- a/src/GameServer/Bot/AI/States/ShoppingState.js
+++ b/src/GameServer/Bot/AI/States/ShoppingState.js
@@ -1,17 +1,50 @@
 const SpeckMath      = invoke('GameServer/SpeckMath');
 const ServerResponse = invoke('GameServer/Network/Response');
+const TradeService   = invoke('GameServer/Bot/TradeService');
+
+function formatAdena(value) {
+    return String(value).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
 
 module.exports = {
     tick(session, bot, Generics, BotAI) {
         const closestTown = BotAI.getClosestTown(bot.fetchLocX(), bot.fetchLocY());
-        const distToTown = new SpeckMath.Point3D(bot.fetchLocX(), bot.fetchLocY(), bot.fetchLocZ())
-            .distance(new SpeckMath.Point3D(closestTown.x, closestTown.y, closestTown.z));
-        
-        if (distToTown > 300) {
-            // Keep moving to Town center if got diverted
+
+        if (!session.shoppingTarget) {
+            const BotManager = invoke('GameServer/Bot/BotManager');
+            const buyer = TradeService.findBestBuyerForActor(bot, BotManager.sessions, { town: closestTown });
+
+            if (buyer) {
+                session.shoppingTarget = {
+                    actorId: buyer.actor.fetchId(),
+                    name: buyer.actor.fetchName(),
+                    locX: buyer.actor.fetchLocX(),
+                    locY: buyer.actor.fetchLocY(),
+                    locZ: buyer.actor.fetchLocZ(),
+                    town: buyer.store.town || closestTown.name
+                };
+                BotAI.say(session, `Heading to ${session.shoppingTarget.name} in ${session.shoppingTarget.town} to sell loot.`);
+            } else {
+                session.shoppingTarget = {
+                    actorId: null,
+                    name: `${closestTown.name} general shop`,
+                    locX: closestTown.x,
+                    locY: closestTown.y,
+                    locZ: closestTown.z,
+                    town: closestTown.name
+                };
+                BotAI.say(session, `No player buyer wants this bag. Going to ${closestTown.name} to liquidate junk.`);
+            }
+        }
+
+        const target = session.shoppingTarget;
+        const distToTarget = new SpeckMath.Point3D(bot.fetchLocX(), bot.fetchLocY(), bot.fetchLocZ())
+            .distance(new SpeckMath.Point3D(target.locX, target.locY, target.locZ));
+
+        if (distToTarget > 300) {
             bot.moveTo({
                 from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
-                to: { locX: closestTown.x, locY: closestTown.y, locZ: closestTown.z }
+                to: { locX: target.locX, locY: target.locY, locZ: target.locZ }
             });
             return;
         }
@@ -19,67 +52,99 @@ module.exports = {
         // In town! Wait and pretend to shop
         if (!session.shoppingDoneAnnounced) {
             session.shoppingDoneAnnounced = true;
-
-            // 1. Actually Sell their junk loot using our new sell-junk bypass!
-            const NpcTalkResponse = invoke(path.world + 'NpcTalkResponse');
-            NpcTalkResponse(session, { link: 'sell-junk' });
-
-            // 2. Schedule actual Soulshot purchase after 4 seconds (giving time for the sell payout to register)
-            const Database = invoke('Database');
-            setTimeout(() => {
-                const backpack = bot.backpack;
-                const adena = backpack.fetchTotalAdena();
-                
-                if (adena >= 7000) {
-                    // Deduct 7000 Adena
-                    backpack.stackableExists(57).then((adenaItem) => {
-                        const total = adenaItem.fetchAmount() - 7000;
-                        Database.updateItemAmount(bot.fetchId(), adenaItem.fetchId(), total).then(() => {
-                            adenaItem.setAmount(total);
-                        });
-                    });
-
-                    // Give 1000 No Grade Soulshots (1835)
-                    backpack.stackableExists(1835).then((shotItem) => {
-                        const total = shotItem.fetchAmount() + 1000;
-                        Database.updateItemAmount(bot.fetchId(), shotItem.fetchId(), total).then(() => {
-                            shotItem.setAmount(total);
-                        });
-                    }).catch(() => {
-                        Database.setItem(bot.fetchId(), {
-                            selfId: 1835,
-                            name: "Soulshot: No Grade",
-                            amount: 1000,
-                            equipped: false,
-                            slot: 0
-                        }).then((packet) => {
-                            backpack.insertItem(Number(packet.insertId), 1835, { amount: 1000 });
-                        });
-                    });
-
-                    BotAI.say(session, "Bought 1000x Soulshot: No Grade (-7000 Adena)!");
-                    // Play a fun casting effect to simulate purchasing / soulshots
-                    session.dataSendToOthers(ServerResponse.skillStarted(bot, bot.fetchId(), { fetchSelfId: () => 2001, fetchCalculatedHitTime: () => 500, fetchReuseTime: () => 500 }), bot);
-                } else {
-                    BotAI.say(session, `Not enough Adena to buy Soulshots (Have ${adena}/7000 Adena). Skipping restocking.`);
-                }
-            }, 4000);
-
-            setTimeout(() => {
-                BotAI.say(session, "All stocked up! Returning to the keltir fields.");
-                session.plan = 'hunting';
-                session.shoppingDoneAnnounced = false;
-                
-                // Teleport back to original hunting spot
-                if (session.preShopLocation) {
-                    Generics.teleportTo(session, bot, session.preShopLocation);
-                    session.preShopLocation = undefined;
-                } else if (session.initialSpawnCoord) {
-                    Generics.teleportTo(session, bot, session.initialSpawnCoord);
-                } else {
-                    Generics.teleportTo(session, bot, { locX: -81174, locY: 246037, locZ: -3719 });
-                }
-            }, 9000);
+            this.sellAndRestock(session, bot, Generics, BotAI);
         }
+    },
+
+    async sellAndRestock(session, bot, Generics, BotAI) {
+        const NpcTalkResponse = invoke(path.world + 'NpcTalkResponse');
+        const BotManager = invoke('GameServer/Bot/BotManager');
+        let soldToBuyer = false;
+
+        if (session.shoppingTarget?.actorId) {
+            const buyerSession = BotManager.findSessionById(session.shoppingTarget.actorId);
+            const buyer = buyerSession?.actor;
+            const store = buyer && buyer.fetchPrivateStore ? buyer.fetchPrivateStore() : null;
+
+            if (store && store.storeType === 3) {
+                try {
+                    const result = await TradeService.sellInventoryToStore(bot, store);
+                    if (result.itemsSold > 0) {
+                        soldToBuyer = true;
+                        const sample = result.sold.slice(0, 3).map((line) => `${line.qty}x ${line.name}`).join(', ');
+                        session.lastTradeSummary = `sold ${result.itemsSold} to ${buyer.fetchName()} for ${formatAdena(result.totalAdena)}a`;
+                        BotAI.say(session, `Sold ${sample} to ${buyer.fetchName()} for ${formatAdena(result.totalAdena)} Adena.`);
+                    }
+                } catch (err) {
+                    utils.infoWarn("Shopping", "buyer sale failed for %s: %s", bot.fetchName(), err);
+                }
+            }
+        }
+
+        if (!soldToBuyer) {
+            NpcTalkResponse(session, { link: 'sell-junk' });
+            session.lastTradeSummary = `used general sell-junk at ${session.shoppingTarget?.town || 'town'}`;
+        } else {
+            // Clear leftovers that no local buyer wanted, but keep the market sale as the visible trade event.
+            NpcTalkResponse(session, { link: 'sell-junk' });
+        }
+
+        this.scheduleRestock(session, bot, Generics, BotAI);
+    },
+
+    scheduleRestock(session, bot, Generics, BotAI) {
+        const Database = invoke('Database');
+
+        setTimeout(() => {
+            const backpack = bot.backpack;
+            const adena = backpack.fetchTotalAdena();
+
+            if (adena >= 7000) {
+                backpack.stackableExists(57).then((adenaItem) => {
+                    const total = adenaItem.fetchAmount() - 7000;
+                    Database.updateItemAmount(bot.fetchId(), adenaItem.fetchId(), total).then(() => {
+                        adenaItem.setAmount(total);
+                    });
+                });
+
+                backpack.stackableExists(1835).then((shotItem) => {
+                    const total = shotItem.fetchAmount() + 1000;
+                    Database.updateItemAmount(bot.fetchId(), shotItem.fetchId(), total).then(() => {
+                        shotItem.setAmount(total);
+                    });
+                }).catch(() => {
+                    Database.setItem(bot.fetchId(), {
+                        selfId: 1835,
+                        name: "Soulshot: No Grade",
+                        amount: 1000,
+                        equipped: false,
+                        slot: 0
+                    }).then((packet) => {
+                        backpack.insertItem(Number(packet.insertId), 1835, { amount: 1000 });
+                    });
+                });
+
+                BotAI.say(session, "Bought 1000x Soulshot: No Grade (-7000 Adena)!");
+                session.dataSendToOthers(ServerResponse.skillStarted(bot, bot.fetchId(), { fetchSelfId: () => 2001, fetchCalculatedHitTime: () => 500, fetchReuseTime: () => 500 }), bot);
+            } else {
+                BotAI.say(session, `Not enough Adena to buy Soulshots (Have ${adena}/7000 Adena). Skipping restocking.`);
+            }
+        }, 4000);
+
+        setTimeout(() => {
+            BotAI.say(session, "All stocked up! Returning to the hunting spot.");
+            session.plan = 'hunting';
+            session.shoppingDoneAnnounced = false;
+            session.shoppingTarget = undefined;
+
+            if (session.preShopLocation) {
+                Generics.teleportTo(session, bot, session.preShopLocation);
+                session.preShopLocation = undefined;
+            } else if (session.initialSpawnCoord) {
+                Generics.teleportTo(session, bot, session.initialSpawnCoord);
+            } else {
+                Generics.teleportTo(session, bot, { locX: -81174, locY: 246037, locZ: -3719 });
+            }
+        }, 9000);
     }
 };

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -1,6 +1,4 @@
-const World          = invoke('GameServer/World/World');
 const ServerResponse = invoke('GameServer/Network/Response');
-const SpeckMath      = invoke('GameServer/SpeckMath');
 const GeodataEngine  = invoke('GameServer/Geodata/GeodataEngine');
 const BotStatus      = invoke('GameServer/Bot/AI/BotStatus');
 
@@ -51,7 +49,7 @@ const States = {
     following: invoke('GameServer/Bot/AI/States/FollowingState'),
     hunting: invoke('GameServer/Bot/AI/States/HuntingState'),
     pk_hunting: invoke('GameServer/Bot/AI/States/PkHuntingState'),
-    merchant: { tick() {} }
+    merchant: invoke('GameServer/Bot/AI/States/MerchantState')
 };
 
 const BotAI = {
@@ -109,6 +107,10 @@ const BotAI = {
         if (!bot) return 3000;
 
         const isCompanion = !!session.followPlayerSession;
+        if (session.plan === 'shopping') {
+            return 1500;
+        }
+
         const World = invoke('GameServer/World/World');
         const onlinePlayers = World.user.sessions.filter(s => 
             s.actor && 
@@ -273,7 +275,7 @@ const BotAI = {
             });
         }
 
-        if (onlinePlayers.length > 0 && minDist > 1500 && !isCompanion) {
+        if (onlinePlayers.length > 0 && minDist > 1500 && !isCompanion && session.plan !== 'shopping') {
             // Far-away bot: light background event processing, skip everything else
             if (Math.random() < 0.05) {
                 this.triggerFarAwayChatEvent(session, bot);
@@ -326,7 +328,8 @@ const BotAI = {
                     spawnTarget.locY += (Math.random() - 0.5) * 800;
                     spawnTarget.locZ = GeodataEngine.getHeight(spawnTarget.locX, spawnTarget.locY, spawnTarget.locZ);
                 } else {
-                    if (bot.fetchName().startsWith("Merchant_") || bot.fetchName().startsWith("MerBuy_")) {
+                    const MerchantConfigs = invoke('GameServer/Bot/MerchantStoreConfigs');
+                    if (MerchantConfigs[bot.fetchName()]) {
                         session.plan = 'merchant';
                         bot.state.setSeated(true);
                         spawnTarget = {
@@ -478,6 +481,19 @@ const BotAI = {
                 session.actor
             );
         }
+    },
+
+    trade(session, text) {
+        if (!session.actor) return;
+        const ServerResponse = invoke('GameServer/Network/Response');
+        const World = invoke('GameServer/World/World');
+        const packet = ServerResponse.speak(session.actor, { kind: 8, text: text });
+
+        World.user.sessions.forEach((user) => {
+            if (user.socket && typeof user.socket.write === 'function' && user.accountId.indexOf('bot_') !== 0) {
+                user.dataSendToMe(packet);
+            }
+        });
     },
 
     getStatus(session) {

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -6,6 +6,7 @@ const BotSession  = invoke('GameServer/Bot/BotSession');
 const BotAI       = invoke('GameServer/Bot/BotAI');
 const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
 const MerchantConfigs = invoke('GameServer/Bot/MerchantStoreConfigs');
+const TradeService = invoke('GameServer/Bot/TradeService');
 
 const BOTS_TO_SPAWN = [
     { name: "Bot_Gimli",   race: 4, sex: 0, classId: 53, face: 0, hair: 0, hairColor: 0 }, // Dwarf
@@ -18,7 +19,7 @@ const MERCHANT_BOTS = Object.keys(MerchantConfigs).map(name => {
     return { name: name, race: 4, sex: 0, classId: 53, face: 0, hair: 0, hairColor: 0, locX: cfg.locX, locY: cfg.locY, locZ: cfg.locZ };
 });
 
-const isMerchantName = name => name.startsWith("Merchant_") || name.startsWith("MerBuy_");
+const isMerchantName = name => !!MerchantConfigs[name];
 
 const EXTRA_BOTS_COUNT = 10; // Configurable: Set to 20, 50, or more to scale up the bot count!
 
@@ -89,6 +90,9 @@ const BotManager = {
         const party = status.party ? `${status.party.role}, ${status.party.stance}, leader ${status.party.leader?.name || 'unknown'}` : 'none';
         const blockers = status.blockers.length > 0 ? status.blockers.join(', ') : 'none';
         const decision = botSession.lastDecision ? `${botSession.lastDecision.action} / ${botSession.lastDecision.reason}${botSession.lastDecision.spotName ? ` / ${botSession.lastDecision.spotName}` : ''}` : 'none';
+        const trade = status.trade?.last ? status.trade.last :
+            status.trade?.shoppingTarget ? `going to ${status.trade.shoppingTarget.name}` :
+            status.trade?.store ? `${status.trade.store.type} / ${status.trade.store.title}` : 'none';
 
         let html = `<html><body><title>Bot Status</title><font color="LEVEL">${status.name}</font><br><br>`;
         html += `<table width=270>`;
@@ -103,6 +107,7 @@ const BotManager = {
         html += row('Move', status.movement.moving ? `moving (${status.movement.towards})` : 'idle');
         html += row('Blockers', blockers);
         html += row('Decision', decision);
+        html += row('Trade', trade);
         html += `</table><br>`;
         html += `<a action="bypass -h bot-status ${status.name}">Refresh</a>`;
         html += `</body></html>`;
@@ -265,17 +270,12 @@ const BotManager = {
                             session.actor.setTitle(storeCfg.title);
                             session.actor.setPrivateStoreType(storeCfg.storeType);
 
-                            let fakeObjectIdSeq = 600000000 + utils.randomNumber(100000000);
-                            const storeItems = storeCfg.items.map(item => ({
-                                objectId: ++fakeObjectIdSeq,
-                                selfId: item.selfId,
-                                price: item.price,
-                                count: item.count
-                            }));
+                            const storeItems = TradeService.normalizeStoreItems(storeCfg);
 
                             session.actor.setPrivateStore({
                                 storeType: storeCfg.storeType,
                                 title: storeCfg.title,
+                                town: storeCfg.town,
                                 items: storeItems
                             });
                         }
@@ -298,25 +298,6 @@ const BotManager = {
                 const ServerResponse = invoke('GameServer/Network/Response');
                 session.dataSendToOthers(ServerResponse.charInfo(session.actor), session.actor);
                 session.dataSendToOthers(ServerResponse.relationChanged(session.actor), session.actor);
-
-                // Send store nameplate packet after a short delay so client processes CharInfo first.
-                // Both Sell and Buy stores use opcode 0x8c in C2.
-                if (session.plan === 'merchant') {
-                    const storeType = session.actor.fetchPrivateStoreType();
-                    setTimeout(() => {
-                        if (storeType === 3) {
-                            session.dataSendToOthers(
-                                ServerResponse.privateStoreBuyMsg(session.actor, session.actor.fetchTitle()),
-                                session.actor
-                            );
-                        } else {
-                            session.dataSendToOthers(
-                                ServerResponse.privateStoreMsg(session.actor, session.actor.fetchTitle()),
-                                session.actor
-                            );
-                        }
-                    }, 500);
-                }
 
                 // Start AI loop
                 BotAI.init(session);
@@ -1051,16 +1032,16 @@ const CONVERSATION_TOPICS = [
 ];
 
 const GLOBAL_SHOUTS = [
-    "WTB Keltir Claws 20a each! PM me!",
-    "LFG for Orc farming, level 6 Elf here!",
-    "Anyone got a spare wooden shield? WTB cheap!",
-    "Gimli here, selling dwarven scrap metal near the town square!",
+    "WTB starter mats near Talking Island. Check Nika or Tarin.",
+    "Mira has cheap mats and soulshots around Talking Island.",
+    "Need D-grade parts? Maren is buying near Gludio.",
+    "Rina has C-grade craft stock in Dion, cheaper than shop.",
     "Wow, this server is so smooth! Loving the solo gameplay.",
     "LFP / Party invite me! Aragorn level 5 ready to hunt!",
     "Legolas is looking for Gandalf, where you at?",
-    "Selling Keltir meat, fresh and delicious! PM me!",
-    "Who is up for some Orc Archer hunting? Level 8 Knight WTT help.",
-    "This Talking Island is so cozy, perfect classic vibes!"
+    "Pavel and Tessa are buying Giran drops.",
+    "Who is up for Orc Archer hunting? Level 8 Knight WTT help.",
+    "Iris has B/A mats near Oren, prices below regular shops."
 ];
 
 module.exports = BotManager;

--- a/src/GameServer/Bot/MerchantStoreConfigs.js
+++ b/src/GameServer/Bot/MerchantStoreConfigs.js
@@ -1,146 +1,236 @@
+const BUY_CAP = 999999;
+
+const s = (selfId, priceRate, count) => ({ selfId, priceRate, count });
+const b = (selfId, priceRate, count = BUY_CAP) => ({ selfId, priceRate, count });
+
 module.exports = {
-    "Merchant_TI": {
-        title: "Materials - D Grade",
+    // Talking Island
+    "Mira": {
+        title: "Local mats",
+        town: "Talking Island",
         storeType: 1,
         locX: -84168, locY: 244729, locZ: -3730,
         items: [
-            { selfId: 1864, price: 100,  count: 5000 },
-            { selfId: 1865, price: 200,  count: 5000 },
-            { selfId: 1866, price: 300,  count: 3000 },
-            { selfId: 1867, price: 150,  count: 5000 },
-            { selfId: 1868, price: 100,  count: 5000 },
-            { selfId: 1869, price: 200,  count: 5000 },
-            { selfId: 1870, price: 200,  count: 3000 },
-            { selfId: 1871, price: 200,  count: 3000 },
-            { selfId: 1872, price: 150,  count: 5000 },
+            s(1864, 0.68, 5000), s(1865, 0.72, 4000), s(1866, 0.70, 3500),
+            s(1867, 0.74, 4500), s(1868, 0.66, 5000), s(1869, 0.72, 3500),
+            s(1060, 0.78, 250), s(736, 0.75, 150), s(1835, 0.70, 30000)
         ]
     },
-    "Merchant_Gludio": {
-        title: "Materials - D/C Grade",
+    "Korin": {
+        title: "Starter gear",
+        town: "Talking Island",
         storeType: 1,
-        locX: -12522, locY: 122926, locZ: -3118,
+        locX: -84230, locY: 244835, locZ: -3730,
         items: [
-            { selfId: 1867, price: 150,  count: 5000 },
-            { selfId: 1868, price: 100,  count: 5000 },
-            { selfId: 1869, price: 200,  count: 5000 },
-            { selfId: 1870, price: 200,  count: 3000 },
-            { selfId: 1871, price: 200,  count: 3000 },
-            { selfId: 1872, price: 150,  count: 5000 },
-            { selfId: 1873, price: 500,  count: 2000 },
-            { selfId: 1879, price: 1200, count: 1000 },
-            { selfId: 1880, price: 2000, count: 1000 },
+            s(14, 0.66, 6), s(9, 0.65, 4), s(22, 0.72, 12),
+            s(29, 0.72, 12), s(37, 0.70, 10), s(49, 0.70, 10),
+            s(2006, 0.62, 60), s(2007, 0.62, 60), s(1796, 0.60, 25)
         ]
     },
-    "Merchant_Dion": {
-        title: "Materials - C Grade",
-        storeType: 1,
-        locX: 15814, locY: 143129, locZ: -2707,
-        items: [
-            { selfId: 1873, price: 500,  count: 3000 },
-            { selfId: 1879, price: 1200, count: 2000 },
-            { selfId: 1880, price: 2000, count: 2000 },
-            { selfId: 1881, price: 1500, count: 2000 },
-            { selfId: 1882, price: 900,  count: 3000 },
-            { selfId: 1883, price: 4500, count: 500 },
-            { selfId: 1884, price: 325,  count: 3000 },
-        ]
-    },
-    "Merchant_Giran": {
-        title: "Materials - C/B Grade",
-        storeType: 1,
-        locX: 83550, locY: 148093, locZ: -3406,
-        items: [
-            { selfId: 1881, price: 1500, count: 2000 },
-            { selfId: 1882, price: 900,  count: 3000 },
-            { selfId: 1883, price: 4500, count: 1000 },
-            { selfId: 1885, price: 2400, count: 1000 },
-            { selfId: 1887, price: 8100, count: 500 },
-            { selfId: 1888, price: 6600, count: 500 },
-            { selfId: 1889, price: 3000, count: 1000 },
-        ]
-    },
-    "Merchant_Oren": {
-        title: "Materials - B/A Grade",
-        storeType: 1,
-        locX: 83110, locY: 53327, locZ: -1497,
-        items: [
-            { selfId: 1885, price: 2400, count: 2000 },
-            { selfId: 1886, price: 13500, count: 300 },
-            { selfId: 1887, price: 8100, count: 1000 },
-            { selfId: 1888, price: 6600, count: 1000 },
-            { selfId: 1889, price: 3000, count: 2000 },
-            { selfId: 1890, price: 13100, count: 500 },
-            { selfId: 1893, price: 24600, count: 300 },
-            { selfId: 1894, price: 5700, count: 1000 },
-        ]
-    },
-
-    // ----- Buy Bots (players sell to them) -----
-
-    "MerBuy_TI": {
-        title: "Buyer - D Mats",
+    "Nika": {
+        title: "Buy starter mats",
+        town: "Talking Island",
         storeType: 3,
         locX: -84120, locY: 244760, locZ: -3730,
         items: [
-            { selfId: 1864, price: 50,  count: 999999 },
-            { selfId: 1865, price: 100, count: 999999 },
-            { selfId: 1867, price: 75,  count: 999999 },
-            { selfId: 1868, price: 50,  count: 999999 },
-            { selfId: 1869, price: 100, count: 999999 },
-            { selfId: 1871, price: 100, count: 999999 },
-            { selfId: 1872, price: 75,  count: 999999 },
+            b(1864, 0.62), b(1865, 0.60), b(1866, 0.58), b(1867, 0.62),
+            b(1868, 0.60), b(1869, 0.60), b(1870, 0.58), b(1871, 0.58),
+            b(1872, 0.62), b(17, 0.55)
         ]
     },
-    "MerBuy_Gludio": {
-        title: "Buyer - D/C Mats",
+    "Tarin": {
+        title: "Buy island drops",
+        town: "Talking Island",
+        storeType: 3,
+        locX: -84062, locY: 244688, locZ: -3730,
+        items: [
+            b(1121, 0.62), b(1119, 0.62), b(1122, 0.62), b(1129, 0.62),
+            b(112, 0.66), b(116, 0.66), b(118, 0.66), b(19, 0.64),
+            b(42, 0.64), b(2006, 0.68), b(2007, 0.68), b(1788, 0.64)
+        ]
+    },
+
+    // Gludio
+    "Lysa": {
+        title: "D mats and gear",
+        town: "Gludio",
+        storeType: 1,
+        locX: -12522, locY: 122926, locZ: -3118,
+        items: [
+            s(1867, 0.70, 5000), s(1869, 0.72, 5000), s(1870, 0.70, 4000),
+            s(1871, 0.68, 4000), s(1872, 0.70, 5000), s(1873, 0.74, 2500),
+            s(1880, 0.78, 1200), s(15, 0.64, 5), s(216, 0.66, 7)
+        ]
+    },
+    "Darin": {
+        title: "Gludio stock",
+        town: "Gludio",
+        storeType: 1,
+        locX: -12470, locY: 123020, locZ: -3118,
+        items: [
+            s(22, 0.68, 20), s(24, 0.68, 10), s(31, 0.68, 10),
+            s(38, 0.72, 12), s(50, 0.72, 12), s(43, 0.70, 10),
+            s(1921, 0.62, 150), s(1922, 0.62, 120), s(1923, 0.62, 120)
+        ]
+    },
+    "Ewan": {
+        title: "Buy D mats",
+        town: "Gludio",
         storeType: 3,
         locX: -12480, locY: 122950, locZ: -3118,
         items: [
-            { selfId: 1867, price: 75,  count: 999999 },
-            { selfId: 1869, price: 100, count: 999999 },
-            { selfId: 1871, price: 100, count: 999999 },
-            { selfId: 1872, price: 75,  count: 999999 },
-            { selfId: 1873, price: 300, count: 999999 },
-            { selfId: 1880, price: 1200, count: 999999 },
+            b(1867, 0.64), b(1868, 0.62), b(1869, 0.62), b(1870, 0.62),
+            b(1871, 0.62), b(1872, 0.64), b(1873, 0.66), b(1880, 0.66),
+            b(1878, 0.64), b(1341, 0.55)
         ]
     },
-    "MerBuy_Dion": {
-        title: "Buyer - C Mats",
+    "Maren": {
+        title: "Buy plains drops",
+        town: "Gludio",
+        storeType: 3,
+        locX: -12582, locY: 122850, locZ: -3118,
+        items: [
+            b(1921, 0.70), b(1922, 0.70), b(1923, 0.70), b(1924, 0.70),
+            b(1925, 0.70), b(2011, 0.68), b(2012, 0.68), b(2013, 0.68),
+            b(1792, 0.66), b(1793, 0.66), b(1794, 0.66), b(1798, 0.66)
+        ]
+    },
+
+    // Dion
+    "Rina": {
+        title: "C craft stock",
+        town: "Dion",
+        storeType: 1,
+        locX: 15814, locY: 143129, locZ: -2707,
+        items: [
+            s(1873, 0.72, 3500), s(1879, 0.70, 2500), s(1880, 0.70, 2500),
+            s(1881, 0.70, 2200), s(1882, 0.68, 3000), s(1883, 0.72, 800),
+            s(1884, 0.66, 3000), s(272, 0.62, 4), s(219, 0.63, 5)
+        ]
+    },
+    "Soren": {
+        title: "Dion gear parts",
+        town: "Dion",
+        storeType: 1,
+        locX: 15910, locY: 143025, locZ: -2707,
+        items: [
+            s(58, 0.65, 6), s(59, 0.65, 6), s(61, 0.68, 10),
+            s(63, 0.68, 10), s(103, 0.68, 6), s(1882, 0.68, 3000),
+            s(2143, 0.64, 100), s(2144, 0.64, 100), s(2139, 0.64, 80)
+        ]
+    },
+    "Vera": {
+        title: "Buy C mats",
+        town: "Dion",
         storeType: 3,
         locX: 15860, locY: 143100, locZ: -2707,
         items: [
-            { selfId: 1873, price: 300,  count: 999999 },
-            { selfId: 1879, price: 800,  count: 999999 },
-            { selfId: 1880, price: 1200, count: 999999 },
-            { selfId: 1881, price: 900,  count: 999999 },
-            { selfId: 1882, price: 500,  count: 999999 },
-            { selfId: 1884, price: 200,  count: 999999 },
+            b(1873, 0.66), b(1879, 0.66), b(1880, 0.66), b(1881, 0.64),
+            b(1882, 0.64), b(1883, 0.62), b(1884, 0.64), b(1885, 0.62),
+            b(1887, 0.60), b(1888, 0.60)
         ]
     },
-    "MerBuy_Giran": {
-        title: "Buyer - C/B Mats",
+    "Borin": {
+        title: "Buy Dion drops",
+        town: "Dion",
+        storeType: 3,
+        locX: 15725, locY: 143055, locZ: -2707,
+        items: [
+            b(2015, 0.68), b(2009, 0.68), b(2150, 0.66), b(2252, 0.66),
+            b(2253, 0.66), b(2254, 0.66), b(956, 0.62), b(955, 0.62),
+            b(37, 0.62), b(49, 0.62), b(44, 0.62), b(102, 0.62)
+        ]
+    },
+
+    // Giran
+    "Elin": {
+        title: "C/B materials",
+        town: "Giran",
+        storeType: 1,
+        locX: 83550, locY: 148093, locZ: -3406,
+        items: [
+            s(1881, 0.68, 2500), s(1882, 0.68, 3500), s(1883, 0.70, 1200),
+            s(1885, 0.66, 1500), s(1887, 0.64, 800), s(1888, 0.64, 800),
+            s(1889, 0.66, 1400), s(78, 0.61, 2), s(91, 0.62, 3)
+        ]
+    },
+    "Naren": {
+        title: "Giran gear",
+        town: "Giran",
+        storeType: 1,
+        locX: 83445, locY: 148170, locZ: -3406,
+        items: [
+            s(60, 0.62, 4), s(62, 0.66, 8), s(64, 0.66, 8),
+            s(119, 0.66, 6), s(117, 0.66, 8), s(845, 0.68, 8),
+            s(877, 0.68, 10), s(908, 0.68, 6), s(1539, 0.76, 500)
+        ]
+    },
+    "Pavel": {
+        title: "Buy Giran mats",
+        town: "Giran",
         storeType: 3,
         locX: 83510, locY: 148120, locZ: -3406,
         items: [
-            { selfId: 1881, price: 900,  count: 999999 },
-            { selfId: 1882, price: 500,  count: 999999 },
-            { selfId: 1885, price: 1400, count: 999999 },
-            { selfId: 1887, price: 5000, count: 999999 },
-            { selfId: 1888, price: 4000, count: 999999 },
-            { selfId: 1889, price: 1800, count: 999999 },
+            b(1881, 0.64), b(1882, 0.64), b(1883, 0.62), b(1885, 0.62),
+            b(1887, 0.60), b(1888, 0.60), b(1889, 0.62), b(1890, 0.58),
+            b(1893, 0.56), b(1894, 0.60)
         ]
     },
-    "MerBuy_Oren": {
-        title: "Buyer - B/A Mats",
+    "Tessa": {
+        title: "Buy Giran drops",
+        town: "Giran",
+        storeType: 3,
+        locX: 83385, locY: 148035, locZ: -3406,
+        items: [
+            b(2140, 0.66), b(2142, 0.66), b(2143, 0.66), b(2144, 0.66),
+            b(2173, 0.66), b(2174, 0.66), b(2175, 0.66), b(956, 0.62),
+            b(955, 0.62), b(219, 0.58), b(272, 0.58), b(309, 0.58)
+        ]
+    },
+
+    // Oren
+    "Iris": {
+        title: "B/A materials",
+        town: "Oren",
+        storeType: 1,
+        locX: 83110, locY: 53327, locZ: -1497,
+        items: [
+            s(1885, 0.66, 2500), s(1886, 0.62, 600), s(1887, 0.62, 1200),
+            s(1888, 0.62, 1200), s(1889, 0.64, 2200), s(1890, 0.60, 700),
+            s(1893, 0.60, 450), s(1894, 0.62, 1400), s(80, 0.60, 2)
+        ]
+    },
+    "Helga": {
+        title: "Oren gear",
+        town: "Oren",
+        storeType: 1,
+        locX: 83020, locY: 53245, locZ: -1497,
+        items: [
+            s(79, 0.60, 3), s(97, 0.60, 3), s(98, 0.60, 2),
+            s(442, 0.61, 3), s(473, 0.61, 3), s(603, 0.62, 5),
+            s(2463, 0.62, 5), s(856, 0.64, 6), s(887, 0.64, 8)
+        ]
+    },
+    "Oskar": {
+        title: "Buy Oren mats",
+        town: "Oren",
         storeType: 3,
         locX: 83150, locY: 53300, locZ: -1497,
         items: [
-            { selfId: 1885, price: 1400, count: 999999 },
-            { selfId: 1887, price: 5000, count: 999999 },
-            { selfId: 1888, price: 4000, count: 999999 },
-            { selfId: 1889, price: 1800, count: 999999 },
-            { selfId: 1890, price: 8000, count: 999999 },
-            { selfId: 1894, price: 3500, count: 999999 },
+            b(1885, 0.62), b(1886, 0.58), b(1887, 0.60), b(1888, 0.60),
+            b(1889, 0.62), b(1890, 0.58), b(1893, 0.56), b(1894, 0.60),
+            b(1874, 0.58), b(1875, 0.58)
+        ]
+    },
+    "Selin": {
+        title: "Buy Oren drops",
+        town: "Oren",
+        storeType: 3,
+        locX: 83245, locY: 53270, locZ: -1497,
+        items: [
+            b(1830, 0.60), b(1343, 0.55), b(1539, 0.62), b(91, 0.56),
+            b(212, 0.56), b(284, 0.56), b(79, 0.56), b(97, 0.56),
+            b(856, 0.58), b(887, 0.58), b(918, 0.58)
         ]
     }
 };

--- a/src/GameServer/Bot/TradeService.js
+++ b/src/GameServer/Bot/TradeService.js
@@ -1,0 +1,300 @@
+const DataCache = invoke('GameServer/DataCache');
+const Database  = invoke('Database');
+
+function itemTemplate(selfId) {
+    return DataCache.items.find((ob) => ob.selfId === selfId);
+}
+
+function itemName(selfId) {
+    return itemTemplate(selfId)?.template?.name ?? `Item ${selfId}`;
+}
+
+function itemBasePrice(selfId) {
+    return itemTemplate(selfId)?.template?.price ?? 0;
+}
+
+function ratedPrice(selfId, rate, fallback = 1) {
+    const base = itemBasePrice(selfId);
+    const price = base > 0 ? Math.floor(base * rate) : fallback;
+    return Math.max(1, price);
+}
+
+function storeLoc(actor) {
+    return {
+        locX: actor.fetchLocX(),
+        locY: actor.fetchLocY(),
+        locZ: actor.fetchLocZ()
+    };
+}
+
+function distance2d(a, b) {
+    const dx = a.locX - b.locX;
+    const dy = a.locY - b.locY;
+    return Math.sqrt(dx * dx + dy * dy);
+}
+
+function fetchAdena(actor) {
+    return actor.backpack.fetchItemFromSelfId(57);
+}
+
+function isSellableInventoryItem(item) {
+    return item && !item.fetchEquipped() && item.fetchSelfId() !== 57;
+}
+
+function normalizeStoreItems(storeCfg) {
+    let fakeObjectIdSeq = 600000000 + utils.randomNumber(100000000);
+    return storeCfg.items.map((item) => ({
+        objectId: ++fakeObjectIdSeq,
+        selfId: item.selfId,
+        price: item.price ?? ratedPrice(item.selfId, item.priceRate ?? 1),
+        count: item.count ?? 1
+    }));
+}
+
+function describeStoreItems(items, limit = 3) {
+    return items
+        .slice(0, limit)
+        .map((item) => itemName(item.selfId))
+        .join(', ');
+}
+
+function deductAdena(actor, amount) {
+    return new Promise((resolve, reject) => {
+        const adenaItem = fetchAdena(actor);
+        if (!adenaItem || adenaItem.fetchAmount() < amount) {
+            return reject("Not enough Adena.");
+        }
+
+        const total = adenaItem.fetchAmount() - amount;
+        if (total > 0) {
+            Database.updateItemAmount(actor.fetchId(), adenaItem.fetchId(), total).then(() => {
+                adenaItem.setAmount(total);
+                resolve();
+            }).catch(reject);
+        } else {
+            Database.deleteItem(actor.fetchId(), adenaItem.fetchId()).then(() => {
+                actor.backpack.items = actor.backpack.items.filter((ob) => ob.fetchId() !== adenaItem.fetchId());
+                resolve();
+            }).catch(reject);
+        }
+    });
+}
+
+function giveAdena(actor, amount) {
+    return new Promise((resolve, reject) => {
+        const adenaItem = fetchAdena(actor);
+        if (adenaItem) {
+            const total = adenaItem.fetchAmount() + amount;
+            Database.updateItemAmount(actor.fetchId(), adenaItem.fetchId(), total).then(() => {
+                adenaItem.setAmount(total);
+                resolve();
+            }).catch(reject);
+            return;
+        }
+
+        Database.setItem(actor.fetchId(), {
+            selfId: 57,
+            name: 'Adena',
+            amount,
+            equipped: false,
+            slot: 0
+        }).then((packet) => {
+            actor.backpack.insertItem(Number(packet.insertId), 57, { amount });
+            resolve();
+        }).catch(reject);
+    });
+}
+
+function giveItem(actor, selfId, amount) {
+    return new Promise((resolve, reject) => {
+        actor.backpack.stackableExists(selfId).then((item) => {
+            const total = item.fetchAmount() + amount;
+            Database.updateItemAmount(actor.fetchId(), item.fetchId(), total).then(() => {
+                actor.backpack.updateAmount(item.fetchId(), total);
+                resolve();
+            }).catch(reject);
+        }).catch(() => {
+            const itemDetails = itemTemplate(selfId);
+            if (!itemDetails) {
+                reject(`Unknown item ${selfId}.`);
+                return;
+            }
+
+            Database.setItem(actor.fetchId(), {
+                selfId: itemDetails.selfId,
+                name: itemDetails.template.name,
+                amount,
+                equipped: false,
+                slot: itemDetails.etc?.slot ?? 0
+            }).then((packet) => {
+                actor.backpack.insertItem(Number(packet.insertId), selfId, { amount });
+                resolve();
+            }).catch(reject);
+        });
+    });
+}
+
+function takeItem(actor, selfId, amount) {
+    return new Promise((resolve, reject) => {
+        const item = actor.backpack.fetchItemFromSelfId(selfId);
+        if (!item || item.fetchAmount() < amount) {
+            return reject("Not enough items.");
+        }
+
+        const total = item.fetchAmount() - amount;
+        if (total > 0) {
+            Database.updateItemAmount(actor.fetchId(), item.fetchId(), total).then(() => {
+                item.setAmount(total);
+                resolve();
+            }).catch(reject);
+        } else {
+            Database.deleteItem(actor.fetchId(), item.fetchId()).then(() => {
+                actor.backpack.items = actor.backpack.items.filter((ob) => ob.fetchId() !== item.fetchId());
+                resolve();
+            }).catch(reject);
+        }
+    });
+}
+
+function previewSaleToStore(actor, store) {
+    if (!store || store.storeType !== 3) {
+        return { totalAdena: 0, itemCount: 0, lines: [] };
+    }
+
+    let totalAdena = 0;
+    let itemCount = 0;
+    const lines = [];
+
+    actor.backpack.fetchItems().filter(isSellableInventoryItem).forEach((inventoryItem) => {
+        const storeItem = store.items.find((item) => item.selfId === inventoryItem.fetchSelfId() && item.count > 0);
+        if (!storeItem) return;
+
+        const qty = Math.min(inventoryItem.fetchAmount(), storeItem.count);
+        if (qty <= 0) return;
+
+        const payout = qty * storeItem.price;
+        totalAdena += payout;
+        itemCount += qty;
+        lines.push({
+            selfId: inventoryItem.fetchSelfId(),
+            name: inventoryItem.fetchName(),
+            qty,
+            price: storeItem.price,
+            payout
+        });
+    });
+
+    return { totalAdena, itemCount, lines };
+}
+
+async function buyFromStore(actor, store, selfId, qty) {
+    if (!store || store.storeType !== 1) {
+        throw new Error("This store is not selling items.");
+    }
+
+    const storeItem = store.items.find((item) => item.selfId === selfId);
+    if (!storeItem) {
+        throw new Error("Item is not available.");
+    }
+
+    const buyQty = Math.min(qty, storeItem.count);
+    if (buyQty <= 0) {
+        throw new Error("Item is out of stock.");
+    }
+
+    const totalCost = storeItem.price * buyQty;
+    await deductAdena(actor, totalCost);
+    await giveItem(actor, selfId, buyQty);
+
+    storeItem.count -= buyQty;
+    store.items = store.items.filter((item) => item.count > 0);
+
+    return { qty: buyQty, totalAdena: totalCost, name: itemName(selfId) };
+}
+
+async function sellToStore(actor, store, selfId, qty) {
+    if (!store || store.storeType !== 3) {
+        throw new Error("This store is not buying items.");
+    }
+
+    const storeItem = store.items.find((item) => item.selfId === selfId);
+    if (!storeItem) {
+        throw new Error("Item is not wanted.");
+    }
+
+    const actorItem = actor.backpack.fetchItemFromSelfId(selfId);
+    const actorCount = actorItem ? actorItem.fetchAmount() : 0;
+    const sellQty = Math.min(qty, actorCount, storeItem.count);
+    if (sellQty <= 0) {
+        throw new Error("No items to sell.");
+    }
+
+    const totalEarn = storeItem.price * sellQty;
+    await takeItem(actor, selfId, sellQty);
+    await giveAdena(actor, totalEarn);
+
+    storeItem.count -= sellQty;
+    store.items = store.items.filter((item) => item.count > 0);
+
+    return { qty: sellQty, totalAdena: totalEarn, name: itemName(selfId) };
+}
+
+async function sellInventoryToStore(actor, store) {
+    const preview = previewSaleToStore(actor, store);
+    const sold = [];
+
+    for (const line of preview.lines) {
+        const result = await sellToStore(actor, store, line.selfId, line.qty);
+        sold.push(result);
+    }
+
+    return {
+        itemsSold: sold.reduce((acc, line) => acc + line.qty, 0),
+        totalAdena: sold.reduce((acc, line) => acc + line.totalAdena, 0),
+        sold
+    };
+}
+
+function findBestBuyerForActor(actor, merchantSessions, options = {}) {
+    const town = options.town || null;
+    const maxTownDistance = options.maxTownDistance ?? 6500;
+    const actorLoc = storeLoc(actor);
+
+    let best = null;
+    merchantSessions.forEach((session) => {
+        const merchant = session.actor;
+        if (!merchant || session.plan !== 'merchant') return;
+
+        const store = merchant.fetchPrivateStore && merchant.fetchPrivateStore();
+        if (!store || store.storeType !== 3 || !store.items.length) return;
+
+        const merchantLoc = storeLoc(merchant);
+        if (town && distance2d(merchantLoc, { locX: town.x, locY: town.y, locZ: town.z }) > maxTownDistance) {
+            return;
+        }
+
+        const preview = previewSaleToStore(actor, store);
+        if (preview.totalAdena <= 0) return;
+
+        const distance = distance2d(actorLoc, merchantLoc);
+        const score = preview.totalAdena - Math.floor(distance / 10);
+        if (!best || score > best.score) {
+            best = { session, actor: merchant, store, preview, distance, score };
+        }
+    });
+
+    return best;
+}
+
+module.exports = {
+    buyFromStore,
+    describeStoreItems,
+    findBestBuyerForActor,
+    itemBasePrice,
+    itemName,
+    normalizeStoreItems,
+    previewSaleToStore,
+    ratedPrice,
+    sellInventoryToStore,
+    sellToStore
+};

--- a/src/GameServer/Network/Request/Speak.js
+++ b/src/GameServer/Network/Request/Speak.js
@@ -48,7 +48,7 @@ function consume(session, data) {
         }
     }
 
-    if (data.kind === 1) { // Shout
+    if (data.kind === 1 || data.kind === 8) { // Shout / Trade
         const packet = ServerResponse.speak(session.actor, data);
         const World = invoke('GameServer/World/World');
         World.user.sessions.forEach((user) => {

--- a/src/GameServer/Network/Response/PrivateStoreBuyMsg.js
+++ b/src/GameServer/Network/Response/PrivateStoreBuyMsg.js
@@ -4,7 +4,7 @@ function privateStoreBuyMsg(actor, storeTitle) {
     const packet = new SendPacket(0x8c);
     packet.writeD(actor.fetchId());
     packet.writeD(3); // Private store type: Buy (3)
-    packet.writeS(storeTitle ?? actor.fetchTitle());
+    packet.writeS(typeof storeTitle === 'string' ? storeTitle : actor.fetchTitle());
     return packet.fetchBuffer();
 }
 

--- a/src/GameServer/Network/Response/PrivateStoreMsg.js
+++ b/src/GameServer/Network/Response/PrivateStoreMsg.js
@@ -4,7 +4,7 @@ function privateStoreMsg(actor, storeTitle) {
     const packet = new SendPacket(0x8c);
     packet.writeD(actor.fetchId());
     packet.writeD(1); // Private store type: Sell (1)
-    packet.writeS(storeTitle ?? actor.fetchTitle());
+    packet.writeS(typeof storeTitle === 'string' ? storeTitle : actor.fetchTitle());
     return packet.fetchBuffer();
 }
 

--- a/src/GameServer/World/Generics/NpcBypasses/BuyMerchantItem.js
+++ b/src/GameServer/World/Generics/NpcBypasses/BuyMerchantItem.js
@@ -1,6 +1,6 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const DataCache      = invoke('GameServer/DataCache');
-const Database       = invoke('Database');
+const TradeService   = invoke('GameServer/Bot/TradeService');
 
 function fold(v) {
     return String(v).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
@@ -45,57 +45,6 @@ ${rows}
 </center></body></html>`;
 }
 
-function deductAdena(session, amount) {
-    const actor = session.actor;
-    const backpack = actor.backpack;
-    return new Promise((resolve, reject) => {
-        const adenaItem = backpack.fetchItemFromSelfId(57);
-        if (!adenaItem || adenaItem.fetchAmount() < amount) {
-            return reject("Not enough Adena.");
-        }
-        const total = adenaItem.fetchAmount() - amount;
-        if (total > 0) {
-            Database.updateItemAmount(actor.fetchId(), adenaItem.fetchId(), total).then(() => {
-                adenaItem.setAmount(total);
-                resolve();
-            }).catch(reject);
-        } else {
-            Database.deleteItem(actor.fetchId(), adenaItem.fetchId()).then(() => {
-                backpack.items = backpack.items.filter(ob => ob.fetchId() !== adenaItem.fetchId());
-                resolve();
-            }).catch(reject);
-        }
-    });
-}
-
-function giveItem(session, selfId, amount) {
-    const actor = session.actor;
-    const backpack = actor.backpack;
-    return new Promise((resolve) => {
-        backpack.stackableExists(selfId).then((item) => {
-            const itemId = item.fetchId();
-            const total = item.fetchAmount() + amount;
-            Database.updateItemAmount(actor.fetchId(), itemId, total).then(() => {
-                backpack.updateAmount(itemId, total);
-                resolve();
-            });
-        }).catch(() => {
-            DataCache.fetchItemFromSelfId(selfId, (item) => {
-                Database.setItem(actor.fetchId(), {
-                    selfId: item.selfId,
-                    name: item.template.name,
-                    amount: amount,
-                    equipped: false,
-                    slot: item.etc.slot
-                }).then((packet) => {
-                    backpack.insertItem(Number(packet.insertId), selfId, { amount: amount });
-                    resolve();
-                });
-            });
-        });
-    });
-}
-
 module.exports = async function(session, parts) {
     const bot = session.viewedPrivateStoreSeller;
     if (!bot) {
@@ -135,13 +84,7 @@ module.exports = async function(session, parts) {
     }
 
     try {
-        await deductAdena(session, totalCost);
-        await giveItem(session, selfId, buyQty);
-
-        storeItem.count -= buyQty;
-        if (storeItem.count <= 0) {
-            store.items = store.items.filter(i => i.count > 0);
-        }
+        await TradeService.buyFromStore(session.actor, store, selfId, buyQty);
 
         session.dataSendToMe(ServerResponse.userInfo(session.actor));
         session.dataSendToMe(ServerResponse.itemsList(session.actor.backpack.fetchItems()));

--- a/src/GameServer/World/Generics/NpcBypasses/SellToMerchantItem.js
+++ b/src/GameServer/World/Generics/NpcBypasses/SellToMerchantItem.js
@@ -1,6 +1,6 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const DataCache      = invoke('GameServer/DataCache');
-const Database       = invoke('Database');
+const TradeService   = invoke('GameServer/Bot/TradeService');
 
 function fold(v) {
     return String(v).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
@@ -48,51 +48,6 @@ ${rows}
 </center></body></html>`;
 }
 
-function takeItem(session, selfId, amount) {
-    return new Promise((resolve, reject) => {
-        const actor = session.actor;
-        const backpack = actor.backpack;
-        const item = backpack.fetchItemFromSelfId(selfId);
-        if (!item || item.fetchAmount() < amount) {
-            return reject("Not enough items.");
-        }
-        const total = item.fetchAmount() - amount;
-        if (total > 0) {
-            Database.updateItemAmount(actor.fetchId(), item.fetchId(), total).then(() => {
-                item.setAmount(total);
-                resolve();
-            }).catch(reject);
-        } else {
-            Database.deleteItem(actor.fetchId(), item.fetchId()).then(() => {
-                backpack.items = backpack.items.filter(ob => ob.fetchId() !== item.fetchId());
-                resolve();
-            }).catch(reject);
-        }
-    });
-}
-
-function giveAdena(session, amount) {
-    const actor = session.actor;
-    const backpack = actor.backpack;
-    return new Promise((resolve, reject) => {
-        const adenaItem = backpack.fetchItemFromSelfId(57);
-        if (adenaItem) {
-            const total = adenaItem.fetchAmount() + amount;
-            Database.updateItemAmount(actor.fetchId(), adenaItem.fetchId(), total).then(() => {
-                adenaItem.setAmount(total);
-                resolve();
-            }).catch(reject);
-        } else {
-            Database.setItem(actor.fetchId(), {
-                selfId: 57, name: 'Adena', amount: amount, equipped: false, slot: 0
-            }).then((packet) => {
-                backpack.insertItem(Number(packet.insertId), 57, { amount: amount });
-                resolve();
-            }).catch(reject);
-        }
-    });
-}
-
 module.exports = async function(session, parts) {
     const bot = session.viewedPrivateStoreSeller;
     if (!bot) {
@@ -129,11 +84,8 @@ module.exports = async function(session, parts) {
         return;
     }
 
-    const totalEarn = storeItem.price * sellQty;
-
     try {
-        await takeItem(session, selfId, sellQty);
-        await giveAdena(session, totalEarn);
+        await TradeService.sellToStore(session.actor, store, selfId, sellQty);
 
         session.dataSendToMe(ServerResponse.userInfo(session.actor));
         session.dataSendToMe(ServerResponse.itemsList(session.actor.backpack.fetchItems()));


### PR DESCRIPTION
## Summary

Adds a broader merchant-bot trading layer with neutral merchant names, town-specific seller and buyer inventories, and shared trade execution logic for private merchant interactions.

## What Changed

- Expanded merchant bot configs across Talking Island, Gludio, Dion, Giran, and Oren.
- Added seller bots with resources, weapons, armor, and consumables priced below regular shops.
- Added buyer bots for local materials and monster drops.
- Added shared trade service logic for pricing, inventory updates, buying, selling, and bot-to-buyer liquidation.
- Updated hunting bots so they can sell loot to nearby buyer bots before falling back to general junk selling.
- Added merchant AI ads in trade chat and enabled global trade chat broadcast for kind 8.
- Avoided unstable custom private-store nameplate packets for merchant bots after client crash testing.

## Validation

- `node -c` over changed JavaScript files
- `npx eslint` over changed trading/bot/chat files
- `git diff --check`
- `node tests/test_path_obstacle.js`
- `node tests/test_pathfinder_astar.js`
- In-client smoke testing confirmed the merchant bots no longer crash the client after removing custom store nameplate packets.