### PR TITLE
Add bot party social availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ L2NodeSolo is judged by what the world feels like in the client, not by how many
 - [x] Explore populated starter areas with persistent SimPlayer characters instead of bots teleporting around the player.
 - [x] See race-appropriate starter populations around each available race start, with a small number of visitor characters for MMO flavor.
 - [x] Meet SimPlayers that hunt, rest, flee, revive, shop, restock, loot, chatter, and react to nearby player chat.
-- [x] Invite SimPlayers as party companions through the normal `/invite` flow and manage them through the in-game companion panel.
-- [x] Inspect companion and bot state through `.botstatus`, companion `Status` links, and server-side status logs.
+- [x] Find available SimPlayers with `.botparty`, invite nearby candidates, and manage accepted companions through the in-game companion panel.
+- [x] Inspect companion, social memory, and bot state through `.botstatus`, companion `Status` links, and server-side status logs.
 - [x] Encounter merchant SimPlayers in Talking Island, Gludio, Dion, Giran, and Oren with private buy/sell stores and occasional trade-chat ads.
 - [x] See early PK-style bot behavior: hostile hunting, fleeing, and nearby bot reactions.
 - [x] Use local admin tools for teleporting, item grants, random teleport, and Adena while testing.
 
 ### In Progress
 
-- [ ] More natural long-term SimPlayer memory: names, home region, level history, relationships, and personal routines should persist instead of feeling reset between sessions.
+- [x] Early SimPlayer social memory: bots remember invite/group/dismiss interactions and expose relationship/trust in status surfaces.
+- [ ] More natural long-term SimPlayer memory: level history, loot etiquette, relationships, and personal routines should persist instead of feeling reset between sessions.
 - [ ] Better starter-zone ecology: race-specific bot ratios, class mix, routes, and town/field behavior need more tuning by location.
 - [ ] Bot progression that feels earned: levels, gear, and class growth should come from real activity, not from hidden scaling.
 - [ ] Richer party play: clearer roles, smarter assist behavior, healing/buff timing, looting rules, and travel together.
@@ -143,7 +144,7 @@ Main bot modes:
 - `merchant` - stand in town with private buy/sell store state.
 - `pk_hunting` / `pk_fleeing` - hostile player-killer loop and safety recovery.
 
-Bot status is meant to be inspectable. Use `.botstatus`, the companion panel `Status` links, or watch `BotStatus :: ...` lines in the server logs.
+Bot status is meant to be inspectable. Use `.botparty` to find available nearby SimPlayers, `.botstatus` for state and social memory, companion panel `Status` links, or watch `BotStatus :: ...` and `BotSocial :: ...` lines in the server logs.
 
 To reset generated SimPlayer accounts and characters while keeping the rest of the database intact:
 

--- a/scripts/wipe-bots.js
+++ b/scripts/wipe-bots.js
@@ -89,6 +89,13 @@ async function main() {
 
         if (ids.length > 0) {
             const idList = placeholders(ids.length);
+            try {
+                await conn.query(`DELETE FROM bot_social_memory WHERE botId IN (${idList}) OR playerId IN (${idList})`, [...ids, ...ids]);
+            } catch (err) {
+                if (err.code !== 'ER_NO_SUCH_TABLE') {
+                    throw err;
+                }
+            }
             await conn.query(`DELETE FROM shortcuts WHERE characterId IN (${idList})`, ids);
             await conn.query(`DELETE FROM skills WHERE characterId IN (${idList})`, ids);
             await conn.query(`DELETE FROM items WHERE characterId IN (${idList})`, ids);

--- a/src/GameServer/Actor/Generics/Select.js
+++ b/src/GameServer/Actor/Generics/Select.js
@@ -19,20 +19,39 @@ function merchantPurchaseItems(store) {
     return items;
 }
 
-function merchantSellRows(actor, store) {
-    return actor.backpack.fetchItems()
-        .filter((item) => !item.fetchEquipped() && item.fetchSelfId() !== 57)
-        .map((item) => {
-            const wanted = store.items.find((storeItem) => storeItem.selfId === item.fetchSelfId() && storeItem.count > 0);
-            if (!wanted) return null;
+function merchantDemandRows(actor, store) {
+    const rows = [];
 
-            return {
-                item,
-                amount: Math.min(item.fetchAmount(), wanted.count),
-                price: wanted.price
-            };
-        })
-        .filter((row) => row && row.amount > 0);
+    store.items.forEach((storeItem) => {
+        const inventoryItem = actor.backpack.fetchItems().find((item) => (
+            item.fetchSelfId() === storeItem.selfId &&
+            !item.fetchEquipped() &&
+            item.fetchSelfId() !== 57
+        ));
+
+        if (inventoryItem) {
+            rows.push({
+                item: inventoryItem,
+                amount: Math.min(inventoryItem.fetchAmount(), storeItem.count),
+                price: storeItem.price
+            });
+            return;
+        }
+
+        DataCache.fetchItemFromSelfId(storeItem.selfId, (item) => {
+            rows.push({
+                item: new Item(storeItem.objectId, {
+                    ...utils.crushOb(item),
+                    amount: 0,
+                    price: storeItem.price
+                }),
+                amount: 0,
+                price: storeItem.price
+            });
+        });
+    });
+
+    return rows;
 }
 
 function openMerchantTradeWindow(session, merchant) {
@@ -54,13 +73,10 @@ function openMerchantTradeWindow(session, merchant) {
     }
 
     if (store.storeType === 3) {
-        const rows = merchantSellRows(session.actor, store);
-        if (!rows.length) {
-            session.dataSendToMe(ServerResponse.speak(session.actor, { kind: 0, text: "This merchant is not buying anything from your inventory." }));
-            return;
-        }
-
-        session.dataSendToMe(ServerResponse.sellList(rows, session.actor.backpack.fetchTotalAdena()));
+        session.dataSendToMe(ServerResponse.sellList(
+            merchantDemandRows(session.actor, store),
+            session.actor.backpack.fetchTotalAdena()
+        ));
     }
 }
 
@@ -96,7 +112,7 @@ function select(session, actor, data) {
                 session.dataSendToMe(ServerResponse.privateStoreMsg(user, user.fetchTitle()));
                 session.dataSendToMe(ServerResponse.privateStoreListSell(user, session.actor));
             } else if (user.fetchPrivateStoreType() === 3) {
-                session.dataSendToMe(ServerResponse.privateStoreListBuy(session.actor, user));
+                openMerchantTradeWindow(session, user);
             }
             return;
         }
@@ -131,7 +147,7 @@ function select(session, actor, data) {
                             session.dataSendToMe(ServerResponse.privateStoreMsg(user, user.fetchTitle()));
                             session.dataSendToMe(ServerResponse.privateStoreListSell(user, session.actor));
                         } else if (user.fetchPrivateStoreType() === 3) {
-                            session.dataSendToMe(ServerResponse.privateStoreListBuy(session.actor, user));
+                            openMerchantTradeWindow(session, user);
                         }
                         return;
                     }

--- a/src/GameServer/Bot/AI/BotAvailability.js
+++ b/src/GameServer/Bot/AI/BotAvailability.js
@@ -1,0 +1,93 @@
+const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
+const SpeckMath = invoke('GameServer/SpeckMath');
+
+const INVITE_RANGE = 1500;
+const MAX_LEVEL_GAP = 12;
+const RECENT_ABANDON_MS = 5 * 60 * 1000;
+
+function actorLocation(actor) {
+    return {
+        locX: actor.fetchLocX(),
+        locY: actor.fetchLocY(),
+        locZ: actor.fetchLocZ()
+    };
+}
+
+function distance(a, b) {
+    if (!a || !b) return null;
+    return new SpeckMath.Point3D(a.locX, a.locY, a.locZ).distance(new SpeckMath.Point3D(b.locX, b.locY, b.locZ));
+}
+
+function reasonText(reason) {
+    const text = {
+        available: 'available',
+        missing_actor: 'missing actor',
+        player_dead: 'you are dead',
+        bot_dead: 'dead',
+        already_grouped: 'already grouped',
+        merchant_duty: 'merchant duty',
+        too_far: 'too far',
+        low_trust: 'low trust',
+        recently_abandoned: 'recently abandoned',
+        level_gap_too_large: 'level gap too large',
+        recovering: 'recovering',
+        hunting_target: 'busy fighting'
+    };
+    return text[reason] || reason;
+}
+
+const BotAvailability = {
+    inviteRange: INVITE_RANGE,
+
+    evaluate(playerSession, botSession) {
+        const player = playerSession?.actor;
+        const bot = botSession?.actor;
+        const memory = BotSocialMemory.getSnapshot(playerSession, botSession);
+        const result = {
+            available: false,
+            reason: 'missing_actor',
+            reasonText: reasonText('missing_actor'),
+            distance: null,
+            relationship: BotSocialMemory.relationship(memory),
+            memory
+        };
+
+        if (!player || !bot) return result;
+
+        result.distance = distance(actorLocation(player), actorLocation(bot));
+
+        let reason = 'available';
+        if (player.isDead && player.isDead()) reason = 'player_dead';
+        else if (bot.isDead && bot.isDead()) reason = 'bot_dead';
+        else if (botSession.plan === 'merchant') reason = 'merchant_duty';
+        else if (botSession.partyCompanion === true && botSession.followPlayerSession) reason = 'already_grouped';
+        else if (result.distance !== null && result.distance > INVITE_RANGE) reason = 'too_far';
+        else if (memory.trust <= -6) reason = 'low_trust';
+        else if (memory.recentlyAbandonedAt && Date.now() - memory.recentlyAbandonedAt < RECENT_ABANDON_MS) reason = 'recently_abandoned';
+        else if (Math.abs(bot.fetchLevel() - player.fetchLevel()) > MAX_LEVEL_GAP) reason = 'level_gap_too_large';
+        else if (botSession.plan === 'resting') reason = 'recovering';
+
+        result.available = reason === 'available';
+        result.reason = reason;
+        result.reasonText = reasonText(reason);
+        return result;
+    },
+
+    listForPlayer(playerSession, botSessions) {
+        return botSessions
+            .filter((session) => session.actor)
+            .map((session) => ({
+                session,
+                bot: session.actor,
+                availability: this.evaluate(playerSession, session)
+            }))
+            .sort((a, b) => {
+                if (a.availability.available !== b.availability.available) return a.availability.available ? -1 : 1;
+                return (a.availability.distance ?? Number.MAX_SAFE_INTEGER) - (b.availability.distance ?? Number.MAX_SAFE_INTEGER);
+            });
+    },
+
+    reasonText
+};
+
+module.exports = BotAvailability;

--- a/src/GameServer/Bot/AI/BotSocialMemory.js
+++ b/src/GameServer/Bot/AI/BotSocialMemory.js
@@ -1,0 +1,299 @@
+const Database = invoke('Database');
+
+const TABLE = 'bot_social_memory';
+const cache = new Map();
+const loadedKeys = new Set();
+const pendingWrites = new Map();
+let initialized = false;
+let initStarted = false;
+
+function now() {
+    return Date.now();
+}
+
+function actorId(session) {
+    return session?.actor?.fetchId ? Number(session.actor.fetchId()) : 0;
+}
+
+function actorName(session) {
+    return session?.actor?.fetchName ? session.actor.fetchName() : '';
+}
+
+function key(playerId, botId) {
+    return `${playerId}:${botId}`;
+}
+
+function defaultRecord(playerSession, botSession) {
+    return {
+        playerId: actorId(playerSession),
+        botId: actorId(botSession),
+        playerName: actorName(playerSession),
+        botName: actorName(botSession),
+        trust: 0,
+        familiarity: 0,
+        lastGroupedAt: null,
+        groupRuns: 0,
+        wipesTogether: 0,
+        helpedInCombat: 0,
+        gaveUsefulLoot: 0,
+        ignoredLootRequests: 0,
+        tradesCompleted: 0,
+        insults: 0,
+        recentlyAbandonedAt: null,
+        notes: ''
+    };
+}
+
+function normalize(row, playerSession, botSession) {
+    return {
+        ...defaultRecord(playerSession, botSession),
+        ...row,
+        playerId: Number(row.playerId),
+        botId: Number(row.botId),
+        trust: Number(row.trust || 0),
+        familiarity: Number(row.familiarity || 0),
+        groupRuns: Number(row.groupRuns || 0),
+        wipesTogether: Number(row.wipesTogether || 0),
+        helpedInCombat: Number(row.helpedInCombat || 0),
+        gaveUsefulLoot: Number(row.gaveUsefulLoot || 0),
+        ignoredLootRequests: Number(row.ignoredLootRequests || 0),
+        tradesCompleted: Number(row.tradesCompleted || 0),
+        insults: Number(row.insults || 0),
+        lastGroupedAt: row.lastGroupedAt ? Number(row.lastGroupedAt) : null,
+        recentlyAbandonedAt: row.recentlyAbandonedAt ? Number(row.recentlyAbandonedAt) : null
+    };
+}
+
+function relationship(record) {
+    if (!record) return 'stranger';
+    if (record.trust >= 8) return 'trusted';
+    if (record.trust >= 3 || record.familiarity >= 5) return 'friendly';
+    if (record.trust <= -5) return 'wary';
+    return record.familiarity > 0 ? 'familiar' : 'stranger';
+}
+
+function applyEvent(record, eventName) {
+    const updated = { ...record };
+    const before = {
+        trust: updated.trust,
+        familiarity: updated.familiarity
+    };
+
+    if (eventName === 'invite_attempt') {
+        updated.familiarity += 1;
+    } else if (eventName === 'party_formed') {
+        updated.trust += 2;
+        updated.familiarity += 2;
+        updated.groupRuns += 1;
+        updated.lastGroupedAt = now();
+    } else if (eventName === 'party_refused') {
+        updated.familiarity += 1;
+    } else if (eventName === 'party_dismissed') {
+        updated.trust -= 1;
+        updated.recentlyAbandonedAt = now();
+    } else if (eventName === 'party_kicked') {
+        updated.trust -= 3;
+        updated.recentlyAbandonedAt = now();
+    } else if (eventName === 'helped_in_combat') {
+        updated.trust += 3;
+        updated.familiarity += 1;
+        updated.helpedInCombat += 1;
+    } else if (eventName === 'trade_completed') {
+        updated.trust += 1;
+        updated.familiarity += 1;
+        updated.tradesCompleted += 1;
+    } else if (eventName === 'gave_useful_loot') {
+        updated.trust += 3;
+        updated.gaveUsefulLoot += 1;
+    } else if (eventName === 'ignored_loot_request') {
+        updated.trust -= 1;
+        updated.ignoredLootRequests += 1;
+    } else if (eventName === 'insulted') {
+        updated.trust -= 3;
+        updated.insults += 1;
+    }
+
+    return {
+        record: updated,
+        delta: {
+            trust: updated.trust - before.trust,
+            familiarity: updated.familiarity - before.familiarity
+        }
+    };
+}
+
+function save(record) {
+    return Database.execute([
+        `INSERT INTO ${TABLE} (
+            playerId, botId, playerName, botName, trust, familiarity, lastGroupedAt,
+            groupRuns, wipesTogether, helpedInCombat, gaveUsefulLoot, ignoredLootRequests,
+            tradesCompleted, insults, recentlyAbandonedAt, notes, updatedAt
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON DUPLICATE KEY UPDATE
+            playerName = VALUES(playerName),
+            botName = VALUES(botName),
+            trust = VALUES(trust),
+            familiarity = VALUES(familiarity),
+            lastGroupedAt = VALUES(lastGroupedAt),
+            groupRuns = VALUES(groupRuns),
+            wipesTogether = VALUES(wipesTogether),
+            helpedInCombat = VALUES(helpedInCombat),
+            gaveUsefulLoot = VALUES(gaveUsefulLoot),
+            ignoredLootRequests = VALUES(ignoredLootRequests),
+            tradesCompleted = VALUES(tradesCompleted),
+            insults = VALUES(insults),
+            recentlyAbandonedAt = VALUES(recentlyAbandonedAt),
+            notes = VALUES(notes),
+            updatedAt = VALUES(updatedAt)`,
+        [
+            record.playerId,
+            record.botId,
+            record.playerName,
+            record.botName,
+            record.trust,
+            record.familiarity,
+            record.lastGroupedAt,
+            record.groupRuns,
+            record.wipesTogether,
+            record.helpedInCombat,
+            record.gaveUsefulLoot,
+            record.ignoredLootRequests,
+            record.tradesCompleted,
+            record.insults,
+            record.recentlyAbandonedAt,
+            record.notes,
+            now()
+        ]
+    ]);
+}
+
+const BotSocialMemory = {
+    init() {
+        if (initialized || initStarted) return;
+        initStarted = true;
+
+        Database.execute([
+            `CREATE TABLE IF NOT EXISTS ${TABLE} (
+                playerId INT NOT NULL,
+                botId INT NOT NULL,
+                playerName VARCHAR(35) NOT NULL DEFAULT '',
+                botName VARCHAR(35) NOT NULL DEFAULT '',
+                trust INT NOT NULL DEFAULT 0,
+                familiarity INT NOT NULL DEFAULT 0,
+                lastGroupedAt BIGINT NULL,
+                groupRuns INT NOT NULL DEFAULT 0,
+                wipesTogether INT NOT NULL DEFAULT 0,
+                helpedInCombat INT NOT NULL DEFAULT 0,
+                gaveUsefulLoot INT NOT NULL DEFAULT 0,
+                ignoredLootRequests INT NOT NULL DEFAULT 0,
+                tradesCompleted INT NOT NULL DEFAULT 0,
+                insults INT NOT NULL DEFAULT 0,
+                recentlyAbandonedAt BIGINT NULL,
+                notes TEXT NULL,
+                updatedAt BIGINT NOT NULL DEFAULT 0,
+                PRIMARY KEY (playerId, botId)
+            )`,
+            []
+        ]).then(() => {
+            initialized = true;
+            utils.infoSuccess('BotSocial', 'memory table ready');
+        }).catch((err) => {
+            utils.infoWarn('BotSocial', 'memory table unavailable: %s', err.message);
+        });
+    },
+
+    getSnapshot(playerSession, botSession) {
+        const playerId = actorId(playerSession);
+        const botId = actorId(botSession);
+        if (!playerId || !botId) return defaultRecord(playerSession, botSession);
+
+        const cacheKey = key(playerId, botId);
+        const cached = cache.get(cacheKey);
+        if (cached) return cached;
+
+        const fallback = defaultRecord(playerSession, botSession);
+        cache.set(cacheKey, fallback);
+        this.load(playerSession, botSession);
+        return fallback;
+    },
+
+    load(playerSession, botSession) {
+        const playerId = actorId(playerSession);
+        const botId = actorId(botSession);
+        if (!playerId || !botId) return Promise.resolve(null);
+
+        return Database.execute([
+            `SELECT * FROM ${TABLE} WHERE playerId = ? AND botId = ? LIMIT 1`,
+            [playerId, botId]
+        ]).then((rows) => {
+            loadedKeys.add(key(playerId, botId));
+            if (!rows[0]) return null;
+            const record = normalize(rows[0], playerSession, botSession);
+            cache.set(key(playerId, botId), record);
+            return record;
+        }).catch(() => null);
+    },
+
+    recordEvent(playerSession, botSession, eventName, detail = '') {
+        const playerId = actorId(playerSession);
+        const botId = actorId(botSession);
+        if (!playerId || !botId) return Promise.resolve(null);
+
+        const cacheKey = key(playerId, botId);
+        const update = (loadedRecord) => {
+            const base = loadedRecord || cache.get(cacheKey) || defaultRecord(playerSession, botSession);
+            const result = applyEvent(base, eventName);
+            const record = {
+                ...result.record,
+                playerName: actorName(playerSession),
+                botName: actorName(botSession)
+            };
+
+            cache.set(cacheKey, record);
+            loadedKeys.add(cacheKey);
+            botSession.socialSummary = {
+                playerName: record.playerName,
+                trust: record.trust,
+                familiarity: record.familiarity,
+                relationship: relationship(record)
+            };
+            botSession.lastSocialEvent = {
+                playerName: record.playerName,
+                event: eventName,
+                detail,
+                at: now()
+            };
+
+            const trustDelta = result.delta.trust === 0 ? '' : ` trust ${result.delta.trust > 0 ? '+' : ''}${result.delta.trust}`;
+            const familiarDelta = result.delta.familiarity === 0 ? '' : ` familiarity ${result.delta.familiarity > 0 ? '+' : ''}${result.delta.familiarity}`;
+            console.info('BotSocial :: %s -> %s %s%s%s', record.botName, record.playerName, eventName, trustDelta, familiarDelta);
+
+            return save(record).catch((err) => {
+                utils.infoWarn('BotSocial', 'failed to save %s/%s: %s', record.playerName, record.botName, err.message);
+                return record;
+            });
+        };
+
+        const run = () => {
+            if (!loadedKeys.has(cacheKey)) {
+                return this.load(playerSession, botSession).then((loadedRecord) => update(loadedRecord));
+            }
+
+            return update(cache.get(cacheKey));
+        };
+
+        const previous = pendingWrites.get(cacheKey) || Promise.resolve();
+        const next = previous.then(run, run);
+        const tracked = next.finally(() => {
+            if (pendingWrites.get(cacheKey) === tracked) {
+                pendingWrites.delete(cacheKey);
+            }
+        });
+        pendingWrites.set(cacheKey, tracked);
+        return next;
+    },
+
+    relationship
+};
+
+module.exports = BotSocialMemory;

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -209,6 +209,8 @@ const BotStatus = {
             },
             nearby: nearbySnapshot(bot),
             trade: tradeSnapshot(session, bot),
+            social: session.socialSummary || null,
+            lastSocialEvent: session.lastSocialEvent || null,
             blockers: []
         };
 
@@ -225,9 +227,10 @@ const BotStatus = {
         const target = status.target && status.target.name ? ` target=${status.target.name}` : '';
         const spot = status.spot && status.spot.name ? ` spot=${status.spot.name}` : '';
         const home = status.home && status.home.region ? ` home=${status.home.region}${status.home.visitor ? ':visitor' : ''}` : '';
+        const social = status.social ? ` social=${status.social.playerName}:${status.social.relationship}/${status.social.trust}` : '';
         const blockers = status.blockers.length > 0 ? ` blockers=${status.blockers.join(',')}` : '';
 
-        return `${status.name}: mode=${status.mode} intent=${status.intent} role=${status.role}${home} hp=${hp}% mp=${mp}%${target}${spot}${blockers}`;
+        return `${status.name}: mode=${status.mode} intent=${status.intent} role=${status.role}${home} hp=${hp}% mp=${mp}%${target}${spot}${social}${blockers}`;
     }
 };
 

--- a/src/GameServer/Bot/AI/States/HuntingState.js
+++ b/src/GameServer/Bot/AI/States/HuntingState.js
@@ -5,6 +5,52 @@ const GeodataEngine  = invoke('GameServer/Geodata/GeodataEngine');
 const SpotService    = invoke('GameServer/Bot/AI/SpotService');
 const DecisionService = invoke('GameServer/Bot/AI/BotDecisionService');
 
+function isSoloHunter(session) {
+    return session.plan === 'hunting' && session.partyCompanion !== true && !session.followPlayerSession;
+}
+
+function isClaimedByOtherSoloBot(session, npc) {
+    const BotManager = invoke('GameServer/Bot/BotManager');
+    const npcId = npc.fetchId();
+
+    return BotManager.sessions.some((otherSession) => {
+        if (otherSession === session || !otherSession.actor || !isSoloHunter(otherSession)) return false;
+        if (otherSession.currentTargetId !== npcId) return false;
+        return !otherSession.actor.state.fetchDead();
+    });
+}
+
+function findPreferredMonster(session, bot, radius, options = {}) {
+    let closestFreeMonster = null;
+    let closestFreeDistance = radius;
+    let closestClaimedMonster = null;
+    let closestClaimedDistance = radius;
+
+    const nearbyNpcs = World.fetchNpcsInRadius(bot.fetchLocX(), bot.fetchLocY(), radius);
+    nearbyNpcs.forEach((npc) => {
+        if (!npc.fetchAttackable() || npc.isDead()) return;
+        if (options.excludeTargetId && npc.fetchId() === options.excludeTargetId) return;
+
+        const distance = new SpeckMath.Point3D(bot.fetchLocX(), bot.fetchLocY(), bot.fetchLocZ())
+            .distance(new SpeckMath.Point3D(npc.fetchLocX(), npc.fetchLocY(), npc.fetchLocZ()));
+
+        if (isClaimedByOtherSoloBot(session, npc)) {
+            if (!options.freeOnly && distance < closestClaimedDistance) {
+                closestClaimedDistance = distance;
+                closestClaimedMonster = npc;
+            }
+            return;
+        }
+
+        if (distance < closestFreeDistance) {
+            closestFreeDistance = distance;
+            closestFreeMonster = npc;
+        }
+    });
+
+    return closestFreeMonster || closestClaimedMonster;
+}
+
 module.exports = {
     tick(session, bot, Generics, BotAI) {
         // 1. Expire buffs check for hunting bots
@@ -155,6 +201,20 @@ module.exports = {
                         if (bot.state.fetchTowards() || bot.state.fetchHits() || bot.state.fetchCasts()) {
                             return;
                         }
+
+                        if (isClaimedByOtherSoloBot(session, npc)) {
+                            const alternateMonster = findPreferredMonster(session, bot, 2500, {
+                                excludeTargetId: npc.fetchId(),
+                                freeOnly: true
+                            });
+                            if (alternateMonster) {
+                                session.currentTargetId = alternateMonster.fetchId();
+                                bot.select({ id: alternateMonster.fetchId() });
+                                BotAI.executeCombat(session, bot, alternateMonster, Generics);
+                                return;
+                            }
+                        }
+
                         BotAI.executeCombat(session, bot, npc, Generics);
                     }
                 }).catch(() => {
@@ -163,22 +223,8 @@ module.exports = {
                 });
             });
         } else {
-            // Find closest monster within 2500 units
-            let closestMonster = null;
-            let closestDistance = 2500;
-
-            const nearbyNpcs = World.fetchNpcsInRadius(bot.fetchLocX(), bot.fetchLocY(), 2500);
-            nearbyNpcs.forEach((npc) => {
-                if (npc.fetchAttackable() && !npc.isDead()) {
-                    const distance = new SpeckMath.Point3D(bot.fetchLocX(), bot.fetchLocY(), bot.fetchLocZ())
-                        .distance(new SpeckMath.Point3D(npc.fetchLocX(), npc.fetchLocY(), npc.fetchLocZ()));
-                    
-                    if (distance < closestDistance) {
-                        closestDistance = distance;
-                        closestMonster = npc;
-                    }
-                }
-            });
+            // Prefer unclaimed mobs so solo SimPlayers do not form accidental trains.
+            const closestMonster = findPreferredMonster(session, bot, 2500);
 
             if (closestMonster) {
                 session.noTargetTicks = 0;

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -9,6 +9,8 @@ const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
 const MerchantConfigs = invoke('GameServer/Bot/MerchantStoreConfigs');
 const TradeService = invoke('GameServer/Bot/TradeService');
 const BotPopulation = invoke('GameServer/Bot/BotPopulation');
+const BotAvailability = invoke('GameServer/Bot/AI/BotAvailability');
+const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
 
 const BOTS_TO_SPAWN = BotPopulation.buildStarterBots();
 
@@ -77,6 +79,9 @@ const BotManager = {
         const trade = status.trade?.last ? status.trade.last :
             status.trade?.shoppingTarget ? `going to ${status.trade.shoppingTarget.name}` :
             status.trade?.store ? `${status.trade.store.type} / ${status.trade.store.title}` : 'none';
+        const availability = BotAvailability.evaluate(playerSession, botSession);
+        const social = availability.memory ? `${availability.relationship}, trust ${availability.memory.trust}, familiarity ${availability.memory.familiarity}` : 'none';
+        const invite = availability.available ? 'available' : availability.reasonText;
 
         let html = `<html><body><title>Bot Status</title><font color="LEVEL">${status.name}</font><br><br>`;
         html += `<table width=270>`;
@@ -93,6 +98,8 @@ const BotManager = {
         html += row('Blockers', blockers);
         html += row('Decision', decision);
         html += row('Trade', trade);
+        html += row('Social', social);
+        html += row('Invite', invite);
         html += `</table><br>`;
         html += `<a action="bypass -h bot-status ${status.name}">Refresh</a>`;
         html += `</body></html>`;
@@ -102,6 +109,7 @@ const BotManager = {
 
     init() {
         console.info("BotManager :: Initializing automated SimPlayers...");
+        BotSocialMemory.init();
         
         const bots = [...BOTS_TO_SPAWN, ...MERCHANT_BOTS];
         console.info("BotManager :: Starter population: %s", BotPopulation.summarize(BOTS_TO_SPAWN));
@@ -364,6 +372,9 @@ const BotManager = {
                 handledByRule = true;
                 setTimeout(() => {
                     this.botSay(session, `Alright, returning to hunt keltirs!`);
+                    if (session.followPlayerSession === playerSession && session.partyCompanion === true) {
+                        BotSocialMemory.recordEvent(playerSession, session, 'party_dismissed', 'chat_hunt');
+                    }
                     session.plan = 'hunting';
                     session.followPlayerSession = null;
                     session.partyCompanion = false;

--- a/src/GameServer/Network/Request/Speak.js
+++ b/src/GameServer/Network/Request/Speak.js
@@ -40,6 +40,11 @@ function consume(session, data) {
             CompanionControl.render(session);
             return;
         }
+        if (data.text === '.botparty') {
+            const BotParty = invoke('GameServer/World/Generics/NpcBypasses/BotParty');
+            BotParty.render(session);
+            return;
+        }
         if (data.text === '.botstatus' || data.text.startsWith('.botstatus ')) {
             const BotStatus = invoke('GameServer/World/Generics/NpcBypasses/BotStatus');
             const parts = data.text.split(/\s+/);

--- a/src/GameServer/World/Generics/NpcBypasses/BotParty.js
+++ b/src/GameServer/World/Generics/NpcBypasses/BotParty.js
@@ -1,0 +1,64 @@
+const BotAvailability = invoke('GameServer/Bot/AI/BotAvailability');
+const BotManager = invoke('GameServer/Bot/BotManager');
+const ServerResponse = invoke('GameServer/Network/Response');
+const World = invoke('GameServer/World/World');
+
+function pct(value) {
+    return `${Math.round((value || 0) * 100)}%`;
+}
+
+function dist(value) {
+    if (value === null || value === undefined) return '?';
+    return `${Math.round(value)}`;
+}
+
+function render(session) {
+    const actor = session.actor;
+    if (!actor) return;
+
+    const candidates = BotAvailability.listForPlayer(
+        session,
+        BotManager.sessions.filter((botSession) => botSession.plan !== 'merchant')
+    ).slice(0, 18);
+    let html = `<html><body><title>Bot Party</title><font color="LEVEL">Available SimPlayers</font><br><br>`;
+
+    candidates.forEach((candidate) => {
+        const bot = candidate.bot;
+        const status = BotManager.getBotStatus(candidate.session);
+        const availability = candidate.availability;
+        const memory = availability.memory;
+        const action = availability.available
+            ? `<a action="bypass -h bot-party invite ${bot.fetchName()}"><font color="00FF00">Invite</font></a>`
+            : `<font color="777777">${availability.reasonText}</font>`;
+
+        html += `<table width=270><tr>`;
+        html += `<td width=165><font color="LEVEL">${bot.fetchName()}</font> Lv ${bot.fetchLevel()} ${status?.role || 'dps'}</td>`;
+        html += `<td width=105 align=right>${action}</td>`;
+        html += `</tr></table>`;
+        html += `<font color="777777">${status?.mode || 'unknown'} / ${availability.relationship} / trust ${memory.trust} / dist ${dist(availability.distance)} / HP ${pct(status?.vitals?.hpPct)}</font><br>`;
+        html += `<img src="L2UI.SquareBlank" width=270 height=5><br>`;
+    });
+
+    html += `<br><a action="bypass -h bot-party refresh">Refresh</a>`;
+    html += `</body></html>`;
+    session.dataSendToMe(ServerResponse.npcHtml(actor.fetchId(), html));
+}
+
+function botParty(session, parts) {
+    const actor = session.actor;
+    if (!actor) return;
+
+    if (parts[1] === 'invite' && parts[2]) {
+        const botName = parts[2];
+        const targetSession = BotManager.findSessionByName(botName);
+        if (targetSession) {
+            World.inviteBotCompanion(session, actor, targetSession, 1, 'botparty');
+        }
+    }
+
+    render(session);
+}
+
+botParty.render = render;
+
+module.exports = botParty;

--- a/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
+++ b/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
@@ -1,6 +1,7 @@
 const BotManager = invoke('GameServer/Bot/BotManager');
 const ServerResponse = invoke('GameServer/Network/Response');
 const TeleportTo = invoke('GameServer/Actor/Generics/TeleportTo');
+const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
 
 function companionControl(session, parts) {
     const actor = session.actor;
@@ -58,6 +59,7 @@ function companionControl(session, parts) {
                 else if (subCommand === 'dismiss') {
                     session.dataSendToMe(ServerResponse.partySmallWindowDelete(bot.fetchId(), bot.fetchName()));
                     setTimeout(() => {
+                        BotSocialMemory.recordEvent(session, targetSession, 'party_dismissed', 'companion_panel');
                         BotManager.botSay(targetSession, "Leaving the group. Goodbye!");
                         targetSession.plan = 'hunting';
                         targetSession.followPlayerSession = null;

--- a/src/GameServer/World/Generics/NpcBypasses/SellToMerchantItem.js
+++ b/src/GameServer/World/Generics/NpcBypasses/SellToMerchantItem.js
@@ -25,10 +25,13 @@ function buildShopHtml(session, bot) {
         const playerCount = playerItem ? playerItem.fetchAmount() : 0;
         const maxSell = Math.min(item.count, playerCount);
 
-        let btns = `<a action="bypass -h sell-to-merchant-item ${item.selfId} 1"><font color="FFCC00">x1</font></a>&nbsp;&nbsp;`;
-        if (maxSell >= 10) btns += `<a action="bypass -h sell-to-merchant-item ${item.selfId} 10"><font color="FFCC00">x10</font></a>&nbsp;&nbsp;`;
-        if (maxSell >= 100) btns += `<a action="bypass -h sell-to-merchant-item ${item.selfId} 100"><font color="FFCC00">x100</font></a>&nbsp;&nbsp;`;
-        if (maxSell > 1) btns += `<a action="bypass -h sell-to-merchant-item ${item.selfId} ${maxSell}"><font color="FFCC00">All</font></a>`;
+        let btns = '<font color="777777">None</font>';
+        if (maxSell > 0) {
+            btns = `<a action="bypass -h sell-to-merchant-item ${item.selfId} 1"><font color="FFCC00">x1</font></a>&nbsp;&nbsp;`;
+            if (maxSell >= 10) btns += `<a action="bypass -h sell-to-merchant-item ${item.selfId} 10"><font color="FFCC00">x10</font></a>&nbsp;&nbsp;`;
+            if (maxSell >= 100) btns += `<a action="bypass -h sell-to-merchant-item ${item.selfId} 100"><font color="FFCC00">x100</font></a>&nbsp;&nbsp;`;
+            if (maxSell > 1) btns += `<a action="bypass -h sell-to-merchant-item ${item.selfId} ${maxSell}"><font color="FFCC00">All</font></a>`;
+        }
 
         rows += `<table width=270><tr><td><font color="${clr}">${iname}</font></td></tr></table>`;
         rows += `<table width=270><tr><td width=80>Have: <font color="99CCFF">${fold(playerCount)}</font></td>`;
@@ -39,7 +42,8 @@ function buildShopHtml(session, bot) {
 
     return `<html><body>
 <center>
-<font color="FFCC00">${title}</font><br1>
+<font color="FFCC00">Buying: ${title}</font><br1>
+<font color="777777">No matching items in your inventory.</font><br1>
 <font color="00FF00">Adena: ${fold(adena)}a</font><br>
 <img src="L2UI_CH3.hegaerectangle" width=270 height=1><br1>
 ${rows}

--- a/src/GameServer/World/World.js
+++ b/src/GameServer/World/World.js
@@ -51,48 +51,55 @@ const World = {
             const targetIsBot = targetSession && (targetSession.constructor.name === 'BotSession' || (targetSession.accountId && targetSession.accountId.startsWith('bot_')));
 
             if (targetIsBot) {
-                const BotManager = invoke('GameServer/Bot/BotManager');
-
-                // 1. Distance check & automated teleportation if far away (> 500 units)
-                const pLoc = { locX: actor.fetchLocX(), locY: actor.fetchLocY(), locZ: actor.fetchLocZ() };
-                const bLoc = { locX: user.fetchLocX(), locY: user.fetchLocY(), locZ: user.fetchLocZ() };
-                const distance = new SpeckMath.Point3D(bLoc.locX, bLoc.locY, bLoc.locZ)
-                    .distance(new SpeckMath.Point3D(pLoc.locX, pLoc.locY, pLoc.locZ));
-
-                if (distance > 500) {
-                    const Generics = invoke('GameServer/Actor/Generics');
-                    Generics.teleportTo(targetSession, user, {
-                        locX: pLoc.locX + 60,
-                        locY: pLoc.locY + 60,
-                        locZ: pLoc.locZ
-                    });
-                }
-
-                // Send JoinParty (0x3a) to client to initialize party UI structure and prevent crash
-                session.dataSendToMe(ServerResponse.joinParty(1));
-
-                // Clear any existing party window elements to prevent client crash
-                session.dataSendToMe(ServerResponse.partySmallWindowDeleteAll());
-
-                // Set companion state immediately so renderCompanionPanel works on the first invite
-                targetSession.plan = 'following';
-                targetSession.followPlayerSession = session;
-                targetSession.partyCompanion = true;
-
-                // 2. Add companion to party HUD sidebar
-                session.dataSendToMe(ServerResponse.partySmallWindowAll(actor.fetchId(), 0, [user]));
-
-                // 3. Open the Companion Control Panel
-                const CompanionControl = invoke('GameServer/World/Generics/NpcBypasses/CompanionControl');
-                CompanionControl.render(session);
-
-                setTimeout(() => {
-                    BotManager.botSay(targetSession, `Party system is a bit complex for my brain, but I've joined you as a companion! (Follow mode active)`);
-                }, 1000);
+                this.inviteBotCompanion(session, actor, targetSession, data.distribution, 'invite');
             } else {
                 user.session.dataSendToMe(ServerResponse.askForTeamUp(actor.fetchId(), data.distribution));
             }
         });
+    },
+
+    inviteBotCompanion(session, actor, targetSession, distribution = 1, source = 'invite') {
+        const BotAvailability = invoke('GameServer/Bot/AI/BotAvailability');
+        const BotManager = invoke('GameServer/Bot/BotManager');
+        const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
+        const availability = BotAvailability.evaluate(session, targetSession);
+        const bot = targetSession.actor;
+
+        BotSocialMemory.recordEvent(session, targetSession, 'invite_attempt', source);
+
+        if (!availability.available) {
+            BotSocialMemory.recordEvent(session, targetSession, 'party_refused', availability.reason);
+            session.dataSendToMe(ServerResponse.actionFailed());
+            BotManager.botTell(targetSession, session, `I can't join right now: ${availability.reasonText}.`);
+            console.info(
+                'BotParty :: %s refused %s: %s distance=%s',
+                bot?.fetchName() || 'unknown',
+                actor?.fetchName() || 'unknown',
+                availability.reason,
+                availability.distance === null ? '?' : Math.round(availability.distance)
+            );
+            return false;
+        }
+
+        session.dataSendToMe(ServerResponse.joinParty(distribution || 1));
+        session.dataSendToMe(ServerResponse.partySmallWindowDeleteAll());
+
+        targetSession.plan = 'following';
+        targetSession.followPlayerSession = session;
+        targetSession.partyCompanion = true;
+        targetSession.botStay = false;
+        targetSession.stayLocation = null;
+
+        session.dataSendToMe(ServerResponse.partySmallWindowAll(actor.fetchId(), 0, [bot]));
+
+        const CompanionControl = invoke('GameServer/World/Generics/NpcBypasses/CompanionControl');
+        CompanionControl.render(session);
+
+        BotSocialMemory.recordEvent(session, targetSession, 'party_formed', source);
+        setTimeout(() => {
+            BotManager.botSay(targetSession, `I'm with you. Lead the way.`);
+        }, 1000);
+        return true;
     },
 
     answerForTeamUp(session, actor, data) {
@@ -108,6 +115,8 @@ const World = {
                 session.dataSendToMe(ServerResponse.partySmallWindowDelete(targetSession.actor.fetchId(), targetSession.actor.fetchName()));
                 
                 setTimeout(() => {
+                    const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
+                    BotSocialMemory.recordEvent(session, targetSession, 'party_kicked', 'oust');
                     BotManager.botSay(targetSession, `I have been kicked from the party. Returning to hunt on my own!`);
                     targetSession.plan = 'hunting';
                     targetSession.followPlayerSession = null;
@@ -129,6 +138,8 @@ const World = {
                 session.dataSendToMe(ServerResponse.partySmallWindowDelete(targetSession.actor.fetchId(), targetSession.actor.fetchName()));
 
                 setTimeout(() => {
+                    const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
+                    BotSocialMemory.recordEvent(session, targetSession, 'party_dismissed', 'dismiss');
                     BotManager.botSay(targetSession, `Party dismissed! Returning to my farming fields.`);
                     targetSession.plan = 'hunting';
                     targetSession.followPlayerSession = null;


### PR DESCRIPTION
## Summary
- Add a `.botparty` panel that lists nearby non-merchant SimPlayers with invite availability, distance, trust, and status.
- Persist early bot social memory for invite, party, dismiss, and kick interactions, and expose relationship/trust in status surfaces.
- Make solo hunting bots prefer unclaimed mobs so they do not all train onto the same target, while party companions still assist the player.
- Keep buyer merchants on a native sell-list flow that shows demanded items even when the player has none, and preserves real sale validation.

## Validation
- Ran syntax checks for the changed JavaScript files.
- Ran `git diff --cached --check`.
- Booted the server successfully through DB, datapack, geodata, auth/game server startup, bot social memory initialization, and merchant bot startup.
- Verified in client that buyer merchants open a native window and allow selling matching resources.
