### PR TITLE
Add persistent starter bot populations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 package-lock.json
 data/Geodata/
 config/local.ini
+tmp/

--- a/README.md
+++ b/README.md
@@ -4,32 +4,50 @@ L2NodeSolo is a local-first Lineage II Chronicle 2 server emulator tuned for a s
 
 It is not trying to be a retail-complete private server. The current focus is bot behavior, party companions, town trade loops, and observability while keeping the server easy to run locally.
 
-## Current State
+## Game Checklist
 
-Works now:
+L2NodeSolo is judged by what the world feels like in the client, not by how many server subsystems exist under the hood.
 
-- Chronicle 2 protocol 485 login and game servers.
-- Local MariaDB-backed accounts, characters, skills, inventory, shortcuts, and positions.
-- Auto account creation when enabled in `config/default.ini`.
-- One-command local startup with `npm start`.
-- NPC spawn loading plus spatial-grid lookup for nearby NPC queries.
-- Player combat, movement, gear equip/unequip, basic item use, drops, pickup, shop buy/sell, and `.sell` junk cleanup.
-- Soulshot consume/load flow with the client activation effect and physical damage boost.
-- Admin panel with teleport, item shop, random teleport, and Adena tools.
-- SimPlayer bots that hunt, rest, flee, revive, shop, restock, chatter, and react to nearby player chat.
-- Dynamic bot scaling around online real players, including level/gear/class adjustment.
-- Companion bots through the normal `/invite` flow with party HUD packets and an in-game control panel.
-- Bot status surfaces through `.botstatus`, companion panel status links, and periodic `BotStatus :: ...` server logs.
-- Merchant bots in Talking Island, Gludio, Dion, Giran, and Oren with buy/sell stores and trade-chat ads.
-- PK bot behavior, including hunting, fleeing, and nearby bot reactions.
-- Optional OpenRouter-backed bot brain, gated to bots visible to real players.
+### Playable Now
 
-Known rough edges:
+- [x] Log in with a Chronicle 2 client and enter the world locally.
+- [x] Create and persist characters, inventory, skills, shortcuts, position, and basic progression.
+- [x] Move through the world, target NPCs, fight monsters, take damage, die, revive, and continue playing.
+- [x] Pick up drops, use basic items, equip and unequip gear, use soulshots, and sell junk with `.sell`.
+- [x] Buy and sell through NPC shops.
+- [x] Explore populated starter areas with persistent SimPlayer characters instead of bots teleporting around the player.
+- [x] See race-appropriate starter populations around each available race start, with a small number of visitor characters for MMO flavor.
+- [x] Meet SimPlayers that hunt, rest, flee, revive, shop, restock, loot, chatter, and react to nearby player chat.
+- [x] Invite SimPlayers as party companions through the normal `/invite` flow and manage them through the in-game companion panel.
+- [x] Inspect companion and bot state through `.botstatus`, companion `Status` links, and server-side status logs.
+- [x] Encounter merchant SimPlayers in Talking Island, Gludio, Dion, Giran, and Oren with private buy/sell stores and occasional trade-chat ads.
+- [x] See early PK-style bot behavior: hostile hunting, fleeing, and nearby bot reactions.
+- [x] Use local admin tools for teleporting, item grants, random teleport, and Adena while testing.
 
-- This is a development server, not a hardened public shard.
+### In Progress
+
+- [ ] More natural long-term SimPlayer memory: names, home region, level history, relationships, and personal routines should persist instead of feeling reset between sessions.
+- [ ] Better starter-zone ecology: race-specific bot ratios, class mix, routes, and town/field behavior need more tuning by location.
+- [ ] Bot progression that feels earned: levels, gear, and class growth should come from real activity, not from hidden scaling.
+- [ ] Richer party play: clearer roles, smarter assist behavior, healing/buff timing, looting rules, and travel together.
+- [ ] More believable economy loops: local buyers, sellers, stock pressure, restocking, and player-visible trade behavior.
+- [ ] More social chatter that sounds like players talking about the world, drops, prices, spots, danger, and plans.
+- [ ] Optional OpenRouter-backed bot brain for player-visible moments without spending tokens on background simulation.
+
+### Planned
+
+- [ ] Quest progression that matters for a solo MMO run.
+- [ ] Broader class/skill coverage and better retail-like combat edge cases.
+- [ ] More complete towns, hunting routes, respawn behavior, and regional difficulty curves.
+- [ ] Crafting, enchanting, warehouse, freight, and deeper item economy systems.
+- [ ] Clan/social systems and longer-term player identity.
+- [ ] Safer public-server hardening. Right now this is a local development shard, not a production private server.
+
+### Known Rough Edges
+
 - Some geodata regions may be missing locally; the server falls back and logs warnings.
-- C2 client packet compatibility is fragile. Store nameplate and party UI changes need live client testing.
-- The database bootstrap preserves existing data by default. Resetting the database is explicit.
+- C2 client packet compatibility is fragile. Store presentation, party UI, and unusual packet changes need live client testing.
+- The database bootstrap preserves existing data by default. Resets are explicit.
 
 ## Requirements
 
@@ -109,7 +127,7 @@ Useful startup variables:
 - `/invite` while targeting a bot - recruit that bot as a companion.
 - `/dismiss <name>` and `/leave` also work through the party request path.
 
-Nearby bots also react to plain chat lines such as `hi`, `follow`, `wait`, `hunt`, `heal`, and `buff`. Healing/buff help is intentionally tied to Gandalf-style mage behavior.
+Nearby bots also react to plain chat lines such as `hi`, `follow`, `wait`, `hunt`, `heal`, and `buff`. Healing and buff help depends on the bot's class and current plan.
 
 ## Bot Systems
 
@@ -126,6 +144,12 @@ Main bot modes:
 - `pk_hunting` / `pk_fleeing` - hostile player-killer loop and safety recovery.
 
 Bot status is meant to be inspectable. Use `.botstatus`, the companion panel `Status` links, or watch `BotStatus :: ...` lines in the server logs.
+
+To reset generated SimPlayer accounts and characters while keeping the rest of the database intact:
+
+```bash
+npm run wipe:bots
+```
 
 ## Merchant Bots
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "author": "Dennis Koluris",
     "scripts": {
         "start": "node scripts/start.js",
-        "NodeL2": "node --openssl-legacy-provider src/NodeL2"
+        "NodeL2": "node --openssl-legacy-provider src/NodeL2",
+        "wipe:bots": "node scripts/wipe-bots.js"
     },
     "dependencies": {
         "blowfish-ecb": "^1.0.2",

--- a/scripts/wipe-bots.js
+++ b/scripts/wipe-bots.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const mariadb = require('mariadb');
+
+const rootDir = path.resolve(__dirname, '..');
+
+function parseIni(raw) {
+    const config = {};
+    let section = config;
+
+    raw.split(/\r?\n/).forEach((line) => {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith(';') || trimmed.startsWith('#')) {
+            return;
+        }
+
+        const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+        if (sectionMatch) {
+            section = config[sectionMatch[1]] = config[sectionMatch[1]] || {};
+            return;
+        }
+
+        const separator = trimmed.indexOf('=');
+        if (separator === -1) return;
+
+        const key = trimmed.slice(0, separator).trim();
+        const value = trimmed.slice(separator + 1).trim();
+        section[key] = value;
+    });
+
+    return config;
+}
+
+function mergeConfig(base, override) {
+    Object.keys(override || {}).forEach((key) => {
+        const baseValue = base[key];
+        const overrideValue = override[key];
+
+        if (
+            baseValue &&
+            overrideValue &&
+            typeof baseValue === 'object' &&
+            typeof overrideValue === 'object' &&
+            !Array.isArray(baseValue) &&
+            !Array.isArray(overrideValue)
+        ) {
+            mergeConfig(baseValue, overrideValue);
+        } else {
+            base[key] = overrideValue;
+        }
+    });
+
+    return base;
+}
+
+function readConfig() {
+    const defaultPath = path.join(rootDir, 'config', 'default.ini');
+    const localPath = path.join(rootDir, 'config', 'local.ini');
+    const config = parseIni(fs.readFileSync(defaultPath, 'utf8'));
+
+    if (fs.existsSync(localPath)) {
+        mergeConfig(config, parseIni(fs.readFileSync(localPath, 'utf8')));
+    }
+
+    return config;
+}
+
+function placeholders(count) {
+    return Array.from({ length: count }, () => '?').join(', ');
+}
+
+async function main() {
+    const config = readConfig().Database || {};
+    const conn = await mariadb.createConnection({
+        host: config.hostname,
+        port: Number(config.port || 3306),
+        user: config.user,
+        password: config.password,
+        database: config.databaseName
+    });
+
+    try {
+        const characters = await conn.query("SELECT id, name, username FROM characters WHERE username LIKE 'bot\\_%' ESCAPE '\\\\'");
+        const accounts = await conn.query("SELECT username FROM accounts WHERE username LIKE 'bot\\_%' ESCAPE '\\\\'");
+        const ids = characters.map((row) => row.id);
+
+        if (ids.length > 0) {
+            const idList = placeholders(ids.length);
+            await conn.query(`DELETE FROM shortcuts WHERE characterId IN (${idList})`, ids);
+            await conn.query(`DELETE FROM skills WHERE characterId IN (${idList})`, ids);
+            await conn.query(`DELETE FROM items WHERE characterId IN (${idList})`, ids);
+            await conn.query(`DELETE FROM characters WHERE id IN (${idList})`, ids);
+        }
+
+        await conn.query("DELETE FROM accounts WHERE username LIKE 'bot\\_%' ESCAPE '\\\\'");
+
+        console.info(`Wiped ${characters.length} bot characters and ${accounts.length} bot accounts.`);
+        if (characters.length > 0) {
+            console.info(`Removed: ${characters.map((row) => row.name).join(', ')}`);
+        }
+    } finally {
+        await conn.end();
+    }
+}
+
+main().catch((err) => {
+    console.error('Bot wipe failed:', err.message || err);
+    process.exit(1);
+});

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -188,6 +188,10 @@ const BotStatus = {
             mode: session.plan || 'hunting',
             intent: undefined,
             role: inferRole(bot),
+            home: {
+                region: session.homeRegion || null,
+                visitor: !!session.visitor
+            },
             loc: actorLocation(bot),
             vitals,
             target,
@@ -220,9 +224,10 @@ const BotStatus = {
         const mp = Math.round(status.vitals.mpPct * 100);
         const target = status.target && status.target.name ? ` target=${status.target.name}` : '';
         const spot = status.spot && status.spot.name ? ` spot=${status.spot.name}` : '';
+        const home = status.home && status.home.region ? ` home=${status.home.region}${status.home.visitor ? ':visitor' : ''}` : '';
         const blockers = status.blockers.length > 0 ? ` blockers=${status.blockers.join(',')}` : '';
 
-        return `${status.name}: mode=${status.mode} intent=${status.intent} role=${status.role} hp=${hp}% mp=${mp}%${target}${spot}${blockers}`;
+        return `${status.name}: mode=${status.mode} intent=${status.intent} role=${status.role}${home} hp=${hp}% mp=${mp}%${target}${spot}${blockers}`;
     }
 };
 

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -206,14 +206,15 @@ const BotAI = {
             const BotManager = invoke('GameServer/Bot/BotManager');
             const townName = this.getClosestTownName(bot.fetchLocX(), bot.fetchLocY());
 
-            const aragornSession = BotManager.sessions.find(s => s.actor && s.actor.fetchName() === "Aragorn");
-            const aragornLoc = aragornSession?.actor ? this.getClosestTownName(aragornSession.actor.fetchLocX(), aragornSession.actor.fetchLocY()) : "Dion";
+            const pkSession = BotManager.sessions.find(s => s.actor && s.actor.fetchKarma() > 0);
+            const pkLoc = pkSession?.actor ? this.getClosestTownName(pkSession.actor.fetchLocX(), pkSession.actor.fetchLocY()) : "Dion";
+            const pkName = pkSession?.actor ? pkSession.actor.fetchName() : "a red name";
 
             const pkPhrases = [
-                `Help! PK spotted near ${aragornLoc}!`,
-                `Watch out, Aragorn is PKing everyone near ${aragornLoc}!`,
-                `Someone kill the PK at ${aragornLoc}! He's red name!`,
-                `Aragorn is hunting newbies near ${aragornLoc}! Flee!`
+                `Help! PK spotted near ${pkLoc}!`,
+                `Watch out, ${pkName} is PKing near ${pkLoc}!`,
+                `Someone deal with the red name at ${pkLoc}!`,
+                `${pkName} is hunting people near ${pkLoc}! Flee!`
             ];
 
             const normalPhrases = [
@@ -224,7 +225,7 @@ const BotAI = {
                 `Wow, the mobs near ${townName} are spawning fast today.`
             ];
 
-            const aragornPhrases = [
+            const pkSelfPhrases = [
                 `No one is safe near ${townName}! I'm coming for you!`,
                 `Dion and ${townName} are my hunting grounds! Prepare to die!`,
                 `Haha, another soul claimed near ${townName}!`,
@@ -232,9 +233,9 @@ const BotAI = {
             ];
 
             let text = "";
-            if (bot.fetchName() === "Aragorn") {
-                text = aragornPhrases[Math.floor(Math.random() * aragornPhrases.length)];
-            } else if (Math.random() < 0.25 && aragornSession && aragornSession.actor && !aragornSession.actor.state.fetchDead()) {
+            if (bot.fetchKarma() > 0) {
+                text = pkSelfPhrases[Math.floor(Math.random() * pkSelfPhrases.length)];
+            } else if (Math.random() < 0.25 && pkSession && pkSession.actor && !pkSession.actor.state.fetchDead()) {
                 text = pkPhrases[Math.floor(Math.random() * pkPhrases.length)];
             } else {
                 text = normalPhrases[Math.floor(Math.random() * normalPhrases.length)];
@@ -323,7 +324,7 @@ const BotAI = {
                 session.currentTargetId = undefined;
                 
                 let spawnTarget;
-                if (bot.fetchKarma() > 0 || bot.fetchName() === "Aragorn") {
+                if (bot.fetchKarma() > 0) {
                     session.plan = 'pk_hunting';
                     const BotManager = invoke('GameServer/Bot/BotManager');
                     spawnTarget = BotManager.findHighDensityCoord();
@@ -331,8 +332,7 @@ const BotAI = {
                     spawnTarget.locY += (Math.random() - 0.5) * 800;
                     spawnTarget.locZ = GeodataEngine.getHeight(spawnTarget.locX, spawnTarget.locY, spawnTarget.locZ);
                 } else {
-                    const MerchantConfigs = invoke('GameServer/Bot/MerchantStoreConfigs');
-                    if (MerchantConfigs[bot.fetchName()]) {
+                    if (session.plan === 'merchant' || (bot.fetchPrivateStore && bot.fetchPrivateStore())) {
                         session.plan = 'merchant';
                         bot.state.setSeated(true);
                         spawnTarget = {
@@ -388,7 +388,6 @@ const BotAI = {
     },
 
     executeCombat(session, bot, npc, Generics) {
-        const botName = bot.fetchName();
         const classId = bot.fetchClassId();
         const MAGE_ATTACK_RANGE = 600;
         const ARCHER_ATTACK_RANGE = 700;
@@ -396,7 +395,7 @@ const BotAI = {
         const MAGE_CLASSES = [10, 11, 12, 13, 14, 15, 16, 17, 25, 26, 27, 28, 29, 30, 38, 39, 40, 41, 42, 43];
         const ARCHER_CLASSES = [8, 9, 22, 23, 35, 36];
 
-        if (botName === 'Bot_Gandalf' || MAGE_CLASSES.includes(classId)) {
+        if (MAGE_CLASSES.includes(classId)) {
             const SkillModel = invoke('GameServer/Model/Skill');
             let skill = bot.skillset.fetchSkill(1177);
             if (!skill) {
@@ -419,7 +418,7 @@ const BotAI = {
                 return;
             }
         }
-        else if (botName === 'Bot_Legolas' || ARCHER_CLASSES.includes(classId)) {
+        else if (ARCHER_CLASSES.includes(classId)) {
             const SkillModel = invoke('GameServer/Model/Skill');
             let skill = bot.skillset.fetchSkill(56);
             if (!skill) {

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -8,34 +8,16 @@ const BotBrain    = invoke('GameServer/Bot/AI/BotBrain');
 const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
 const MerchantConfigs = invoke('GameServer/Bot/MerchantStoreConfigs');
 const TradeService = invoke('GameServer/Bot/TradeService');
+const BotPopulation = invoke('GameServer/Bot/BotPopulation');
 
-const BOTS_TO_SPAWN = [
-    { name: "Bot_Gimli",   race: 4, sex: 0, classId: 53, face: 0, hair: 0, hairColor: 0 }, // Dwarf
-    { name: "Bot_Legolas", race: 1, sex: 0, classId: 18, face: 0, hair: 4, hairColor: 0 }, // Elf
-    { name: "Bot_Gandalf", race: 0, sex: 0, classId: 10, face: 0, hair: 2, hairColor: 0 }  // Human Mage
-];
+const BOTS_TO_SPAWN = BotPopulation.buildStarterBots();
 
 const MERCHANT_BOTS = Object.keys(MerchantConfigs).map(name => {
     const cfg = MerchantConfigs[name];
-    return { name: name, race: 4, sex: 0, classId: 53, face: 0, hair: 0, hairColor: 0, locX: cfg.locX, locY: cfg.locY, locZ: cfg.locZ };
+    return { name: name, merchantConfigName: name, race: 4, sex: 0, classId: 53, face: 0, hair: 0, hairColor: 0, locX: cfg.locX, locY: cfg.locY, locZ: cfg.locZ };
 });
 
-const isMerchantName = name => !!MerchantConfigs[name];
-
-const EXTRA_BOTS_COUNT = 10; // Configurable: Set to 20, 50, or more to scale up the bot count!
-
-const FANTASY_NAMES = [
-    "Aragorn", "Boromir", "Galadriel", "Arwen", "Elrond", "Eowyn", "Faramir", "Theoden", 
-    "Conan", "Xena", "Arthur", "Merlin", "Robin", "Marian", "Frodo", "Samwise", 
-    "Merry", "Pippin", "Bilbo", "Geralt", "Yennefer", "Triss", "Ciri", "Dandelion"
-];
-
-const BOT_COMBINATIONS = [
-    { race: 0, sex: 0, classId: 10 }, // Human Mage
-    { race: 0, sex: 0, classId: 0 },  // Human Fighter
-    { race: 1, sex: 0, classId: 18 }, // Elf Knight
-    { race: 4, sex: 0, classId: 53 }  // Dwarf Scavenger
-];
+const merchantConfigFor = (botData, characterName) => MerchantConfigs[botData.merchantConfigName || characterName];
 
 const BotManager = {
     sessions: [],
@@ -89,6 +71,7 @@ const BotManager = {
         const spot = status.spot ? `${status.spot.name} / Lv ${status.spot.minLevel}-${status.spot.maxLevel} / density ${status.spot.density}` : 'none';
         const target = status.target ? `${status.target.type}:${status.target.name || status.target.id}` : 'none';
         const party = status.party ? `${status.party.role}, ${status.party.stance}, leader ${status.party.leader?.name || 'unknown'}` : 'none';
+        const home = status.home?.region ? `${status.home.region}${status.home.visitor ? ' visitor' : ''}` : 'unknown';
         const blockers = status.blockers.length > 0 ? status.blockers.join(', ') : 'none';
         const decision = botSession.lastDecision ? `${botSession.lastDecision.action} / ${botSession.lastDecision.reason}${botSession.lastDecision.spotName ? ` / ${botSession.lastDecision.spotName}` : ''}` : 'none';
         const trade = status.trade?.last ? status.trade.last :
@@ -100,6 +83,7 @@ const BotManager = {
         html += row('Mode', status.mode);
         html += row('Intent', status.intent);
         html += row('Role', status.role);
+        html += row('Home', home);
         html += row('Vitals', `HP ${pct(status.vitals.hpPct)} / MP ${pct(status.vitals.mpPct)}`);
         html += row('Target', target);
         html += row('Party', party);
@@ -120,21 +104,7 @@ const BotManager = {
         console.info("BotManager :: Initializing automated SimPlayers...");
         
         const bots = [...BOTS_TO_SPAWN, ...MERCHANT_BOTS];
-
-        // Dynamically generate extra bots
-        for (let i = 0; i < EXTRA_BOTS_COUNT; i++) {
-            const name = FANTASY_NAMES[i % FANTASY_NAMES.length] + (Math.floor(i / FANTASY_NAMES.length) || "");
-            const combo = BOT_COMBINATIONS[i % BOT_COMBINATIONS.length];
-            bots.push({
-                name: name,
-                race: combo.race,
-                sex: combo.sex,
-                classId: combo.classId,
-                face: 0,
-                hair: 0,
-                hairColor: 0
-            });
-        }
+        console.info("BotManager :: Starter population: %s", BotPopulation.summarize(BOTS_TO_SPAWN));
         
         // Wait 5 seconds after startup to let world finish loading
         setTimeout(() => {
@@ -147,7 +117,7 @@ const BotManager = {
     },
 
     provisionAndSpawn(botData, idx) {
-        const username = ("bot_" + botData.name.toLowerCase()).slice(0, 16);
+        const username = (botData.username || ("bot_" + botData.name.toLowerCase())).slice(0, 16);
         
         // 1. Ensure Bot Account exists
         Database.fetchUserPassword(username).then((rows) => {
@@ -161,54 +131,71 @@ const BotManager = {
         });
     },
 
+    resolveCharacterName(baseName, attempt = 0) {
+        const suffix = attempt === 0 ? '' : String(attempt);
+        const candidate = `${String(baseName).slice(0, 16 - suffix.length)}${suffix}`;
+
+        return Database.fetchCharacterName(candidate).then((rows) => {
+            if (!rows[0]) return candidate;
+            return this.resolveCharacterName(baseName, attempt + 1);
+        });
+    },
+
     provisionCharacter(username, botData, idx) {
-        // 2. Ensure Bot Character exists
-        Database.fetchCharacterName(botData.name).then((rows) => {
-            if (!rows[0]) {
-                Shared.fetchClassInformation(botData.classId).then((classInfo) => {
+        Database.fetchCharacters(username).then((characters) => {
+            if (characters[0]) {
+                this.loadAndSpawnBot(username, botData);
+                return;
+            }
+
+            this.resolveCharacterName(botData.name).then((characterName) => {
+                const effectiveBotData = { ...botData, name: characterName };
+                if (characterName !== botData.name) {
+                    utils.infoWarn('BotManager', 'bot name %s is taken; using %s for %s', botData.name, characterName, username);
+                }
+
+                Shared.fetchClassInformation(effectiveBotData.classId).then((classInfo) => {
                     let coords;
-                    if (botData.locX !== undefined) {
+                    if (effectiveBotData.locX !== undefined) {
                         coords = {
-                            locX: botData.locX,
-                            locY: botData.locY,
-                            locZ: botData.locZ
+                            locX: effectiveBotData.locX,
+                            locY: effectiveBotData.locY,
+                            locZ: effectiveBotData.locZ
                         };
                     } else {
-                        const spawns = BotAI.newbieSpawnCoords(botData.classId);
+                        const spawns = BotAI.newbieSpawnCoords(effectiveBotData.spawnClassId || effectiveBotData.classId);
                         const spawn = spawns[Math.floor(Math.random() * spawns.length)];
                         coords = {
-                            locX: spawn.locX + (idx % 5) * 20, // small offset to avoid direct overlapping
-                            locY: spawn.locY + (idx % 5) * 20,
+                            locX: spawn.locX + utils.oneFromSpan(-180, 180),
+                            locY: spawn.locY + utils.oneFromSpan(-180, 180),
                             locZ: spawn.locZ
                         };
                     }
 
                     const charData = {
-                        name: botData.name,
-                        race: botData.race,
-                        sex: botData.sex,
-                        classId: botData.classId,
-                        hair: botData.hair ?? 0,
-                        hairColor: botData.hairColor ?? 0,
-                        face: botData.face ?? 0,
+                        name: effectiveBotData.name,
+                        race: effectiveBotData.race,
+                        sex: effectiveBotData.sex,
+                        classId: effectiveBotData.classId,
+                        hair: effectiveBotData.hair ?? 0,
+                        hairColor: effectiveBotData.hairColor ?? 0,
+                        face: effectiveBotData.face ?? 0,
                         ...classInfo.vitals,
                         ...coords
                     };
 
                     Database.createCharacter(username, charData).then((packet) => {
                         const charId = Number(packet.insertId);
-                        this.awardBaseGear(charId, botData.classId);
-                        this.awardBaseSkills(charId, botData.classId);
-                        this.loadAndSpawnBot(username);
+                        this.awardBaseGear(charId, effectiveBotData.classId);
+                        this.awardBaseSkills(charId, effectiveBotData.classId);
+                        this.loadAndSpawnBot(username, effectiveBotData);
                     });
                 });
-            } else {
-                this.loadAndSpawnBot(username);
-            }
+            });
         });
     },
 
-    loadAndSpawnBot(username) {
+    loadAndSpawnBot(username, botData = {}) {
         const session = new BotSession(username);
         
         Shared.fetchCharacters(username).then((characters) => {
@@ -216,20 +203,15 @@ const BotManager = {
             if (!character) return;
 
             Shared.fetchClassInformation(character.classId).then((classInfo) => {
-                // Reset merchant bots back to their exact designated coordinates on load
-                if (isMerchantName(character.name)) {
-                    const config = MERCHANT_BOTS.find(b => b.name === character.name);
-                    if (config) {
-                        character.locX = config.locX;
-                        character.locY = config.locY;
-                        character.locZ = config.locZ;
-                    }
-                }
+                const storeCfg = merchantConfigFor(botData, character.name);
 
-                // Randomize initial location slightly to scatter them across the starting area
-                if (character.name !== "Bot_Gimli" && character.name !== "Bot_Legolas" && character.name !== "Bot_Gandalf" && character.name !== "Aragorn" && !isMerchantName(character.name)) {
-                    character.locX += (Math.random() - 0.5) * 1600;
-                    character.locY += (Math.random() - 0.5) * 1600;
+                // Reset merchant bots back to their exact designated coordinates on load
+                if (storeCfg) {
+                    if (botData.locX !== undefined) {
+                        character.locX = botData.locX;
+                        character.locY = botData.locY;
+                        character.locZ = botData.locZ;
+                    }
                 }
 
                 character.locZ = GeodataEngine.getHeight(character.locX, character.locY, character.locZ);
@@ -237,6 +219,9 @@ const BotManager = {
                 session.setActor({
                     ...character, ...utils.crushOb(classInfo)
                 });
+
+                session.homeRegion = botData.homeRegion || null;
+                session.visitor = !!botData.visitor;
                 
                 session.initialSpawnCoord = {
                     locX: character.locX,
@@ -244,51 +229,24 @@ const BotManager = {
                     locZ: character.locZ
                 };
 
-                // Designate some extra bots as permanent town gossips, and Aragorn as PK!
-                if (character.name !== "Bot_Gimli" && character.name !== "Bot_Legolas" && character.name !== "Bot_Gandalf") {
-                    if (character.name === "Aragorn") {
-                        session.plan = 'pk_hunting';
-                        session.actor.setPk(5);
-                        session.actor.setKarma(9999);
-                        
-                        // Teleport Aragorn to the highest player density coordinate after spawning
-                        setTimeout(() => {
-                            const densityCoord = this.findHighDensityCoord();
-                            session.actor.setLocXYZ(densityCoord);
-                            
-                            const TeleportTo = invoke('GameServer/Actor/Generics/TeleportTo');
-                            if (TeleportTo && typeof TeleportTo === 'function') {
-                                TeleportTo(session, session.actor, densityCoord);
-                            }
-                            utils.infoSuccess("BotManager", "PK Bot %s (Level %d) is hunting at %d, %d", character.name, character.level, densityCoord.locX, densityCoord.locY);
-                        }, 8000);
-                    } else if (isMerchantName(character.name)) {
-                        session.plan = 'merchant';
-                        session.actor.state.setSeated(true);
+                if (storeCfg) {
+                    session.plan = 'merchant';
+                    session.actor.state.setSeated(true);
 
-                        const storeCfg = MerchantConfigs[character.name];
-                        if (storeCfg) {
-                            session.actor.setTitle(storeCfg.title);
-                            session.actor.setPrivateStoreType(storeCfg.storeType);
+                    session.actor.setTitle(storeCfg.title);
+                    session.actor.setPrivateStoreType(storeCfg.storeType);
 
-                            const storeItems = TradeService.normalizeStoreItems(storeCfg);
+                    const storeItems = TradeService.normalizeStoreItems(storeCfg);
 
-                            session.actor.setPrivateStore({
-                                storeType: storeCfg.storeType,
-                                title: storeCfg.title,
-                                town: storeCfg.town,
-                                items: storeItems
-                            });
-                        }
-                    } else if (Math.random() < 0.40) {
-                        session.plan = 'resting';
-                        session.townGossip = true;
-                        session.actor.state.setSeated(true);
-                    } else {
-                        session.plan = 'hunting';
-                    }
+                    session.actor.setPrivateStore({
+                        storeType: storeCfg.storeType,
+                        title: storeCfg.title,
+                        town: storeCfg.town,
+                        items: storeItems
+                    });
                 } else {
-                    session.plan = 'hunting';
+                    session.plan = botData.plan || 'hunting';
+                    session.actor.state.setSeated(false);
                 }
 
                 // Spawn the bot actor in the World
@@ -414,7 +372,8 @@ const BotManager = {
 
             else if (text.includes("heal") || text.includes("хил") || text.includes("buff") || text.includes("бафф")) {
                 handledByRule = true;
-                if (bot.fetchName() === 'Bot_Gandalf') {
+                const healerClasses = [15, 16, 17, 29, 30, 42, 43];
+                if (healerClasses.includes(bot.fetchClassId())) {
                     setTimeout(() => {
                         this.botSay(session, `Casting divine healing on you, ${player.fetchName()}!`);
                         
@@ -437,7 +396,7 @@ const BotManager = {
                     }, 1000);
                 } else {
                     setTimeout(() => {
-                        this.botSay(session, `I'm not a mage! Ask Bot_Gandalf for healing.`);
+                        this.botTell(session, playerSession, `I do not have proper healing magic yet.`);
                     }, 1000 + Math.random() * 500);
                 }
             }
@@ -564,7 +523,7 @@ const BotManager = {
 
         World.user.sessions.forEach((session) => {
             const actor = session.actor;
-            if (actor && actor.fetchIsOnline() && actor.fetchKarma() === 0 && actor.fetchName() !== 'Bot_Gimli' && actor.fetchName() !== 'Bot_Legolas' && actor.fetchName() !== 'Bot_Gandalf' && !utils.isInPeaceZone(actor.fetchLocX(), actor.fetchLocY())) {
+            if (actor && actor.fetchIsOnline() && actor.fetchKarma() === 0 && !session.accountId?.startsWith('bot_') && !utils.isInPeaceZone(actor.fetchLocX(), actor.fetchLocY())) {
                 const sx = Math.floor(actor.fetchLocX() / 4000);
                 const sy = Math.floor(actor.fetchLocY() / 4000);
                 const key = `${sx},${sy}`;
@@ -592,13 +551,7 @@ const BotManager = {
     },
 
     startDynamicScalingMonitor() {
-        setInterval(() => {
-            try {
-                this.monitorAndScaleBots();
-            } catch (err) {
-                console.error("Dynamic Scaling Monitor Error:", err);
-            }
-        }, 5000); // Check and scale bots every 5 seconds
+        console.info("BotManager :: Dynamic bot teleport/level scaling removed; using persistent starter populations.");
     },
 
     startStatusLogMonitor() {
@@ -622,416 +575,6 @@ const BotManager = {
                 console.error("Bot Status Monitor Error:", err);
             }
         }, 30000);
-    },
-
-    monitorAndScaleBots() {
-        const World = invoke('GameServer/World/World');
-        
-        // 1. Get all online real players
-        const onlinePlayers = World.user.sessions.filter(s => 
-            s.actor && 
-            s.actor.fetchIsOnline() && 
-            s.accountId && 
-            !s.accountId.startsWith('bot_')
-        );
-
-        if (onlinePlayers.length === 0) return;
-
-        // Target bots we want to maintain around each player
-        const TARGET_BOTS_COUNT = 8;
-
-        onlinePlayers.forEach(playerSession => {
-            const player = playerSession.actor;
-            const px = player.fetchLocX();
-            const py = player.fetchLocY();
-            const pz = player.fetchLocZ();
-            const playerLevel = player.fetchLevel();
-
-            // 2. Filter bots that are already close to this player (within 2500 radius)
-            const nearbyBots = this.sessions.filter(botSession => {
-                const bot = botSession.actor;
-                if (!bot || !bot.fetchIsOnline()) return false;
-                if (botSession.plan === 'merchant') return false;
-
-                const dx = bot.fetchLocX() - px;
-                const dy = bot.fetchLocY() - py;
-                const dist = Math.sqrt(dx * dx + dy * dy);
-                return dist <= 2500;
-            });
-
-            // 3. If nearby bots count is less than target, teleport far/idle bots to this player
-            if (nearbyBots.length < TARGET_BOTS_COUNT) {
-                const countToTeleport = TARGET_BOTS_COUNT - nearbyBots.length;
-
-                // Find bots that are currently far (> 2500) from this player, and not close to any other player
-                const farBots = this.sessions.filter(botSession => {
-                    if (botSession.followPlayerSession && botSession.partyCompanion === true) return false; // Do not dynamically scale/teleport active companion bots!
-                    if (botSession.plan === 'merchant') return false;
-                    const bot = botSession.actor;
-                    if (!bot || !bot.fetchIsOnline()) return false;
-
-                    const dx = bot.fetchLocX() - px;
-                    const dy = bot.fetchLocY() - py;
-                    const dist = Math.sqrt(dx * dx + dy * dy);
-
-                    if (dist <= 2500) return false; // Eliminate the dead zone between 2500 and 3000
-
-                    // Make sure it's not near any other online player either
-                    const isNearOtherPlayer = onlinePlayers.some(otherPlayerSession => {
-                        if (otherPlayerSession === playerSession) return false;
-                        const op = otherPlayerSession.actor;
-                        const odx = bot.fetchLocX() - op.fetchLocX();
-                        const ody = bot.fetchLocY() - op.fetchLocY();
-                        const odist = Math.sqrt(odx * odx + ody * ody);
-                        return odist <= 2500;
-                    });
-
-                    return !isNearOtherPlayer;
-                });
-
-                // Teleport the bots and scale their levels
-                for (let i = 0; i < Math.min(countToTeleport, farBots.length); i++) {
-                    const botSession = farBots[i];
-                    const bot = botSession.actor;
-
-                    // Randomized position around player (between 1500 and 2500 units)
-                    const angle = Math.random() * 2 * Math.PI;
-                    const rad = 1500 + Math.random() * 1000;
-                    const tx = Math.floor(px + Math.cos(angle) * rad);
-                    const ty = Math.floor(py + Math.sin(angle) * rad);
-                    const tz = GeodataEngine.getHeight(tx, ty, pz);
-
-                    // Dynamic Level Scaling (playerLevel ± 1)
-                    const levelVariance = Math.floor(Math.random() * 3) - 1; // -1, 0, or 1
-                    const targetLevel = Math.max(1, playerLevel + levelVariance);
-                    bot.setLevel(targetLevel);
-
-                    const getBaseClassId = (race, isSpellcaster) => {
-                        if (race === 0) return isSpellcaster ? 10 : 0;
-                        if (race === 1) return isSpellcaster ? 25 : 18;
-                        if (race === 2) return isSpellcaster ? 38 : 31;
-                        if (race === 3) return isSpellcaster ? 49 : 44;
-                        if (race === 4) return 53;
-                        return 0;
-                    };
-
-                    const getRandomClassForLevel = (baseClassId, level) => {
-                        if (level < 20) return baseClassId;
-                        
-                        const firstProfMap = {
-                            0: [1, 4, 7],
-                            10: [11, 15],
-                            18: [19, 22],
-                            25: [26, 29],
-                            31: [32, 35],
-                            38: [39, 42],
-                            44: [45, 47],
-                            49: [50],
-                            53: [54, 56]
-                        };
-
-                        const secondProfMap = {
-                            1: [2, 3],
-                            4: [5, 6],
-                            7: [8, 9],
-                            11: [12, 13, 14],
-                            15: [16, 17],
-                            19: [20, 21],
-                            22: [23, 24],
-                            26: [27, 28],
-                            29: [30],
-                            32: [33, 34],
-                            35: [36, 37],
-                            39: [40, 41],
-                            42: [43],
-                            45: [46],
-                            47: [48],
-                            50: [51, 52],
-                            54: [55],
-                            56: [57]
-                        };
-
-                        const firstProfs = firstProfMap[baseClassId] || [baseClassId];
-                        const randomFirst = firstProfs[Math.floor(Math.random() * firstProfs.length)];
-
-                        if (level < 40) return randomFirst;
-
-                        const secondProfs = secondProfMap[randomFirst] || [randomFirst];
-                        return secondProfs[Math.floor(Math.random() * secondProfs.length)];
-                    };
-
-                    const baseClass = getBaseClassId(bot.fetchRace(), bot.isSpellcaster());
-                    const targetClassId = getRandomClassForLevel(baseClass, targetLevel);
-                    bot.setClassId(targetClassId);
-
-                    bot.skillset.awardSkills(bot.fetchId(), targetClassId, targetLevel).then(() => {
-                        this.equipScaledBot(botSession, bot, targetLevel, targetClassId).then(() => {
-                            // Recalculate stats & replenish HP/MP
-                            const CalculateStats = invoke('GameServer/Actor/Generics/CalculateStats');
-                            if (typeof CalculateStats === 'function') {
-                                CalculateStats(botSession, bot);
-                            }
-                            bot.fillupVitals();
-                        });
-                    });
-
-                    // Update bot session plans & centers
-                    botSession.initialSpawnCoord = { locX: tx, locY: ty, locZ: tz };
-                    if (bot.fetchKarma() > 0 || bot.fetchName() === "Aragorn") {
-                        botSession.plan = 'pk_hunting';
-                        bot.setPk(5);
-                        bot.setKarma(9999);
-                    } else {
-                        // Reset gossip/hunt plans dynamically
-                        botSession.plan = (botSession.townGossip) ? 'resting' : 'hunting';
-                        if (botSession.plan === 'resting') {
-                            bot.state.setSeated(true);
-                        } else {
-                            bot.state.setSeated(false);
-                        }
-                    }
-
-                    // Perform smooth teleportation and sync
-                    const TeleportTo = invoke('GameServer/Actor/Generics/TeleportTo');
-                    if (TeleportTo && typeof TeleportTo === 'function') {
-                        TeleportTo(botSession, bot, { locX: tx, locY: ty, locZ: tz });
-                    }
-
-                    console.info("BotManager :: Dynamically scaled & teleported bot %s (Level %d) to player %s (Level %d) at %d, %d", 
-                        bot.fetchName(), bot.fetchLevel(), player.fetchName(), player.fetchLevel(), tx, ty);
-                }
-            }
-        });
-    },
-
-    getClassArchetype(classId) {
-        const mages = [10, 11, 12, 13, 14, 15, 16, 17, 25, 26, 27, 28, 29, 30, 38, 39, 40, 41, 42, 43, 49, 50, 51, 52];
-        const archers = [9, 24, 37];
-        const daggers = [7, 8, 23, 35, 36, 47, 48];
-        if (mages.includes(classId)) return 'MAGE';
-        if (archers.includes(classId)) return 'ARCHER';
-        if (daggers.includes(classId)) return 'DAGGER';
-        return 'HEAVY';
-    },
-
-    mapLevelToRank(level) {
-        if (level < 20) return "none";
-        if (level < 40) return "d";
-        if (level < 52) return "c";
-        if (level < 61) return "b";
-        if (level < 76) return "a";
-        return "s";
-    },
-
-    selectItemForBot(archetype, slot, rank) {
-        let candidates = DataCache.items.filter(item => {
-            if (slot === 10) {
-                return item.etc?.slot === 10 || item.etc?.slot === 15;
-            }
-            return item.etc?.slot === slot;
-        });
-
-        let rankCandidates = candidates.filter(item => item.etc?.rank === rank);
-        
-        if (rankCandidates.length === 0) {
-            const ranks = ["none", "d", "c", "b", "a", "s"];
-            let idx = ranks.indexOf(rank);
-            while (idx > 0 && rankCandidates.length === 0) {
-                idx--;
-                rankCandidates = candidates.filter(item => item.etc?.rank === ranks[idx]);
-            }
-        }
-        if (rankCandidates.length === 0) {
-            rankCandidates = candidates;
-        }
-
-        let finalCandidates = [];
-        if (slot === 10 || slot === 11) {
-            const isRobe = archetype === 'MAGE';
-            const isLight = archetype === 'LIGHT' || archetype === 'ARCHER' || archetype === 'DAGGER';
-            
-            if (isRobe) {
-                finalCandidates = rankCandidates.filter(item => item.template?.kind === 'Armor.Fabric');
-            } else if (isLight) {
-                finalCandidates = rankCandidates.filter(item => item.template?.kind === 'Armor.Leather');
-            } else {
-                finalCandidates = rankCandidates.filter(item => item.template?.kind === 'Armor.Chain');
-            }
-        } else if (slot === 7 || slot === 14) {
-            if (archetype === 'MAGE') {
-                finalCandidates = rankCandidates.filter(item => 
-                    item.template?.kind === 'Weapon.Blunt' || 
-                    item.template?.kind === 'Weapon.Sword'
-                );
-            } else if (archetype === 'ARCHER') {
-                finalCandidates = rankCandidates.filter(item => item.template?.kind === 'Weapon.Bow');
-            } else if (archetype === 'DAGGER') {
-                finalCandidates = rankCandidates.filter(item => item.template?.kind === 'Weapon.Knife');
-            } else {
-                finalCandidates = rankCandidates.filter(item => 
-                    item.template?.kind === 'Weapon.Sword' || 
-                    item.template?.kind === 'Weapon.Blunt' || 
-                    item.template?.kind === 'Weapon.Pole'
-                );
-            }
-        } else {
-            finalCandidates = rankCandidates;
-        }
-
-        if (finalCandidates.length === 0) {
-            finalCandidates = rankCandidates;
-        }
-
-        if (finalCandidates.length === 0) {
-            return null;
-        }
-
-        if (slot === 7 || slot === 14) {
-            if (archetype === 'MAGE') {
-                finalCandidates.sort((a, b) => (b.stats?.mAtk ?? 0) - (a.stats?.mAtk ?? 0));
-            } else {
-                finalCandidates.sort((a, b) => (b.stats?.pAtk ?? 0) - (a.stats?.pAtk ?? 0));
-            }
-        } else if (slot === 10 || slot === 11 || slot === 6 || slot === 9 || slot === 12 || slot === 8) {
-            finalCandidates.sort((a, b) => (b.stats?.pDef ?? 0) - (a.stats?.pDef ?? 0));
-        } else if (slot === 1 || slot === 3 || slot === 4) {
-            finalCandidates.sort((a, b) => (b.stats?.mDef ?? 0) - (a.stats?.mDef ?? 0));
-        }
-
-        return finalCandidates[0];
-    },
-
-    selectGearForBot(classId, level) {
-        const archetype = this.getClassArchetype(classId);
-        const rank = this.mapLevelToRank(level);
-        const gearList = [];
-
-        const weaponSlot = (archetype === 'ARCHER' || archetype === 'MAGE') ? 14 : 7;
-        let weapon = this.selectItemForBot(archetype, weaponSlot, rank);
-        
-        if (!weapon) {
-            const alternateSlot = weaponSlot === 7 ? 14 : 7;
-            weapon = this.selectItemForBot(archetype, alternateSlot, rank);
-        }
-
-        if (weapon) {
-            gearList.push({ selfId: weapon.selfId, slot: weapon.etc?.slot ?? weaponSlot });
-        }
-
-        const isOneHanded = weapon && (weapon.etc?.slot === 7);
-        const needsShield = isOneHanded && (archetype === 'HEAVY' || (archetype === 'MAGE' && [15, 16, 17, 29, 30, 42, 43].includes(classId)));
-        if (needsShield) {
-            const shield = this.selectItemForBot(archetype, 8, rank);
-            if (shield) {
-                gearList.push({ selfId: shield.selfId, slot: 8 });
-            }
-        }
-
-        const chest = this.selectItemForBot(archetype, 10, rank);
-        let isFullBody = false;
-        if (chest) {
-            const slot = chest.etc?.slot ?? 10;
-            isFullBody = (slot === 15);
-            gearList.push({ selfId: chest.selfId, slot: slot });
-        }
-
-        if (!isFullBody) {
-            const pants = this.selectItemForBot(archetype, 11, rank);
-            if (pants) {
-                gearList.push({ selfId: pants.selfId, slot: 11 });
-            }
-        }
-
-        const helmet = this.selectItemForBot(archetype, 6, rank);
-        if (helmet) {
-            gearList.push({ selfId: helmet.selfId, slot: 6 });
-        }
-
-        const gloves = this.selectItemForBot(archetype, 9, rank);
-        if (gloves) {
-            gearList.push({ selfId: gloves.selfId, slot: 9 });
-        }
-
-        const boots = this.selectItemForBot(archetype, 12, rank);
-        if (boots) {
-            gearList.push({ selfId: boots.selfId, slot: 12 });
-        }
-
-        const neck = this.selectItemForBot(archetype, 3, rank);
-        if (neck) {
-            gearList.push({ selfId: neck.selfId, slot: 3 });
-        }
-
-        const earring = this.selectItemForBot(archetype, 1, rank);
-        if (earring) {
-            gearList.push({ selfId: earring.selfId, slot: 1 });
-            gearList.push({ selfId: earring.selfId, slot: 2 });
-        }
-
-        const ring = this.selectItemForBot(archetype, 4, rank);
-        if (ring) {
-            gearList.push({ selfId: ring.selfId, slot: 4 });
-            gearList.push({ selfId: ring.selfId, slot: 5 });
-        }
-
-        return gearList;
-    },
-
-    equipScaledBot(botSession, bot, targetLevel, targetClassId) {
-        const charId = bot.fetchId();
-        const gearList = this.selectGearForBot(targetClassId, targetLevel);
-
-        return Database.deleteGearItems(charId).then(() => {
-            const promises = gearList.map(gear => {
-                const itemDetails = DataCache.items.find(ob => ob.selfId === gear.selfId);
-                const item = {
-                    selfId: gear.selfId,
-                    name: itemDetails?.template?.name ?? '',
-                    amount: 1,
-                    equipped: true,
-                    slot: gear.slot
-                };
-                return Database.setItem(charId, item);
-            });
-
-            return Promise.all(promises).then(() => {
-                return this.rebuildBotInventory(bot);
-            });
-        });
-    },
-
-    rebuildBotInventory(bot) {
-        return new Promise((resolve) => {
-            Database.fetchItems(bot.fetchId()).then((dbItems) => {
-                bot.backpack.items = [];
-                bot.backpack.paperdoll = utils.tupleAlloc(15 + 1, {});
-
-                const promises = dbItems.map((dbItem) => {
-                    return new Promise((done) => {
-                        bot.backpack.insertItem(dbItem.id, dbItem.selfId, dbItem);
-
-                        if (dbItem.equipped === 1 || dbItem.equipped === true) {
-                            const slot = dbItem.slot;
-                            if (slot === 15) {
-                                bot.backpack.paperdoll[10] = { id: dbItem.id, selfId: dbItem.selfId };
-                                bot.backpack.paperdoll[11] = { id: dbItem.id, selfId: dbItem.selfId };
-                            }
-                            bot.backpack.paperdoll[slot] = { id: dbItem.id, selfId: dbItem.selfId };
-                        }
-                        done();
-                    });
-                });
-
-                Promise.all(promises).then(() => {
-                    const ServerResponse = invoke('GameServer/Network/Response');
-                    if (bot.session && typeof bot.session.dataSendToOthers === 'function') {
-                        bot.session.dataSendToOthers(ServerResponse.charInfo(bot), bot);
-                        bot.session.dataSendToOthers(ServerResponse.relationChanged(bot), bot);
-                    }
-                    resolve();
-                });
-            });
-        });
     }
 };
 
@@ -1041,14 +584,14 @@ const CONVERSATION_TOPICS = [
         replies: [
             "Tell me about it! I've killed like a hundred today.",
             "At least they drop some adena. Slow and steady!",
-            "I'm moving to Orcs soon. Goblins are much better exp."
+            "I'm moving to the ruins soon. Better exp there."
         ]
     },
     {
         prompt: "Anyone want to form a party later for Goblins?",
         replies: [
             "Sure! I'm a Knight, can tank them easily.",
-            "I'm in if Gandalf joins. We need a healer!",
+            "I'm in if we find someone who can heal.",
             "Count me in, I need to level my Scavenger skills."
         ]
     },
@@ -1069,11 +612,11 @@ const CONVERSATION_TOPICS = [
         ]
     },
     {
-        prompt: "Do you think the server admin is watching us right now?",
+        prompt: "Have you seen the market near town today?",
         replies: [
-            "Shh! Don't say that, they might spawn a giant boss on us!",
-            "Haha, probably coding some cool new feature for us bots.",
-            "As long as my pathfinding works, I'm happy!"
+            "Adena is tight, but the material prices are fair.",
+            "I should sell this junk before I go back out.",
+            "If I find enough leather, I might upgrade my gloves."
         ]
     }
 ];
@@ -1083,9 +626,9 @@ const GLOBAL_SHOUTS = [
     "Mira has cheap mats and soulshots around Talking Island.",
     "Need D-grade parts? Maren is buying near Gludio.",
     "Rina has C-grade craft stock in Dion, cheaper than shop.",
-    "Wow, this server is so smooth! Loving the solo gameplay.",
-    "LFP / Party invite me! Aragorn level 5 ready to hunt!",
-    "Legolas is looking for Gandalf, where you at?",
+    "The roads near Gludio feel busy today.",
+    "LFP near the ruins. Need a tank or healer.",
+    "Anyone seen a good hunting group near Gludio?",
     "Pavel and Tessa are buying Giran drops.",
     "Who is up for Orc Archer hunting? Level 8 Knight WTT help.",
     "Iris has B/A mats near Oren, prices below regular shops."

--- a/src/GameServer/Bot/BotPopulation.js
+++ b/src/GameServer/Bot/BotPopulation.js
@@ -1,0 +1,144 @@
+const STARTER_REGIONS = [
+    {
+        code: 'ti',
+        name: 'Talking Island',
+        spawnClassId: 0,
+        locals: [
+            { name: 'Aldren', race: 0, classId: 0, sex: 0 },
+            { name: 'Brinna', race: 0, classId: 0, sex: 1 },
+            { name: 'Cedric', race: 0, classId: 0, sex: 0 },
+            { name: 'Darian', race: 0, classId: 0, sex: 0 },
+            { name: 'Elena', race: 0, classId: 10, sex: 1 },
+            { name: 'Merek', race: 0, classId: 10, sex: 0 },
+            { name: 'Rona', race: 0, classId: 0, sex: 1 },
+            { name: 'Serra', race: 0, classId: 10, sex: 1 }
+        ],
+        visitors: [
+            { name: 'Tovin', race: 4, classId: 53, sex: 0 },
+            { name: 'Elandor', race: 1, classId: 18, sex: 0 }
+        ]
+    },
+    {
+        code: 'elf',
+        name: 'Elven Village',
+        spawnClassId: 18,
+        locals: [
+            { name: 'Aelwyn', race: 1, classId: 18, sex: 1 },
+            { name: 'Faelar', race: 1, classId: 18, sex: 0 },
+            { name: 'Ilyana', race: 1, classId: 25, sex: 1 },
+            { name: 'Liora', race: 1, classId: 25, sex: 1 },
+            { name: 'Meriel', race: 1, classId: 18, sex: 1 },
+            { name: 'Naeris', race: 1, classId: 25, sex: 0 },
+            { name: 'Saelen', race: 1, classId: 18, sex: 0 },
+            { name: 'Velion', race: 1, classId: 18, sex: 0 }
+        ],
+        visitors: [
+            { name: 'Borik', race: 4, classId: 53, sex: 0 },
+            { name: 'Rowan', race: 0, classId: 0, sex: 0 }
+        ]
+    },
+    {
+        code: 'de',
+        name: 'Dark Elven Village',
+        spawnClassId: 31,
+        locals: [
+            { name: 'Draven', race: 2, classId: 31, sex: 0 },
+            { name: 'Ilyra', race: 2, classId: 38, sex: 1 },
+            { name: 'Kaelith', race: 2, classId: 31, sex: 0 },
+            { name: 'Lethar', race: 2, classId: 31, sex: 0 },
+            { name: 'Morwen', race: 2, classId: 38, sex: 1 },
+            { name: 'Nyssa', race: 2, classId: 38, sex: 1 },
+            { name: 'Raelis', race: 2, classId: 31, sex: 1 },
+            { name: 'Vorn', race: 2, classId: 31, sex: 0 }
+        ],
+        visitors: [
+            { name: 'Korrin', race: 4, classId: 53, sex: 0 },
+            { name: 'Selwyn', race: 1, classId: 18, sex: 1 }
+        ]
+    },
+    {
+        code: 'orc',
+        name: 'Orc Village',
+        spawnClassId: 44,
+        locals: [
+            { name: 'Brugar', race: 3, classId: 44, sex: 0 },
+            { name: 'Dargul', race: 3, classId: 44, sex: 0 },
+            { name: 'Groma', race: 3, classId: 49, sex: 1 },
+            { name: 'Harka', race: 3, classId: 44, sex: 1 },
+            { name: 'Kasha', race: 3, classId: 49, sex: 1 },
+            { name: 'Mogar', race: 3, classId: 44, sex: 0 },
+            { name: 'Ogra', race: 3, classId: 44, sex: 1 },
+            { name: 'Urta', race: 3, classId: 49, sex: 0 }
+        ],
+        visitors: [
+            { name: 'Hedin', race: 4, classId: 53, sex: 0 },
+            { name: 'Calder', race: 0, classId: 0, sex: 0 }
+        ]
+    },
+    {
+        code: 'dwarf',
+        name: 'Dwarven Village',
+        spawnClassId: 53,
+        locals: [
+            { name: 'Bordin', race: 4, classId: 53, sex: 0 },
+            { name: 'Dagna', race: 4, classId: 53, sex: 1 },
+            { name: 'Gerta', race: 4, classId: 53, sex: 1 },
+            { name: 'Hilda', race: 4, classId: 53, sex: 1 },
+            { name: 'Kurgan', race: 4, classId: 53, sex: 0 },
+            { name: 'Milla', race: 4, classId: 53, sex: 1 },
+            { name: 'Norik', race: 4, classId: 53, sex: 0 },
+            { name: 'Toma', race: 4, classId: 53, sex: 0 }
+        ],
+        visitors: [
+            { name: 'Jalen', race: 0, classId: 0, sex: 0 },
+            { name: 'Aerin', race: 1, classId: 25, sex: 1 }
+        ]
+    }
+];
+
+function appearance(seed, sex) {
+    return {
+        sex,
+        face: seed % 3,
+        hair: seed % 5,
+        hairColor: seed % 4
+    };
+}
+
+function botRecord(region, data, index, visitor) {
+    return {
+        ...data,
+        ...appearance(index, data.sex),
+        username: `bot_${region.code}_${String(index + 1).padStart(2, '0')}`,
+        homeRegion: region.name,
+        spawnClassId: visitor ? region.spawnClassId : data.classId,
+        visitor: !!visitor,
+        plan: 'hunting'
+    };
+}
+
+const BotPopulation = {
+    buildStarterBots() {
+        const bots = [];
+
+        STARTER_REGIONS.forEach((region) => {
+            region.locals.forEach((data, index) => {
+                bots.push(botRecord(region, data, index, false));
+            });
+
+            region.visitors.forEach((data, index) => {
+                bots.push(botRecord(region, data, region.locals.length + index, true));
+            });
+        });
+
+        return bots;
+    },
+
+    summarize(bots) {
+        return STARTER_REGIONS
+            .map((region) => `${region.name}: ${bots.filter((bot) => bot.homeRegion === region.name).length}`)
+            .join(', ');
+    }
+};
+
+module.exports = BotPopulation;


### PR DESCRIPTION
## Summary

- replace player-centered dynamic bot teleport/level scaling with persistent starter-region SimPlayer populations
- add a generated bot wipe command for resetting SimPlayer accounts and characters during local development
- update bot status and README wording so the project presents player-facing game progress instead of only technical server features

## Why

Bots previously followed the real player by being reused, teleported, and rescaled around them. That made progression feel fake: the same characters could appear in unrelated places, and their level/class could change without a believable cause.

This change makes starter populations explicit by race region, keeps visitors as a small minority, and removes the hidden scaling path so future bot memory/progression work has a stable foundation.

## Validation

- `node --check` on the changed bot modules and wipe script
- staged diff whitespace check
- starter population smoke check: 50 bots, 10 per starter region
- short server boot check with starter bots and merchant bots loading successfully
