### PR TITLE
Add OpenRouter bot brain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 data/Geodata/
+config/local.ini

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ npm run NodeL2
 ```
 *The spatial grid will index the spawns at boot, and bots will automatically load from database accounts and spawn beside Talk Village town center within 5 seconds!*
 
+### Optional: OpenRouter Bot Brain
+The committed `config/default.ini` contains safe defaults only. Put private overrides in ignored `config/local.ini`:
+```ini
+[OpenRouter]
+enabled = true
+apiKey = sk-or-v1-your-key-here
+model = google/gemini-2.5-flash-lite
+debug = true
+```
+You can also use environment variables instead of a local file:
+```bash
+OPENROUTER_API_KEY=sk-or-v1-your-key-here npm run NodeL2
+```
+With `debug = true`, BotBrain logs why it skips a request (`disabled`, `missing_api_key`, `no_visible_real_players`, `cooldown`) or when it sends a decision request. The brain only runs for bots visible to a real player.
+
 ---
 
 ## ✴️ In-Game Chat Commands

--- a/config/default.ini
+++ b/config/default.ini
@@ -26,3 +26,17 @@ expRate = 1.0
 adenaRate = 1.0
 dropChanceRate = 1.0
 showMonsterLevel = true
+
+[OpenRouter]
+enabled = false
+apiKey =
+model = google/gemini-2.5-flash-lite
+temperature = 0.35
+maxTokens = 160
+timeoutMs = 3500
+cooldownMs = 45000
+chatCooldownMs = 12000
+visibilityRadius = 6000
+maxPromptPrice = 0.15
+maxCompletionPrice = 0.60
+debug = false

--- a/config/local.example.ini
+++ b/config/local.example.ini
@@ -1,0 +1,5 @@
+[OpenRouter]
+enabled = true
+apiKey = sk-or-v1-your-key-here
+model = google/gemini-2.5-flash-lite
+debug = true

--- a/src/GameServer/Actor/Generics/MoveTo.js
+++ b/src/GameServer/Actor/Generics/MoveTo.js
@@ -64,7 +64,7 @@ function moveTo(session, actor, coords) {
         };
 
         const distanceToPlayer = getDistanceToClosestPlayer();
-        const isCompanion = !!session.followPlayerSession;
+        const isCompanion = !!session.followPlayerSession && session.partyCompanion === true;
 
         if (distanceToPlayer > 1500 && !isCompanion) {
             // Low LOD: instant warp (we do not calculate movements at all)

--- a/src/GameServer/Bot/AI/BotBrain.js
+++ b/src/GameServer/Bot/AI/BotBrain.js
@@ -1,0 +1,550 @@
+const ServerResponse = invoke('GameServer/Network/Response');
+const SpotService    = invoke('GameServer/Bot/AI/SpotService');
+
+const ALLOWED_PLANS = ['hunting', 'following', 'resting', 'shopping', 'pk_hunting', 'merchant'];
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
+
+function bool(value, fallback = false) {
+    if (value === undefined || value === null || value === '') return fallback;
+    if (typeof value === 'boolean') return value;
+    return ['1', 'true', 'yes', 'on'].includes(String(value).toLowerCase());
+}
+
+function num(value, fallback) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function config() {
+    const optn = options.default.OpenRouter || {};
+    return {
+        enabled: bool(optn.enabled, false),
+        apiKey: process.env.OPENROUTER_API_KEY || optn.apiKey || '',
+        model: process.env.OPENROUTER_MODEL || optn.model || 'google/gemini-2.5-flash-lite',
+        temperature: num(optn.temperature, 0.35),
+        maxTokens: num(optn.maxTokens, 160),
+        timeoutMs: num(optn.timeoutMs, 3500),
+        cooldownMs: num(optn.cooldownMs, 45000),
+        chatCooldownMs: num(optn.chatCooldownMs, 12000),
+        visibilityRadius: num(optn.visibilityRadius, 6000),
+        maxPromptPrice: num(optn.maxPromptPrice, 0),
+        maxCompletionPrice: num(optn.maxCompletionPrice, 0),
+        debug: bool(optn.debug, false)
+    };
+}
+
+function debugSkip(session, cfg, reason) {
+    if (!cfg.debug) return;
+
+    const now = Date.now();
+    if (session.lastBrainDebugAt && now - session.lastBrainDebugAt < 5000) return;
+
+    session.lastBrainDebugAt = now;
+    const name = session.actor?.fetchName?.() || session.accountId || 'unknown';
+    utils.infoWarn('BotBrain', '%s skip: %s', name, reason);
+}
+
+function isRealPlayer(session) {
+    return session &&
+        session.actor &&
+        session.actor.fetchIsOnline() &&
+        session.accountId &&
+        !session.accountId.startsWith('bot_');
+}
+
+function location(actor) {
+    return {
+        locX: actor.fetchLocX(),
+        locY: actor.fetchLocY(),
+        locZ: actor.fetchLocZ()
+    };
+}
+
+function distance2d(a, b) {
+    const dx = a.locX - b.locX;
+    const dy = a.locY - b.locY;
+    return Math.sqrt(dx * dx + dy * dy);
+}
+
+function compactPlayer(session, botLoc) {
+    const actor = session.actor;
+    const loc = location(actor);
+    return {
+        id: actor.fetchId(),
+        name: actor.fetchName(),
+        level: actor.fetchLevel(),
+        hpPct: Math.round((actor.fetchHp() / actor.fetchMaxHp()) * 100),
+        karma: typeof actor.fetchKarma === 'function' ? actor.fetchKarma() : 0,
+        distance: Math.round(distance2d(loc, botLoc)),
+        targetId: actor.fetchDestId ? actor.fetchDestId() : 0
+    };
+}
+
+function visibleRealPlayers(session, bot, cfg = config()) {
+    if (!bot) return [];
+
+    const World = invoke('GameServer/World/World');
+    const botLoc = location(bot);
+    const visible = World.fetchVisibleUsers(session, bot)
+        .filter(isRealPlayer)
+        .map((playerSession) => compactPlayer(playerSession, botLoc))
+        .filter((player) => player.distance <= cfg.visibilityRadius)
+        .sort((a, b) => a.distance - b.distance);
+
+    return visible;
+}
+
+function compactStatus(status) {
+    if (!status || !status.available) return status;
+    return {
+        name: status.name,
+        level: status.level,
+        classId: status.classId,
+        mode: status.mode,
+        intent: status.intent,
+        role: status.role,
+        vitals: {
+            hpPct: Math.round(status.vitals.hpPct * 100),
+            mpPct: Math.round(status.vitals.mpPct * 100)
+        },
+        target: status.target ? {
+            type: status.target.type,
+            name: status.target.name || null,
+            level: status.target.level || null,
+            dead: status.target.dead,
+            distance: status.target.distance ? Math.round(status.target.distance) : null
+        } : null,
+        party: status.party ? {
+            leader: status.party.leader?.name || null,
+            stance: status.party.stance,
+            role: status.party.role
+        } : null,
+        nearby: status.nearby,
+        blockers: status.blockers,
+        spot: status.spot ? {
+            id: status.spot.id,
+            name: status.spot.name,
+            minLevel: status.spot.minLevel,
+            maxLevel: status.spot.maxLevel,
+            density: status.spot.density
+        } : null
+    };
+}
+
+function candidateSpots(status) {
+    if (!status || !status.available || status.mode !== 'hunting') return [];
+
+    return SpotService.ensureIndexed()
+        .map((spot) => ({
+            id: spot.id,
+            name: spot.name,
+            minLevel: spot.minLevel,
+            maxLevel: spot.maxLevel,
+            density: spot.density,
+            distance: Math.round(SpotService.distance2d(status.loc, spot.center))
+        }))
+        .filter((spot) => spot.density >= 3)
+        .filter((spot) => spot.minLevel <= status.level + 4 && spot.maxLevel >= status.level - 4)
+        .sort((a, b) => {
+            if (a.distance !== b.distance) return a.distance - b.distance;
+            return b.density - a.density;
+        })
+        .slice(0, 6);
+}
+
+function schema() {
+    return {
+        type: 'object',
+        properties: {
+            action: {
+                type: 'string',
+                enum: ['none', 'say', 'follow_player', 'stay_here', 'hunt', 'rest', 'shop', 'move_to_spot']
+            },
+            reply: {
+                type: 'string',
+                description: 'Short in-character bot line, max 120 chars. Empty string when no reply is needed.'
+            },
+            targetPlayerName: {
+                type: 'string',
+                description: 'Visible player name for follow_player, or empty string.'
+            },
+            spotId: {
+                type: 'string',
+                description: 'Candidate spot id for move_to_spot, or empty string.'
+            },
+            reason: {
+                type: 'string',
+                description: 'Short private reason for logs/status.'
+            },
+            confidence: {
+                type: 'number',
+                minimum: 0,
+                maximum: 1
+            }
+        },
+        required: ['action', 'reply', 'targetPlayerName', 'spotId', 'reason', 'confidence'],
+        additionalProperties: false
+    };
+}
+
+function systemPrompt() {
+    return [
+        'You are the slow high-level brain for one Lineage 2 SimPlayer bot.',
+        'The deterministic server code handles combat, pathfinding, HP/MP, loot, and safety.',
+        'Only choose small, high-level social or intent changes.',
+        'React only when a real visible player would notice it.',
+        'For ambient events, usually choose none unless a reply or plan change would make the world feel alive.',
+        'For player_chat, react only if the message is addressed to this bot, nearby bots, or clearly asks for help.',
+        'follow_player only means approach a visible player unless the bot is already an invited party companion.',
+        'Never invent unavailable actions, players, items, or spells.'
+    ].join(' ');
+}
+
+function userPayload(event, session, status, visiblePlayers, text) {
+    return {
+        event,
+        playerMessage: text || '',
+        bot: compactStatus(status),
+        visiblePlayers,
+        candidateSpots: candidateSpots(status),
+        allowedActions: ['none', 'say', 'follow_player', 'stay_here', 'hunt', 'rest', 'shop', 'move_to_spot'],
+        constraints: {
+            keepReplyShort: true,
+            avoidSpam: true,
+            noCombatMicromanagement: true
+        },
+        lastDecision: session.lastBrainDecision || null
+    };
+}
+
+async function requestDecision(payload, cfg) {
+    if (typeof fetch !== 'function') {
+        utils.infoWarn('BotBrain', 'global fetch is unavailable; OpenRouter brain disabled for this runtime');
+        return null;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), cfg.timeoutMs);
+
+    const provider = {};
+    if (cfg.maxPromptPrice > 0 || cfg.maxCompletionPrice > 0) {
+        provider.max_price = {};
+        if (cfg.maxPromptPrice > 0) provider.max_price.prompt = cfg.maxPromptPrice;
+        if (cfg.maxCompletionPrice > 0) provider.max_price.completion = cfg.maxCompletionPrice;
+    }
+
+    const body = {
+        model: cfg.model,
+        messages: [
+            { role: 'system', content: systemPrompt() },
+            { role: 'user', content: JSON.stringify(payload) }
+        ],
+        temperature: cfg.temperature,
+        max_tokens: cfg.maxTokens,
+        response_format: {
+            type: 'json_schema',
+            json_schema: {
+                name: 'bot_brain_decision',
+                strict: true,
+                schema: schema()
+            }
+        }
+    };
+
+    if (Object.keys(provider).length > 0) {
+        body.provider = provider;
+    }
+
+    try {
+        const response = await fetch(OPENROUTER_URL, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${cfg.apiKey}`,
+                'Content-Type': 'application/json',
+                'HTTP-Referer': 'http://localhost',
+                'X-OpenRouter-Title': 'L2Node SimPlayers'
+            },
+            body: JSON.stringify(body),
+            signal: controller.signal
+        });
+
+        if (!response.ok) {
+            const detail = await response.text().catch(() => '');
+            utils.infoWarn('BotBrain', 'OpenRouter request failed: %d %s', response.status, detail.slice(0, 180));
+            return null;
+        }
+
+        const json = await response.json();
+        const content = json.choices?.[0]?.message?.content;
+        if (!content) return null;
+
+        const decision = JSON.parse(content);
+        decision.usage = json.usage || null;
+        return decision;
+    } catch (err) {
+        if (err.name !== 'AbortError') {
+            utils.infoWarn('BotBrain', 'OpenRouter error: %s', err.message);
+        }
+        return null;
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+function findVisiblePlayerByName(name, visiblePlayers) {
+    if (!name) return null;
+
+    const lookup = String(name).toLowerCase();
+    const visible = visiblePlayers.find((player) => player.name.toLowerCase() === lookup);
+    if (!visible) return null;
+
+    const World = invoke('GameServer/World/World');
+    return World.user.sessions.find((session) =>
+        isRealPlayer(session) &&
+        session.actor.fetchId() === visible.id
+    ) || null;
+}
+
+function responseTargetSession(decision, visiblePlayers) {
+    return findVisiblePlayerByName(decision?.targetPlayerName, visiblePlayers) ||
+        findVisiblePlayerByName(visiblePlayers[0]?.name, visiblePlayers);
+}
+
+function say(session, text, targetSession = null) {
+    const clean = String(text || '').trim().slice(0, 120);
+    if (!clean) return;
+    const BotAI = invoke('GameServer/Bot/BotAI');
+    if (targetSession) {
+        BotAI.tell(session, targetSession, clean);
+    } else {
+        BotAI.say(session, clean);
+    }
+}
+
+function sit(session, bot) {
+    if (bot.state.fetchSeated()) return;
+    bot.state.setSeated(true);
+    session.dataSendToOthers(ServerResponse.sitAndStand(bot), bot);
+}
+
+function stand(session, bot) {
+    if (!bot.state.fetchSeated()) return;
+    bot.state.setSeated(false);
+    session.dataSendToOthers(ServerResponse.sitAndStand(bot), bot);
+}
+
+function applyMoveToSpot(session, bot, spotId) {
+    const spot = SpotService.findById(spotId);
+    if (!spot) return false;
+
+    const assignedSpot = SpotService.assignSpot(session, spot);
+    const targetLoc = SpotService.randomPointNear(spot);
+    session.initialSpawnCoord = { ...assignedSpot.center };
+    session.lastSpotMoveAt = Date.now();
+    session.noTargetTicks = 0;
+
+    bot.moveTo({
+        from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
+        to: targetLoc
+    });
+
+    return true;
+}
+
+function startShopping(session, bot) {
+    const BotAI = invoke('GameServer/Bot/BotAI');
+    const closestTown = BotAI.getClosestTown(bot.fetchLocX(), bot.fetchLocY());
+    session.preShopLocation = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
+    session.plan = 'shopping';
+    session.shopTimer = Date.now();
+    session.shoppingTarget = undefined;
+    bot.moveTo({
+        from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
+        to: { locX: closestTown.x, locY: closestTown.y, locZ: closestTown.z }
+    });
+}
+
+function isPartyCompanionOf(session, targetSession) {
+    return session.partyCompanion === true && session.followPlayerSession === targetSession;
+}
+
+function approachPlayer(session, bot, targetSession) {
+    const player = targetSession?.actor;
+    if (!player) return false;
+
+    const dx = player.fetchLocX() - bot.fetchLocX();
+    const dy = player.fetchLocY() - bot.fetchLocY();
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist <= 350) return true;
+
+    bot.moveTo({
+        from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
+        to: {
+            locX: player.fetchLocX() + utils.oneFromSpan(-80, 80),
+            locY: player.fetchLocY() + utils.oneFromSpan(-80, 80),
+            locZ: player.fetchLocZ()
+        }
+    });
+
+    return true;
+}
+
+function applyDecision(session, decision, visiblePlayers) {
+    const bot = session.actor;
+    if (!bot || !decision || decision.confidence < 0.45) return false;
+
+    const action = decision.action;
+    const targetSession = responseTargetSession(decision, visiblePlayers);
+    let applied = false;
+
+    if (action === 'none') {
+        applied = true;
+    } else if (action === 'say') {
+        say(session, decision.reply, targetSession);
+        applied = true;
+    } else if (action === 'follow_player') {
+        if (targetSession) {
+            stand(session, bot);
+            if (isPartyCompanionOf(session, targetSession)) {
+                session.plan = 'following';
+                session.botStay = false;
+                say(session, decision.reply || `Following you, ${targetSession.actor.fetchName()}!`, targetSession);
+            } else {
+                approachPlayer(session, bot, targetSession);
+                say(session, decision.reply || `Coming closer. Invite me if you want party follow.`, targetSession);
+            }
+            applied = true;
+        }
+    } else if (action === 'stay_here') {
+        session.botStay = true;
+        session.stayLocation = {
+            locX: bot.fetchLocX(),
+            locY: bot.fetchLocY(),
+            locZ: bot.fetchLocZ()
+        };
+        if (session.followPlayerSession && session.partyCompanion === true) {
+            session.plan = 'following';
+        }
+        say(session, decision.reply || 'Holding this position.', targetSession);
+        applied = true;
+    } else if (action === 'hunt') {
+        stand(session, bot);
+        session.plan = 'hunting';
+        session.followPlayerSession = null;
+        session.partyCompanion = false;
+        session.botStay = false;
+        say(session, decision.reply, targetSession);
+        applied = true;
+    } else if (action === 'rest') {
+        session.plan = 'resting';
+        session.currentTargetId = undefined;
+        bot.unselect();
+        sit(session, bot);
+        say(session, decision.reply, targetSession);
+        applied = true;
+    } else if (action === 'shop') {
+        startShopping(session, bot);
+        say(session, decision.reply, targetSession);
+        applied = true;
+    } else if (action === 'move_to_spot') {
+        if (applyMoveToSpot(session, bot, decision.spotId)) {
+            say(session, decision.reply, targetSession);
+            applied = true;
+        }
+    }
+
+    if (applied) {
+        session.lastBrainDecision = {
+            action: decision.action,
+            reason: decision.reason,
+            at: Date.now(),
+            model: config().model,
+            usage: decision.usage ? {
+                promptTokens: decision.usage.prompt_tokens,
+                completionTokens: decision.usage.completion_tokens,
+                cost: decision.usage.cost
+            } : null
+        };
+    }
+
+    return applied;
+}
+
+const BotBrain = {
+    isEnabled() {
+        const cfg = config();
+        return cfg.enabled && !!cfg.apiKey;
+    },
+
+    visibleRealPlayers,
+
+    maybeThink(session, event, status, text = '') {
+        const cfg = config();
+        const bot = session.actor;
+        if (!bot) return false;
+        if (!cfg.enabled) {
+            debugSkip(session, cfg, 'disabled');
+            return false;
+        }
+        if (!cfg.apiKey) {
+            debugSkip(session, cfg, 'missing_api_key');
+            return false;
+        }
+        if (session.brainInFlight) {
+            debugSkip(session, cfg, 'request_in_flight');
+            return false;
+        }
+        if (bot.isDead && bot.isDead()) {
+            debugSkip(session, cfg, 'dead');
+            return false;
+        }
+        if (session.plan === 'merchant') {
+            debugSkip(session, cfg, 'merchant_plan');
+            return false;
+        }
+        if (!ALLOWED_PLANS.includes(session.plan || 'hunting')) {
+            debugSkip(session, cfg, `plan_not_allowed:${session.plan}`);
+            return false;
+        }
+
+        const visiblePlayers = visibleRealPlayers(session, bot, cfg);
+        if (visiblePlayers.length === 0) {
+            debugSkip(session, cfg, 'no_visible_real_players');
+            return false;
+        }
+
+        const cooldown = event === 'player_chat' ? cfg.chatCooldownMs : cfg.cooldownMs;
+        const lastAt = event === 'player_chat' ? session.lastBrainChatAt : session.lastBrainThinkAt;
+        if (lastAt && Date.now() - lastAt < cooldown) {
+            debugSkip(session, cfg, `cooldown:${event}`);
+            return false;
+        }
+
+        if (event !== 'player_chat' && Math.random() > 0.12) {
+            debugSkip(session, cfg, 'ambient_sample_skip');
+            return false;
+        }
+
+        if (event === 'player_chat') {
+            session.lastBrainChatAt = Date.now();
+        } else {
+            session.lastBrainThinkAt = Date.now();
+        }
+
+        session.brainInFlight = true;
+        const payload = userPayload(event, session, status, visiblePlayers, text);
+        if (cfg.debug) {
+            utils.infoSuccess('BotBrain', '%s requesting %s decision via %s', bot.fetchName(), event, cfg.model);
+        }
+
+        requestDecision(payload, cfg).then((decision) => {
+            applyDecision(session, decision, visiblePlayers);
+        }).finally(() => {
+            session.brainInFlight = false;
+        });
+
+        return true;
+    }
+};
+
+module.exports = BotBrain;

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -172,7 +172,7 @@ const BotStatus = {
         };
 
         const target = findTarget(session, bot);
-        const party = session.followPlayerSession ? {
+        const party = session.followPlayerSession && session.partyCompanion === true ? {
             leader: actorSummary(session.followPlayerSession.actor, bot),
             role: inferRole(bot),
             stance: session.botStay ? 'stay' : 'follow',

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -5,6 +5,12 @@ const ServerResponse = invoke('GameServer/Network/Response');
 module.exports = {
     tick(session, bot, Generics, BotAI) {
         const playerSession = session.followPlayerSession;
+        if (session.partyCompanion !== true) {
+            session.plan = 'hunting';
+            session.followPlayerSession = null;
+            return;
+        }
+
         if (!playerSession || !playerSession.actor || !playerSession.actor.fetchIsOnline()) {
             session.plan = 'hunting';
             BotAI.say(session, "My companion has disconnected. Heading back to hunt.");
@@ -270,7 +276,7 @@ module.exports = {
                 World.fetchUser(playerTargetId).then((user) => {
                     const targetIsTeammate = user.session && (
                         user.session === playerSession ||
-                        user.session.followPlayerSession === playerSession
+                        (user.session.followPlayerSession === playerSession && user.session.partyCompanion === true)
                     );
 
                     const isAttackablePvPTarget = user.fetchKarma() > 0 || user.fetchPvpFlag() > 0;

--- a/src/GameServer/Bot/AI/States/RestingState.js
+++ b/src/GameServer/Bot/AI/States/RestingState.js
@@ -20,7 +20,7 @@ module.exports = {
         if (hpRatio >= 0.95 && mpRatio >= 0.95) {
             bot.state.setSeated(false);
             session.dataSendToOthers(ServerResponse.sitAndStand(bot), bot);
-            if (session.followPlayerSession) {
+            if (session.followPlayerSession && session.partyCompanion === true) {
                 session.plan = 'following';
                 BotAI.say(session, "Fully rested! Ready to follow you again.");
             } else {

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -1,6 +1,7 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const GeodataEngine  = invoke('GameServer/Geodata/GeodataEngine');
 const BotStatus      = invoke('GameServer/Bot/AI/BotStatus');
+const BotBrain       = invoke('GameServer/Bot/AI/BotBrain');
 
 const CHAT_PHRASES = {
     foundTarget: [
@@ -106,7 +107,7 @@ const BotAI = {
         const bot = session.actor;
         if (!bot) return 3000;
 
-        const isCompanion = !!session.followPlayerSession;
+        const isCompanion = !!session.followPlayerSession && session.partyCompanion === true;
         if (session.plan === 'shopping') {
             return 1500;
         }
@@ -251,7 +252,7 @@ const BotAI = {
 
         session.botStatus = BotStatus.getStatus(session);
 
-        const isCompanion = !!session.followPlayerSession;
+        const isCompanion = !!session.followPlayerSession && session.partyCompanion === true;
         const World = invoke('GameServer/World/World');
         const onlinePlayers = World.user.sessions.filter(s => 
             s.actor && 
@@ -275,6 +276,8 @@ const BotAI = {
             });
         }
 
+        BotBrain.maybeThink(session, 'ambient', session.botStatus);
+
         if (onlinePlayers.length > 0 && minDist > 1500 && !isCompanion && session.plan !== 'shopping') {
             // Far-away bot: light background event processing, skip everything else
             if (Math.random() < 0.05) {
@@ -294,7 +297,7 @@ const BotAI = {
         }
 
         // If bot is a companion, dynamically refresh player's party HUD sidebar HP/MP bars
-        if (session.plan === 'following' && session.followPlayerSession) {
+        if (session.plan === 'following' && session.followPlayerSession && session.partyCompanion === true) {
             const playerSession = session.followPlayerSession;
             if (playerSession && playerSession.actor && playerSession.actor.fetchIsOnline()) {
                 playerSession.dataSendToMe(
@@ -470,7 +473,7 @@ const BotAI = {
     say(session, text) {
         if (!session.actor) return;
         const ServerResponse = invoke('GameServer/Network/Response');
-        if (session.plan === 'following' && session.followPlayerSession) {
+        if (session.plan === 'following' && session.followPlayerSession && session.partyCompanion === true) {
             const packet = ServerResponse.speak(session.actor, { kind: 3, text: text });
             if (session.followPlayerSession.dataSendToMe) {
                 session.followPlayerSession.dataSendToMe(packet);
@@ -481,6 +484,17 @@ const BotAI = {
                 session.actor
             );
         }
+    },
+
+    tell(session, targetSession, text) {
+        if (!session.actor || !targetSession || !targetSession.dataSendToMe) return;
+        const clean = String(text || '').trim().slice(0, 120);
+        if (!clean) return;
+
+        const ServerResponse = invoke('GameServer/Network/Response');
+        targetSession.dataSendToMe(
+            ServerResponse.speak(session.actor, { kind: 2, text: clean })
+        );
     },
 
     trade(session, text) {

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -4,6 +4,7 @@ const DataCache   = invoke('GameServer/DataCache');
 const World       = invoke('GameServer/World/World');
 const BotSession  = invoke('GameServer/Bot/BotSession');
 const BotAI       = invoke('GameServer/Bot/BotAI');
+const BotBrain    = invoke('GameServer/Bot/AI/BotBrain');
 const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
 const MerchantConfigs = invoke('GameServer/Bot/MerchantStoreConfigs');
 const TradeService = invoke('GameServer/Bot/TradeService');
@@ -338,12 +339,14 @@ const BotManager = {
     },
 
     handlePlayerSpeak(playerSession, data) {
-        const text = data.text.trim().toLowerCase();
+        const rawText = data.text.trim();
+        const text = rawText.toLowerCase();
         const player = playerSession.actor;
-        if (!player) return;
+        if (!player || rawText.length === 0) return;
 
         const SpeckMath = invoke('GameServer/SpeckMath');
         const playerPt = new SpeckMath.Point3D(player.fetchLocX(), player.fetchLocY(), player.fetchLocZ());
+        let brainGroupResponderPicked = false;
 
         this.sessions.forEach((session) => {
             const bot = session.actor;
@@ -352,7 +355,10 @@ const BotManager = {
             const distance = new SpeckMath.Point3D(bot.fetchLocX(), bot.fetchLocY(), bot.fetchLocZ()).distance(playerPt);
             if (distance > 1500) return; // Too far to hear
 
+            let handledByRule = false;
+
             if (text.includes("hi") || text.includes("hello") || text.includes("привет") || text.includes("ку")) {
+                handledByRule = true;
                 setTimeout(() => {
                     const currentPlan = session.plan || 'hunting';
                     const phrases = [
@@ -365,14 +371,27 @@ const BotManager = {
             }
 
             else if (text.includes("follow") || text.includes("за мной") || text.includes("помоги")) {
+                handledByRule = true;
                 setTimeout(() => {
-                    this.botSay(session, `Sure! I will follow you and assist in combat.`);
-                    session.plan = 'following';
-                    session.followPlayerSession = playerSession;
+                    if (session.partyCompanion === true && session.followPlayerSession === playerSession) {
+                        this.botSay(session, `Sure! I will follow you and assist in combat.`);
+                        session.plan = 'following';
+                    } else {
+                        this.botTell(session, playerSession, `I can come closer, but invite me if you want party follow.`);
+                        bot.moveTo({
+                            from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
+                            to: {
+                                locX: player.fetchLocX() + utils.oneFromSpan(-80, 80),
+                                locY: player.fetchLocY() + utils.oneFromSpan(-80, 80),
+                                locZ: player.fetchLocZ()
+                            }
+                        });
+                    }
                 }, 800 + Math.random() * 800);
             }
 
             else if (text.includes("stop") || text.includes("стой") || text.includes("wait")) {
+                handledByRule = true;
                 setTimeout(() => {
                     this.botSay(session, `Staying here! Let me know if you need help.`);
                     session.plan = 'resting';
@@ -384,14 +403,17 @@ const BotManager = {
             }
 
             else if (text.includes("hunt") || text.includes("иди качайся") || text.includes("кач")) {
+                handledByRule = true;
                 setTimeout(() => {
                     this.botSay(session, `Alright, returning to hunt keltirs!`);
                     session.plan = 'hunting';
                     session.followPlayerSession = null;
+                    session.partyCompanion = false;
                 }, 800 + Math.random() * 800);
             }
 
             else if (text.includes("heal") || text.includes("хил") || text.includes("buff") || text.includes("бафф")) {
+                handledByRule = true;
                 if (bot.fetchName() === 'Bot_Gandalf') {
                     setTimeout(() => {
                         this.botSay(session, `Casting divine healing on you, ${player.fetchName()}!`);
@@ -419,6 +441,22 @@ const BotManager = {
                     }, 1000 + Math.random() * 500);
                 }
             }
+
+            if (!handledByRule) {
+                const botName = bot.fetchName().toLowerCase();
+                const shortBotName = botName.replace(/^bot_/, '');
+                const addressedToBot = text.includes(botName) || text.includes(shortBotName);
+                const selectedBot = typeof player.fetchDestId === 'function' && player.fetchDestId() === bot.fetchId();
+                const companionBot = session.followPlayerSession === playerSession && session.partyCompanion === true;
+                const groupAddress = /\b(bot|bots|guys|party|team|help)\b/.test(text) || /(бот|боты|ребят|народ|пати|команда|кто-нибудь)/.test(text);
+
+                if (addressedToBot || selectedBot || companionBot || (groupAddress && !brainGroupResponderPicked)) {
+                    if (groupAddress && !addressedToBot && !selectedBot && !companionBot) {
+                        brainGroupResponderPicked = true;
+                    }
+                    BotBrain.maybeThink(session, 'player_chat', BotAI.getStatus(session), rawText);
+                }
+            }
         });
     },
 
@@ -426,7 +464,7 @@ const BotManager = {
         if (!session.actor) return;
         const ServerResponse = invoke('GameServer/Network/Response');
         
-        if (session.plan === 'following' && session.followPlayerSession) {
+        if (session.plan === 'following' && session.followPlayerSession && session.partyCompanion === true) {
             const packet = ServerResponse.speak(session.actor, { kind: 3, text: text });
             if (session.followPlayerSession.dataSendToMe) {
                 session.followPlayerSession.dataSendToMe(packet);
@@ -437,6 +475,15 @@ const BotManager = {
                 session.actor
             );
         }
+    },
+
+    botTell(session, targetSession, text) {
+        if (!session.actor || !targetSession || !targetSession.dataSendToMe) return;
+        const clean = String(text || '').trim().slice(0, 120);
+        if (!clean) return;
+
+        const ServerResponse = invoke('GameServer/Network/Response');
+        targetSession.dataSendToMe(ServerResponse.speak(session.actor, { kind: 2, text: clean }));
     },
 
     botShout(session, text) {
@@ -618,7 +665,7 @@ const BotManager = {
 
                 // Find bots that are currently far (> 2500) from this player, and not close to any other player
                 const farBots = this.sessions.filter(botSession => {
-                    if (botSession.followPlayerSession) return false; // Do not dynamically scale/teleport active companion bots!
+                    if (botSession.followPlayerSession && botSession.partyCompanion === true) return false; // Do not dynamically scale/teleport active companion bots!
                     if (botSession.plan === 'merchant') return false;
                     const bot = botSession.actor;
                     if (!bot || !bot.fetchIsOnline()) return false;

--- a/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
+++ b/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
@@ -15,7 +15,7 @@ function companionControl(session, parts) {
         if (botName) {
             const targetSession = BotManager.sessions.find(s => s.actor && s.actor.fetchName().toLowerCase() === botName.toLowerCase());
             
-            if (targetSession && targetSession.followPlayerSession === session) {
+            if (targetSession && targetSession.followPlayerSession === session && targetSession.partyCompanion === true) {
                 const bot = targetSession.actor;
                 
                 if (subCommand === 'follow') {
@@ -61,6 +61,7 @@ function companionControl(session, parts) {
                         BotManager.botSay(targetSession, "Leaving the group. Goodbye!");
                         targetSession.plan = 'hunting';
                         targetSession.followPlayerSession = null;
+                        targetSession.partyCompanion = false;
                         targetSession.botStay = false;
                         targetSession.stayLocation = null;
                     }, 1000);
@@ -78,7 +79,7 @@ function renderCompanionPanel(session) {
     if (!actor) return;
 
     // Find all bot sessions following this player
-    const myCompanions = BotManager.sessions.filter(s => s.followPlayerSession === session && s.actor);
+    const myCompanions = BotManager.sessions.filter(s => s.followPlayerSession === session && s.partyCompanion === true && s.actor);
 
     if (myCompanions.length === 0) {
         const html = `<html><body><title>Party Control</title><font color="LEVEL">Companion Panel</font><br><br>You currently have no companions in your party.<br>Target a bot and type <font color="LEVEL">/invite</font> to recruit them!</body></html>`;

--- a/src/GameServer/World/World.js
+++ b/src/GameServer/World/World.js
@@ -77,6 +77,7 @@ const World = {
                 // Set companion state immediately so renderCompanionPanel works on the first invite
                 targetSession.plan = 'following';
                 targetSession.followPlayerSession = session;
+                targetSession.partyCompanion = true;
 
                 // 2. Add companion to party HUD sidebar
                 session.dataSendToMe(ServerResponse.partySmallWindowAll(actor.fetchId(), 0, [user]));
@@ -102,7 +103,7 @@ const World = {
         const BotManager = invoke('GameServer/Bot/BotManager');
         let botFound = false;
         BotManager.sessions.forEach((targetSession) => {
-            if (targetSession.actor && targetSession.actor.fetchName().toLowerCase() === data.name.toLowerCase() && targetSession.followPlayerSession === session) {
+            if (targetSession.actor && targetSession.actor.fetchName().toLowerCase() === data.name.toLowerCase() && targetSession.followPlayerSession === session && targetSession.partyCompanion === true) {
                 botFound = true;
                 session.dataSendToMe(ServerResponse.partySmallWindowDelete(targetSession.actor.fetchId(), targetSession.actor.fetchName()));
                 
@@ -110,6 +111,7 @@ const World = {
                     BotManager.botSay(targetSession, `I have been kicked from the party. Returning to hunt on my own!`);
                     targetSession.plan = 'hunting';
                     targetSession.followPlayerSession = null;
+                    targetSession.partyCompanion = false;
                 }, 1000);
             }
         });
@@ -122,7 +124,7 @@ const World = {
         const BotManager = invoke('GameServer/Bot/BotManager');
         let botsDisbanded = 0;
         BotManager.sessions.forEach((targetSession) => {
-            if (targetSession.followPlayerSession === session) {
+            if (targetSession.followPlayerSession === session && targetSession.partyCompanion === true) {
                 botsDisbanded++;
                 session.dataSendToMe(ServerResponse.partySmallWindowDelete(targetSession.actor.fetchId(), targetSession.actor.fetchName()));
 
@@ -130,6 +132,7 @@ const World = {
                     BotManager.botSay(targetSession, `Party dismissed! Returning to my farming fields.`);
                     targetSession.plan = 'hunting';
                     targetSession.followPlayerSession = null;
+                    targetSession.partyCompanion = false;
                 }, 1000);
             }
         });

--- a/src/Global.js
+++ b/src/Global.js
@@ -105,10 +105,36 @@ global.utils = {
     }
 };
 
+function mergeConfig(base, override) {
+    Object.keys(override || {}).forEach((key) => {
+        const baseValue = base[key];
+        const overrideValue = override[key];
+
+        if (
+            baseValue &&
+            overrideValue &&
+            typeof baseValue === 'object' &&
+            typeof overrideValue === 'object' &&
+            !Array.isArray(baseValue) &&
+            !Array.isArray(overrideValue)
+        ) {
+            mergeConfig(baseValue, overrideValue);
+        } else {
+            base[key] = overrideValue;
+        }
+    });
+
+    return base;
+}
+
+const ini = require('js-ini');
+const defaultConfig = ini.parse(utils.parseRawFile('./config/default.ini'));
+const localConfig = utils.fileExists('./config/local.ini')
+    ? ini.parse(utils.parseRawFile('./config/local.ini'))
+    : {};
+
 global.options = {
-    default: require('js-ini').parse(
-        utils.parseRawFile('./config/default.ini')
-    )
+    default: mergeConfig(defaultConfig, localConfig)
 };
 
 global.path = {


### PR DESCRIPTION
## Summary
- Add an optional OpenRouter-backed BotBrain layer for visible SimPlayers with structured JSON decisions, cooldowns, timeouts, price caps, and debug skip logging.
- Add safe config defaults plus ignored local overrides for private OpenRouter keys.
- Tighten companion semantics so bots only use party behavior after the real invite flow, while LLM/free-form requests can only make non-party bots approach or reply privately.

## Why
This lets nearby bots feel more responsive without spending model calls on bots outside player visibility, and prevents free-form AI decisions from bypassing party membership.

## Validation
- `node --check src\Global.js`
- `node --check src\GameServer\Bot\AI\BotBrain.js`
- `node --check src\GameServer\Bot\BotAI.js`
- `node --check src\GameServer\Bot\BotManager.js`
- `node tests\test_pathfinder_astar.js`
- `node tests\test_path_obstacle.js`