### PR TITLE
Simplify server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,79 @@
-# L2NodeSolo - Offline Solo MMORPG Lineage II C2 Server
+# L2NodeSolo
 
-**L2NodeSolo** is a highly customized, ultra-fast **Lineage II Chronicle 2 (C2 Splendor)** server emulator written in **Node.js** and backed by **MariaDB**. 
+L2NodeSolo is a local-first Lineage II Chronicle 2 server emulator tuned for a solo MMO experiment: one real player, a live world, and SimPlayer bots that make the server feel populated.
 
-Unlike standard private servers, L2NodeSolo is specifically designed to create an immersive, single-player **Solo MMORPG offline experience** (conceptually similar to *Erenshor*). It populates the game world with active, autonomous **SimPlayers (AI Bots)** that hunt, chat, level up, manage their own economies, and can join your actual in-game party!
+It is not trying to be a retail-complete private server. The current focus is bot behavior, party companions, town trade loops, and observability while keeping the server easy to run locally.
 
-> [!NOTE]  
-> This project is a heavily expanded fork of the excellent and lightweight **[NodeL2 Server Emulator](https://github.com/NodeL2/NodeL2)**.
+## Current State
 
----
+Works now:
 
-## 🚀 Key Solo & Bot Features
+- Chronicle 2 protocol 485 login and game servers.
+- Local MariaDB-backed accounts, characters, skills, inventory, shortcuts, and positions.
+- Auto account creation when enabled in `config/default.ini`.
+- One-command local startup with `npm start`.
+- NPC spawn loading plus spatial-grid lookup for nearby NPC queries.
+- Player combat, movement, gear equip/unequip, basic item use, drops, pickup, shop buy/sell, and `.sell` junk cleanup.
+- Soulshot consume/load flow with the client activation effect and physical damage boost.
+- Admin panel with teleport, item shop, random teleport, and Adena tools.
+- SimPlayer bots that hunt, rest, flee, revive, shop, restock, chatter, and react to nearby player chat.
+- Dynamic bot scaling around online real players, including level/gear/class adjustment.
+- Companion bots through the normal `/invite` flow with party HUD packets and an in-game control panel.
+- Bot status surfaces through `.botstatus`, companion panel status links, and periodic `BotStatus :: ...` server logs.
+- Merchant bots in Talking Island, Gludio, Dion, Giran, and Oren with buy/sell stores and trade-chat ads.
+- PK bot behavior, including hunting, fleeing, and nearby bot reactions.
+- Optional OpenRouter-backed bot brain, gated to bots visible to real players.
 
-* **Player-Centric Dynamic Spawner:** Instead of rendering bots across empty zones of the world, a background monitor dynamics checks coordinates and spawns/anchors bots directly around active players (within a 2500-unit radius). This creates an extremely dense, alive, and packed MMO atmosphere while keeping CPU and RAM footprint extremely low.
-* **Real-Time Level & Stats Scaling:** All automated bots automatically adapt their level to match the active player's level (`playerLevel ± 1`). When the player gains a level, nearby bots celebrate with a social action flare and scale their stats (Max HP/MP, P.Atk, P.Def, Atk.Spd, and Cast.Spd) instantly according to the retail Formulas, replenishing their vitals in real time!
-* **Autonomous SimPlayers (Bots) & Shopping State:** SimPlayers are fully self-sufficient. They roam, hunt, rest to regenerate, chat dynamically, and periodically return to town when their inventory is full to sell junk loot (`sell-junk` NPC bypass) and restock on No-Grade Soulshots.
-* **PK Bots & Random Coordinate Respawn:** Watch out for PK (Player Killer) bots like **Aragorn** that roam, scale, and hunt players! To prevent bots and players from death-looping in a pile, a random coordinate respawn scatter system disperses resurrected bots across dynamic coordinates around the zone.
-* **High-Performance Soulshots:** Completely revamped synchronous-in-memory soulshots system. Using a soulshot manually or relying on the automatic attack consume triggers memory updates, UI visual flashes (Skill `2039` weapon glow effect), and **2.0x physical attack damage** instantly. Heavy database writes are executed asynchronously in the background, ensuring 0ms latency and a buttery smooth combat loop.
-* **Party HUD Companion System:** Target any bot and type `/invite` to summon them to your party. Companions dynamically teleport to your location, accept the invite with chat flavor text, and join the party HUD sidebar with active, real-time HP/MP bars!
-* **Town Helpers & Divine Actions:** Talk Village town helpers and unique AI bots like Gandalf will react to public chat keywords. Typing `heal` or `buff` near Gandalf prompts him to instantly cast restoration spells on your character.
-* **Instant Sell Bypass (`.sell`):** Sell your unequipped loot in town dialogues or instantly via the `.sell` console command, giving you 50% retail Adena value instantly to keep your farming runs fast and rewarding.
+Known rough edges:
 
----
+- This is a development server, not a hardened public shard.
+- Some geodata regions may be missing locally; the server falls back and logs warnings.
+- C2 client packet compatibility is fragile. Store nameplate and party UI changes need live client testing.
+- The database bootstrap preserves existing data by default. Resetting the database is explicit.
 
-## 🛠️ Prerequisites
+## Requirements
 
-* Install **[NodeJS LTS](https://nodejs.org/en/download)**, and **Docker** (to run MariaDB in a lightweight container).
-* For convenience, install **[VS Code](https://code.visualstudio.com/download)**.
-* Download the **[LINEAGE II C2 Splendor Client (Protocol 485)](https://drive.google.com/file/d/1NVA4XY3bC2xD_Jejggo_b0fuMFChsZqe/view?usp=sharing)**.
+- Node.js LTS.
+- Docker, unless you run MariaDB yourself.
+- A Lineage II C2 Splendor client using protocol 485.
 
----
+Client reference: [LINEAGE II C2 Splendor Client](https://drive.google.com/file/d/1NVA4XY3bC2xD_Jejggo_b0fuMFChsZqe/view?usp=sharing)
 
-## 💻 Quick Start
+## Quick Start
 
-### 1. Start the MariaDB Docker Container
-Start a clean MariaDB 10.6 container mapping standard port `3306`:
 ```bash
-docker run -d --name nodel2-mariadb -p 3306:3306 -e MARIADB_ROOT_PASSWORD='alosi!$53' mariadb:10.6
+npm start
 ```
 
-### 2. Import the Database
-Import the Chronicle 2 table structures:
+That command will:
+
+- install Node dependencies if `node_modules` is missing;
+- create or start a local `nodel2-mariadb` Docker container when the configured database host is `127.0.0.1` or `localhost`;
+- import `database/sql/database.sql` on first boot if database `nodel2` does not exist;
+- start the auth server on `2106` and the game server on `7777`.
+
+If you run MariaDB yourself, set:
+
 ```bash
-Get-Content database/sql/database.sql -Raw | docker exec -i nodel2-mariadb mariadb -u root -palosi!$53
+L2NODE_SKIP_DOCKER=1 npm start
 ```
 
-### 3. Install Sockets & Dependencies
-Install Node packages:
-```bash
-npm install
-```
+The old direct server command still works:
 
-### 4. Boot the Server
-Launch the Game and Login servers:
 ```bash
 npm run NodeL2
 ```
-*The spatial grid will index the spawns at boot, and bots will automatically load from database accounts and spawn beside Talk Village town center within 5 seconds!*
 
-### Optional: OpenRouter Bot Brain
-The committed `config/default.ini` contains safe defaults only. Put private overrides in ignored `config/local.ini`:
+Use it when dependencies and database are already prepared and you want no bootstrap behavior.
+
+## Configuration
+
+Committed defaults live in `config/default.ini`.
+
+Private local overrides go in ignored `config/local.ini`. This is where API keys and machine-specific database settings belong.
+
+Example:
+
 ```ini
 [OpenRouter]
 enabled = true
@@ -66,31 +81,104 @@ apiKey = sk-or-v1-your-key-here
 model = google/gemini-2.5-flash-lite
 debug = true
 ```
-You can also use environment variables instead of a local file:
+
+If you use your own database instead of the local Docker container, override the `Database` section there as well.
+
+OpenRouter can also read the key/model from environment variables:
+
 ```bash
-OPENROUTER_API_KEY=sk-or-v1-your-key-here npm run NodeL2
+OPENROUTER_API_KEY=sk-or-v1-your-key-here npm start
 ```
-With `debug = true`, BotBrain logs why it skips a request (`disabled`, `missing_api_key`, `no_visible_real_players`, `cooldown`) or when it sends a decision request. The brain only runs for bots visible to a real player.
 
----
+Useful startup variables:
 
-## ✴️ In-Game Chat Commands
+- `L2NODE_SKIP_DOCKER=1` - skip Docker bootstrap and use the configured database.
+- `L2NODE_DB_CONTAINER=some-name` - override the Docker container name.
+- `L2NODE_DB_IMAGE=mariadb:10.6` - override the MariaDB image.
+- `BOT_STATUS_LOGS=0` - disable periodic bot status log lines.
 
-* `.admin` - Opens the administrative menu (Teleports, Leveling, and full Item Lists).
-* `.sell` - Instantly cleans out all unequipped junk loot from your inventory for 50% retail value.
-* `.leave` / `/leave` - Dissolves the current companion group, returning bots to their farming fields.
-* `.kick <name>` / `/dismiss <name>` - Kicks a specific bot companion from your party.
-* Nearby bots will react to chat lines like: `hi`, `follow`, `wait`, `hunt`, and `heal` (Gandalf only).
+## In-Game Commands
 
----
+- `.admin` - open the admin menu.
+- `.sell` - sell all unequipped non-Adena items for 50% item value.
+- `.bot` or `.companion` - open the companion control panel.
+- `.botstatus` - show a bot overview panel.
+- `.botstatus <name>` - show detailed status for a specific bot.
+- `.leave` - dismiss all companion bots.
+- `.kick <name>` - dismiss one companion bot.
+- `/invite` while targeting a bot - recruit that bot as a companion.
+- `/dismiss <name>` and `/leave` also work through the party request path.
 
-## 🧪 Debug Notes
+Nearby bots also react to plain chat lines such as `hi`, `follow`, `wait`, `hunt`, `heal`, and `buff`. Healing/buff help is intentionally tied to Gandalf-style mage behavior.
 
-* C2 Buy store nameplate opcode probe: `0xAE` reacts/crashes with bad payload, but safe payload is `objectId + byte(0)`.
-* Spell-cancel overlay effect trick: inserting a `writeS(title)` after `CharInfo.privateStoreType` shifts client parsing into effect/status fields and renders the cancel-spell overlay above the character. Do **not** use this for store text; restore CharInfo structure afterward.
+## Bot Systems
 
----
+SimPlayers are normal server sessions backed by database characters. On startup, `BotManager` loads them, assigns plans, and ticks their behavior.
 
-## 📄 License
-L2NodeSolo is licensed under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).  
-Original L2Node framework credited to [naden](https://github.com/NodeL2/NodeL2).
+Main bot modes:
+
+- `hunting` - find monsters, fight, loot, and move between spots.
+- `resting` - recover HP/MP.
+- `getting_buffed` - visit newbie buff flow when low-level buffs expire.
+- `shopping` - return to town, sell junk, and restock consumables.
+- `following` - assist a real player as a companion.
+- `merchant` - stand in town with private buy/sell store state.
+- `pk_hunting` / `pk_fleeing` - hostile player-killer loop and safety recovery.
+
+Bot status is meant to be inspectable. Use `.botstatus`, the companion panel `Status` links, or watch `BotStatus :: ...` lines in the server logs.
+
+## Merchant Bots
+
+Merchant bots currently cover:
+
+- Talking Island: starter materials, starter gear, and island-drop buyers.
+- Gludio: D-grade materials, gear, and plains-drop buyers.
+- Dion: C-grade crafting stock, parts, and Dion-drop buyers.
+- Giran: C/B-grade materials, gear, and Giran-drop buyers.
+- Oren: B/A-grade materials, gear, and Oren-drop buyers.
+
+The source of truth for town merchant stock is `src/GameServer/Bot/MerchantStoreConfigs.js`.
+
+## OpenRouter Bot Brain
+
+The deterministic server code still owns combat, movement, inventory, shopping, and safety. The optional LLM brain is only allowed to influence small, whitelisted decisions.
+
+Important behavior:
+
+- Disabled by default.
+- Requires `OpenRouter.enabled = true` plus an API key.
+- Only considers bots visible to a real online player.
+- Skips merchant plans and missing-player contexts.
+- Emits debug skip reasons when `OpenRouter.debug = true`.
+
+This keeps token spend tied to player-visible moments instead of letting offline bots burn calls in an empty world.
+
+## Development
+
+Run the focused tests:
+
+```bash
+node tests/test_pathfinder_astar.js
+node tests/test_path_obstacle.js
+```
+
+Run a full boot check:
+
+```bash
+npm start
+```
+
+Expected healthy boot signs:
+
+- `DB :: connected`
+- `Datapack :: cached`
+- `SpawnsGrid :: Indexed ... npcs in 2D spatial grid`
+- `AuthServer :: successful init for 0.0.0.0:2106`
+- `GameServer :: successful init for 0.0.0.0:7777`
+- `BotManager :: ... is active in World`
+
+## Credits
+
+This project is a heavily modified solo-MMO fork of the original [NodeL2 Server Emulator](https://github.com/NodeL2/NodeL2).
+
+L2NodeSolo is licensed under the Apache 2.0 license.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "L2 Chronicle 2 server emulator in NodeJS",
     "author": "Dennis Koluris",
     "scripts": {
+        "start": "node scripts/start.js",
         "NodeL2": "node --openssl-legacy-provider src/NodeL2"
     },
     "dependencies": {

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawn, spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const containerName = process.env.L2NODE_DB_CONTAINER || 'nodel2-mariadb';
+const imageName = process.env.L2NODE_DB_IMAGE || 'mariadb:10.6';
+const isWindows = process.platform === 'win32';
+const npmCommand = isWindows ? 'npm.cmd' : 'npm';
+const dockerCommand = isWindows ? 'docker.exe' : 'docker';
+
+function log(message) {
+    console.info(`Startup    :: ${message}`);
+}
+
+function warn(message) {
+    console.warn(`Startup    :: ${message}`);
+}
+
+function sleep(ms) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function run(command, args, options = {}) {
+    return spawnSync(command, args, {
+        cwd: rootDir,
+        encoding: 'utf8',
+        ...options
+    });
+}
+
+function commandAvailable(command) {
+    const result = run(command, ['--version'], { stdio: 'ignore' });
+    return result.status === 0;
+}
+
+function parseIni(raw) {
+    const config = {};
+    let section = config;
+
+    raw.split(/\r?\n/).forEach((line) => {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith(';') || trimmed.startsWith('#')) {
+            return;
+        }
+
+        const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+        if (sectionMatch) {
+            section = config[sectionMatch[1]] = config[sectionMatch[1]] || {};
+            return;
+        }
+
+        const separator = trimmed.indexOf('=');
+        if (separator === -1) {
+            return;
+        }
+
+        const key = trimmed.slice(0, separator).trim();
+        const value = trimmed.slice(separator + 1).trim();
+        section[key] = value;
+    });
+
+    return config;
+}
+
+function mergeConfig(base, override) {
+    Object.keys(override || {}).forEach((key) => {
+        const baseValue = base[key];
+        const overrideValue = override[key];
+
+        if (
+            baseValue &&
+            overrideValue &&
+            typeof baseValue === 'object' &&
+            typeof overrideValue === 'object' &&
+            !Array.isArray(baseValue) &&
+            !Array.isArray(overrideValue)
+        ) {
+            mergeConfig(baseValue, overrideValue);
+        } else {
+            base[key] = overrideValue;
+        }
+    });
+
+    return base;
+}
+
+function readConfig() {
+    const defaultPath = path.join(rootDir, 'config', 'default.ini');
+    const localPath = path.join(rootDir, 'config', 'local.ini');
+    const config = parseIni(fs.readFileSync(defaultPath, 'utf8'));
+
+    if (fs.existsSync(localPath)) {
+        mergeConfig(config, parseIni(fs.readFileSync(localPath, 'utf8')));
+    }
+
+    return config;
+}
+
+function ensureDependencies() {
+    if (fs.existsSync(path.join(rootDir, 'node_modules'))) {
+        return;
+    }
+
+    log('node_modules not found; running npm install');
+    const result = run(npmCommand, ['install'], { stdio: 'inherit' });
+    if (result.status !== 0) {
+        process.exit(result.status || 1);
+    }
+}
+
+function isLocalDatabase(dbConfig) {
+    const hostname = String(dbConfig.hostname || '').toLowerCase();
+    return hostname === '127.0.0.1' || hostname === 'localhost';
+}
+
+function dockerInspect(format) {
+    return run(dockerCommand, ['inspect', '-f', format, containerName]);
+}
+
+function ensureDockerDatabase(dbConfig) {
+    if (process.env.L2NODE_SKIP_DOCKER === '1') {
+        warn('L2NODE_SKIP_DOCKER=1; assuming MariaDB is already reachable');
+        return;
+    }
+
+    if (!isLocalDatabase(dbConfig)) {
+        warn(`database host is ${dbConfig.hostname}; skipping local Docker bootstrap`);
+        return;
+    }
+
+    if (!commandAvailable(dockerCommand)) {
+        warn('Docker is not available; assuming MariaDB is already reachable');
+        return;
+    }
+
+    const password = dbConfig.password || '';
+    const port = String(dbConfig.port || '3306');
+    const databaseName = dbConfig.databaseName || 'nodel2';
+    let containerCreated = false;
+
+    const exists = dockerInspect('{{.Name}}').status === 0;
+    if (!exists) {
+        log(`creating ${containerName} (${imageName}) on port ${port}`);
+        const result = run(dockerCommand, [
+            'run',
+            '-d',
+            '--name',
+            containerName,
+            '-p',
+            `${port}:3306`,
+            '-e',
+            `MARIADB_ROOT_PASSWORD=${password}`,
+            imageName
+        ], { stdio: 'inherit' });
+
+        if (result.status !== 0) {
+            warn('could not create MariaDB container; server startup will try the configured database anyway');
+            return;
+        }
+
+        containerCreated = true;
+    } else {
+        const running = dockerInspect('{{.State.Running}}');
+        if (String(running.stdout).trim() !== 'true') {
+            log(`starting ${containerName}`);
+            const result = run(dockerCommand, ['start', containerName], { stdio: 'inherit' });
+            if (result.status !== 0) {
+                warn('could not start MariaDB container; server startup will try the configured database anyway');
+                return;
+            }
+        }
+    }
+
+    waitForDatabase(password);
+
+    if (containerCreated || !databaseExists(password, databaseName)) {
+        importDatabase(password);
+    }
+}
+
+function waitForDatabase(password) {
+    const passwordArg = `-p${password}`;
+
+    for (let attempt = 1; attempt <= 30; attempt += 1) {
+        const result = run(dockerCommand, [
+            'exec',
+            containerName,
+            'mariadb',
+            '-u',
+            'root',
+            passwordArg,
+            '-e',
+            'SELECT 1;'
+        ], { stdio: 'ignore' });
+
+        if (result.status === 0) {
+            return;
+        }
+
+        sleep(1000);
+    }
+
+    warn('MariaDB did not become ready in 30s; server startup will continue and report any DB error');
+}
+
+function databaseExists(password, databaseName) {
+    const passwordArg = `-p${password}`;
+    const result = run(dockerCommand, [
+        'exec',
+        containerName,
+        'mariadb',
+        '-u',
+        'root',
+        passwordArg,
+        '-N',
+        '-s',
+        '-e',
+        `SHOW DATABASES LIKE '${databaseName.replace(/'/g, "''")}';`
+    ]);
+
+    return result.status === 0 && String(result.stdout).trim() === databaseName;
+}
+
+function importDatabase(password) {
+    const sqlPath = path.join(rootDir, 'database', 'sql', 'database.sql');
+    const sql = fs.readFileSync(sqlPath, 'utf8');
+    const passwordArg = `-p${password}`;
+
+    log('importing database/sql/database.sql');
+    const result = run(dockerCommand, [
+        'exec',
+        '-i',
+        containerName,
+        'mariadb',
+        '-u',
+        'root',
+        passwordArg
+    ], {
+        input: sql,
+        stdio: ['pipe', 'inherit', 'inherit']
+    });
+
+    if (result.status !== 0) {
+        process.exit(result.status || 1);
+    }
+}
+
+function startServer() {
+    log('starting NodeL2');
+    const child = spawn(process.execPath, ['--openssl-legacy-provider', 'src/NodeL2'], {
+        cwd: rootDir,
+        stdio: 'inherit',
+        env: process.env
+    });
+
+    child.on('exit', (code, signal) => {
+        if (signal) {
+            process.kill(process.pid, signal);
+            return;
+        }
+
+        process.exit(code || 0);
+    });
+}
+
+function main() {
+    const config = readConfig();
+    ensureDependencies();
+    ensureDockerDatabase(config.Database || {});
+    startServer();
+}
+
+main();


### PR DESCRIPTION
## Summary

- Add `npm start` as the one-command local startup path.
- Add a Node bootstrap script that can install dependencies, manage the local MariaDB Docker container, import the schema on first boot, and then launch NodeL2.
- Rewrite the README around current behavior: what works now, rough edges, startup/configuration, in-game commands, bot systems, merchant coverage, OpenRouter behavior, and development checks.

## Validation

- `node --check scripts/start.js`
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"`
- `node tests/test_pathfinder_astar.js`
- `node tests/test_path_obstacle.js`
- Live `npm start` boot smoke test reached DB connection, auth/game server startup, and bot initialization before being stopped.