### PR TITLE
Add native merchant trade windows

### DIFF
--- a/src/GameServer/Actor/Generics/Select.js
+++ b/src/GameServer/Actor/Generics/Select.js
@@ -1,5 +1,68 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const World          = invoke('GameServer/World/World');
+const DataCache      = invoke('GameServer/DataCache');
+const Item           = invoke('GameServer/Item/Item');
+
+function merchantPurchaseItems(store) {
+    const items = [];
+
+    store.items.forEach((storeItem) => {
+        DataCache.fetchItemFromSelfId(storeItem.selfId, (item) => {
+            items.push(new Item(storeItem.objectId, {
+                ...utils.crushOb(item),
+                amount: storeItem.count,
+                price: storeItem.price
+            }));
+        });
+    });
+
+    return items;
+}
+
+function merchantSellRows(actor, store) {
+    return actor.backpack.fetchItems()
+        .filter((item) => !item.fetchEquipped() && item.fetchSelfId() !== 57)
+        .map((item) => {
+            const wanted = store.items.find((storeItem) => storeItem.selfId === item.fetchSelfId() && storeItem.count > 0);
+            if (!wanted) return null;
+
+            return {
+                item,
+                amount: Math.min(item.fetchAmount(), wanted.count),
+                price: wanted.price
+            };
+        })
+        .filter((row) => row && row.amount > 0);
+}
+
+function openMerchantTradeWindow(session, merchant) {
+    const store = merchant.fetchPrivateStore && merchant.fetchPrivateStore();
+    if (!store || !store.items || store.items.length === 0) {
+        session.dataSendToMe(ServerResponse.speak(session.actor, { kind: 0, text: "This merchant is not trading right now." }));
+        return;
+    }
+
+    session.activeMerchantTrade = { merchant, store };
+    session.viewedPrivateStoreSeller = merchant;
+
+    if (store.storeType === 1) {
+        session.dataSendToMe(ServerResponse.purchaseList(
+            merchantPurchaseItems(store),
+            session.actor.backpack.fetchTotalAdena()
+        ));
+        return;
+    }
+
+    if (store.storeType === 3) {
+        const rows = merchantSellRows(session.actor, store);
+        if (!rows.length) {
+            session.dataSendToMe(ServerResponse.speak(session.actor, { kind: 0, text: "This merchant is not buying anything from your inventory." }));
+            return;
+        }
+
+        session.dataSendToMe(ServerResponse.sellList(rows, session.actor.backpack.fetchTotalAdena()));
+    }
+}
 
 function select(session, actor, data) {
     const Generics = invoke(path.actor);
@@ -25,25 +88,15 @@ function select(session, actor, data) {
         if (user.fetchPrivateStoreType && user.fetchPrivateStoreType() !== 0) {
             utils.infoWarn('Select', 'Second click on bot "%s" with private store type %d. Plan: %s', user.fetchName(), user.fetchPrivateStoreType(), botSession.plan);
             session.viewedPrivateStoreSeller = user;
-            if (user.fetchPrivateStoreType() === 1) {
-                const isMerchantBot = botSession.plan === 'merchant';
-                if (isMerchantBot) {
-                    utils.infoSuccess('Select', 'Routing bot "%s" to BuyMerchantItem HTML shop', user.fetchName());
-                    const BuyMerchantItem = invoke('GameServer/World/Generics/NpcBypasses/BuyMerchantItem');
-                    BuyMerchantItem(session, ["buy-merchant-item"]);
-                } else {
-                    session.dataSendToMe(ServerResponse.privateStoreMsg(user, user.fetchTitle()));
-                    session.dataSendToMe(ServerResponse.privateStoreListSell(user, session.actor));
-                }
+            const isMerchantBot = botSession.plan === 'merchant';
+            if (isMerchantBot) {
+                utils.infoSuccess('Select', 'Opening native merchant trade window for bot "%s"', user.fetchName());
+                openMerchantTradeWindow(session, user);
+            } else if (user.fetchPrivateStoreType() === 1) {
+                session.dataSendToMe(ServerResponse.privateStoreMsg(user, user.fetchTitle()));
+                session.dataSendToMe(ServerResponse.privateStoreListSell(user, session.actor));
             } else if (user.fetchPrivateStoreType() === 3) {
-                const isMerchantBot = botSession.plan === 'merchant';
-                if (isMerchantBot) {
-                    utils.infoSuccess('Select', 'Routing bot "%s" to SellToMerchantItem HTML shop', user.fetchName());
-                    const SellToMerchantItem = invoke('GameServer/World/Generics/NpcBypasses/SellToMerchantItem');
-                    SellToMerchantItem(session, ["sell-to-merchant-item"]);
-                } else {
-                    session.dataSendToMe(ServerResponse.privateStoreListBuy(session.actor, user));
-                }
+                session.dataSendToMe(ServerResponse.privateStoreListBuy(session.actor, user));
             }
             return;
         }

--- a/src/GameServer/Network/Opcodes.js
+++ b/src/GameServer/Network/Opcodes.js
@@ -23,6 +23,7 @@ const Opcodes = {
         table[0x12] = ClientRequest.dropItem;
         table[0x14] = ClientRequest.useItem;
         table[0x1b] = ClientRequest.socialAction;
+        table[0x1e] = ClientRequest.sell;
         table[0x1f] = ClientRequest.purchase;
         table[0x21] = ClientRequest.htmlLink;
         table[0x29] = ClientRequest.askForTeamUp;

--- a/src/GameServer/Network/Request/Purchase.js
+++ b/src/GameServer/Network/Request/Purchase.js
@@ -1,5 +1,25 @@
 const World         = invoke('GameServer/World/World');
 const ReceivePacket = invoke('Packet/Receive');
+const ServerResponse = invoke('GameServer/Network/Response');
+const DataCache      = invoke('GameServer/DataCache');
+const Item           = invoke('GameServer/Item/Item');
+const TradeService   = invoke('GameServer/Bot/TradeService');
+
+function merchantPurchaseItems(store) {
+    const items = [];
+
+    store.items.forEach((storeItem) => {
+        DataCache.fetchItemFromSelfId(storeItem.selfId, (item) => {
+            items.push(new Item(storeItem.objectId, {
+                ...utils.crushOb(item),
+                amount: storeItem.count,
+                price: storeItem.price
+            }));
+        });
+    });
+
+    return items;
+}
 
 function purchase(session, buffer) {
     const packet = new ReceivePacket(buffer);
@@ -24,7 +44,29 @@ function purchase(session, buffer) {
     });
 }
 
-function consume(session, data) {
+async function consume(session, data) {
+    const trade = session.activeMerchantTrade;
+    const store = trade && trade.store;
+
+    if (store && store.storeType === 1) {
+        try {
+            for (const item of data.list) {
+                await TradeService.buyFromStore(session.actor, store, item.selfId, item.amount);
+            }
+
+            session.dataSendToMe(ServerResponse.userInfo(session.actor));
+            session.dataSendToMe(ServerResponse.itemsList(session.actor.backpack.fetchItems()));
+            session.dataSendToMe(ServerResponse.purchaseList(
+                merchantPurchaseItems(store),
+                session.actor.backpack.fetchTotalAdena()
+            ));
+        } catch (err) {
+            utils.infoWarn('Purchase', 'merchant purchase error: %s', err.message || err);
+            session.dataSendToMe(ServerResponse.actionFailed());
+        }
+        return;
+    }
+
     World.purchaseItems(session, data.list);
 }
 

--- a/src/GameServer/Network/Request/Sell.js
+++ b/src/GameServer/Network/Request/Sell.js
@@ -1,0 +1,74 @@
+const ReceivePacket = invoke('Packet/Receive');
+const ServerResponse = invoke('GameServer/Network/Response');
+const TradeService   = invoke('GameServer/Bot/TradeService');
+
+function merchantSellRows(actor, store) {
+    return actor.backpack.fetchItems()
+        .filter((item) => !item.fetchEquipped() && item.fetchSelfId() !== 57)
+        .map((item) => {
+            const wanted = store.items.find((storeItem) => storeItem.selfId === item.fetchSelfId() && storeItem.count > 0);
+            if (!wanted) return null;
+
+            return {
+                item,
+                amount: Math.min(item.fetchAmount(), wanted.count),
+                price: wanted.price
+            };
+        })
+        .filter((row) => row && row.amount > 0);
+}
+
+function sell(session, buffer) {
+    const packet = new ReceivePacket(buffer);
+
+    packet
+        .readD()  // List Id
+        .readD(); // Count
+
+    const count = packet.data[1];
+    const list = [];
+
+    for (let i = 0; i < count; i++) {
+        packet
+            .readD()
+            .readD();
+
+        list.push({
+            objectId: packet.data[2 + (i * 2)],
+            amount: packet.data[3 + (i * 2)]
+        });
+    }
+
+    consume(session, list);
+}
+
+async function consume(session, list) {
+    const trade = session.activeMerchantTrade;
+    const store = trade && trade.store;
+
+    if (!store || store.storeType !== 3) {
+        session.dataSendToMe(ServerResponse.actionFailed());
+        return;
+    }
+
+    try {
+        for (const line of list) {
+            const item = session.actor.backpack.fetchItems().find((ob) => ob.fetchId() === line.objectId);
+            if (!item || item.fetchEquipped() || item.fetchSelfId() === 57) continue;
+
+            await TradeService.sellToStore(session.actor, store, item.fetchSelfId(), line.amount);
+        }
+
+        session.dataSendToMe(ServerResponse.userInfo(session.actor));
+        session.dataSendToMe(ServerResponse.itemsList(session.actor.backpack.fetchItems()));
+        session.dataSendToMe(ServerResponse.sellList(
+            merchantSellRows(session.actor, store),
+            session.actor.backpack.fetchTotalAdena()
+        ));
+    } catch (err) {
+        utils.infoWarn('Sell', 'merchant sell error: %s', err.message || err);
+        session.dataSendToMe(ServerResponse.actionFailed());
+    }
+}
+
+module.exports = sell;

--- a/src/GameServer/Network/Request/index.js
+++ b/src/GameServer/Network/Request/index.js
@@ -24,6 +24,7 @@ module.exports = {
        removeShortcut: require('./RemoveShortcut'),
               restart: require('./Restart'),
          restartPoint: require('./RestartPoint'),
+                  sell: require('./Sell'),
            skillsList: require('./SkillsList'),
              skillUse: require('./SkillUse'),
          socialAction: require('./SocialAction'),

--- a/src/GameServer/Network/Response/SellList.js
+++ b/src/GameServer/Network/Response/SellList.js
@@ -1,0 +1,36 @@
+const SendPacket = invoke('Packet/Send');
+
+function sellList(rows, adena) {
+    const packet = new SendPacket(0x10);
+
+    packet
+        .writeD(adena)
+        .writeD(0x00)
+        .writeH(utils.size(rows));
+
+    rows.forEach((row) => {
+        const item = row.item;
+
+        packet
+            .writeH(item.fetchClass1())
+            .writeD(item.fetchId())
+            .writeD(item.fetchSelfId())
+            .writeD(row.amount)
+            .writeH(item.fetchClass2())
+            .writeH(0x00);
+
+        if (item.isWearable()) {
+            packet
+                .writeD(item.fetchSlot())
+                .writeH(0x00)
+                .writeH(0x00)
+                .writeH(0x00);
+        }
+
+        packet.writeD(row.price);
+    });
+
+    return packet.fetchBuffer();
+}
+
+module.exports = sellList;

--- a/src/GameServer/Network/Response/index.js
+++ b/src/GameServer/Network/Response/index.js
@@ -31,6 +31,7 @@ module.exports = {
                 restart: require('./Restart'),
                  revive: require('./Revive'),
            shortcutInit: require('./ShortcutInit'),
+                sellList: require('./SellList'),
                 showMap: require('./ShowMap'),
             sitAndStand: require('./SitAndStand'),
        skillDurationBar: require('./SkillDurationBar'),

--- a/src/GameServer/World/Generics/NpcBypasses/BuyShop.js
+++ b/src/GameServer/World/Generics/NpcBypasses/BuyShop.js
@@ -3,6 +3,8 @@ const Item           = invoke('GameServer/Item/Item');
 const DataCache      = invoke('GameServer/DataCache');
 
 module.exports = function(session, parts) {
+    session.activeMerchantTrade = null;
+
     let list = [];
     let itemIds = [];
 


### PR DESCRIPTION
## Summary

- Open native merchant buy/sell windows when interacting with trading bots instead of rendering custom HTML shops.
- Route merchant purchases through the bot store inventory and prices, preserving stock counts.
- Add native sell-list handling so buyer bots can accept player items and pay Adena through the shared trade service.

## Validation

- `node -c` on the changed game server request/response/select files
- `npx eslint` on the native merchant trade files
- `node tests/test_path_obstacle.js`
- `node tests/test_pathfinder_astar.js`
- Packet smoke for merchant buy and sell requests, including sell-list price encoding
- Server boot smoke reached DB/datapack/geodata/spawn initialization; full bind was blocked because the auth port was already in use during local testing