### PR TITLE
Keep ranged bot combat at range

### DIFF
--- a/src/GameServer/Actor/Generics/AttackExec.js
+++ b/src/GameServer/Actor/Generics/AttackExec.js
@@ -1,8 +1,10 @@
 const World = invoke('GameServer/World/World');
 
 function attackExec(session, actor, data) {
+    const attackRange = Math.max(0, Number(data.range) || 0);
+
     World.fetchNpc(data.id).then((npc) => {
-        actor.automation.scheduleAction(session, actor, npc, 0, () => {
+        actor.automation.scheduleAction(session, actor, npc, attackRange, () => {
             if (npc.fetchAttackable() || data.ctrl) {
                 actor.attack.meleeHit(session, npc);
             }
@@ -12,7 +14,7 @@ function attackExec(session, actor, data) {
         });
     }).catch(() => {
         World.fetchUser(data.id).then((user) => {
-            actor.automation.scheduleAction(session, actor, user, 0, () => {
+            actor.automation.scheduleAction(session, actor, user, attackRange, () => {
                 if (data.ctrl) {
                     if (utils.isInPeaceZone(actor.fetchLocX(), actor.fetchLocY()) || utils.isInPeaceZone(user.fetchLocX(), user.fetchLocY())) {
                         const ServerResponse = invoke('GameServer/Network/Response');

--- a/src/GameServer/Automation.js
+++ b/src/GameServer/Automation.js
@@ -79,15 +79,51 @@ class Automation extends SelectedModel {
     }
 
     ticksToMove(srcX, srcY, srcZ, dstX, dstY, dstZ, radius, speed) {
-        const distance = new SpeckMath.Point3D(srcX, srcY, srcZ).distance(new SpeckMath.Point3D(dstX, dstY, dstZ)) - radius;
-        const duration = 1 + ((this.ticksPerSecond * distance) / speed);
+        const stopRadius = Math.max(0, Number(radius) || 0);
+        const moveDistance = Math.max(0, new SpeckMath.Point3D(srcX, srcY, srcZ).distance(new SpeckMath.Point3D(dstX, dstY, dstZ)) - stopRadius);
+        const duration = 1 + ((this.ticksPerSecond * moveDistance) / speed);
         return (1000 / this.ticksPerSecond) * duration;
+    }
+
+    actionStopCoords(src, dst, radius) {
+        const srcCoords = {
+            locX: src.fetchLocX(),
+            locY: src.fetchLocY(),
+            locZ: src.fetchLocZ(),
+        };
+        const dstCoords = {
+            locX: dst.fetchLocX(),
+            locY: dst.fetchLocY(),
+            locZ: dst.fetchLocZ(),
+        };
+        const stopRadius = Math.max(0, Number(radius) || 0);
+
+        if (stopRadius <= 0) {
+            return dstCoords;
+        }
+
+        const dx = dstCoords.locX - srcCoords.locX;
+        const dy = dstCoords.locY - srcCoords.locY;
+        const dz = dstCoords.locZ - srcCoords.locZ;
+        const distance = Math.sqrt((dx ** 2) + (dy ** 2) + (dz ** 2));
+
+        if (distance <= stopRadius || distance === 0) {
+            return srcCoords;
+        }
+
+        const ratio = (distance - stopRadius) / distance;
+        return {
+            locX: Math.round(srcCoords.locX + dx * ratio),
+            locY: Math.round(srcCoords.locY + dy * ratio),
+            locZ: Math.round(srcCoords.locZ + dz * ratio),
+        };
     }
 
     scheduleAction(session, src, dst, radius, callback) {
         // Execute each time, or else creature is stuck
         this.setDestId(dst.fetchId());
         session.dataSendToMeAndOthers(ServerResponse.moveToPawn(src, dst, radius), src);
+        const stopCoords = this.actionStopCoords(src, dst, radius);
 
         // Calculate duration
         src.state.setTowards(radius === 0 ? 'melee' : 'remote');
@@ -105,9 +141,9 @@ class Automation extends SelectedModel {
             const startX = src.fetchLocX();
             const startY = src.fetchLocY();
             const startZ = src.fetchLocZ();
-            const endX = dst.fetchLocX();
-            const endY = dst.fetchLocY();
-            const endZ = dst.fetchLocZ();
+            const endX = stopCoords.locX;
+            const endY = stopCoords.locY;
+            const endZ = stopCoords.locZ;
 
             const dx = endX - startX;
             const dy = endY - startY;
@@ -139,11 +175,7 @@ class Automation extends SelectedModel {
             src.state.setTowards(false);
             this.clearDestId();
             if (session && (session.constructor.name === 'BotSession' || (session.accountId && session.accountId.startsWith('bot_')))) {
-                src.setLocXYZ({
-                    locX: dst.fetchLocX(),
-                    locY: dst.fetchLocY(),
-                    locZ: dst.fetchLocZ()
-                });
+                src.setLocXYZ(stopCoords);
                 if (session.moveTimer) {
                     clearInterval(session.moveTimer);
                     session.moveTimer = null;

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -390,6 +390,8 @@ const BotAI = {
     executeCombat(session, bot, npc, Generics) {
         const botName = bot.fetchName();
         const classId = bot.fetchClassId();
+        const MAGE_ATTACK_RANGE = 600;
+        const ARCHER_ATTACK_RANGE = 700;
 
         const MAGE_CLASSES = [10, 11, 12, 13, 14, 15, 16, 17, 25, 26, 27, 28, 29, 30, 38, 39, 40, 41, 42, 43];
         const ARCHER_CLASSES = [8, 9, 22, 23, 35, 36];
@@ -407,7 +409,7 @@ const BotAI = {
                     hitTime: 1500,
                     reuse: 1000,
                     power: 12,
-                    distance: 600,
+                    distance: MAGE_ATTACK_RANGE,
                     passive: false
                 });
                 bot.skillset.skills.push(skill);
@@ -430,7 +432,7 @@ const BotAI = {
                     hitTime: 1200,
                     reuse: 1500,
                     power: 15,
-                    distance: 600,
+                    distance: ARCHER_ATTACK_RANGE,
                     passive: false
                 });
                 bot.skillset.skills.push(skill);
@@ -439,6 +441,8 @@ const BotAI = {
                 Generics.skillExec(session, bot, { id: npc.fetchId(), selfId: 56, ctrl: true });
                 return;
             }
+            Generics.attackExec(session, bot, { id: npc.fetchId(), ctrl: true, range: ARCHER_ATTACK_RANGE });
+            return;
         }
         else {
             // Melee Fighter: Cast Power Strike with 40% probability if MP allows


### PR DESCRIPTION
## Summary
- Keep bot action movement from snapping ranged actors onto their targets.
- Allow normal attacks to opt into a range while preserving melee as the default.
- Keep mage combat at 600 range and archer combat at 700 range, including archer fallback attacks when Power Shot cannot be used.

## Root cause
Ranged skills had distance values, but bot movement simulation always ended at the target coordinates after scheduled actions. Archers also fell back to a normal zero-range attack when they lacked MP for Power Shot.

## Validation
- node --check src\GameServer\Bot\BotAI.js src\GameServer\Actor\Generics\AttackExec.js src\GameServer\Automation.js
- npx eslint src\GameServer\Bot\BotAI.js src\GameServer\Actor\Generics\AttackExec.js src\GameServer\Automation.js
- Micro-check for Automation.actionStopCoords at 600 and 700 range
- npm run NodeL2 booted through DB, datapack, geodata, world, and active bot startup; stopped manually after observation