### PR TITLE
Add HTML window UI kit

### DIFF
--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -49,24 +49,34 @@ const BotManager = {
         if (!playerSession.actor) return;
 
         const ServerResponse = invoke('GameServer/Network/Response');
+        const Html = invoke('GameServer/World/Generics/HtmlKit');
         const pct = (value) => `${Math.round((value || 0) * 100)}%`;
-        const row = (label, value) => `<tr><td width=80><font color="LEVEL">${label}</font></td><td width=190>${value}</td></tr>`;
+        const safe = (value) => Html.esc(value);
 
         if (!botSession) {
             const statuses = this.getAllBotStatuses().slice(0, 14);
-            let html = `<html><body><title>Bot Status</title><font color="LEVEL">Bot Runtime Status</font><br><br>`;
+            let body = `${Html.font('Bot Runtime Status', Html.COLOR.title)}<br>`;
             statuses.forEach((status) => {
                 const blockers = status.blockers.length > 0 ? ` / ${status.blockers.join(',')}` : '';
-                html += `<a action="bypass -h bot-status ${status.name}">${status.name}</a>: ${status.mode}, ${status.intent}, HP ${pct(status.vitals.hpPct)}, MP ${pct(status.vitals.mpPct)}${blockers}<br>`;
+                body += Html.botCard({
+                    name: status.name,
+                    badge: Html.font(pct(status.vitals.hpPct), Html.COLOR.ok),
+                    subtitle: `${status.mode}, ${status.intent}, HP ${pct(status.vitals.hpPct)}, MP ${pct(status.vitals.mpPct)}${blockers}`,
+                    actions: [
+                        { label: 'Open', command: `bot-status ${status.name}` }
+                    ]
+                });
+                body += Html.spacer(3);
             });
-            html += `</body></html>`;
+            const html = Html.page(body, { title: 'Bot Status' });
             playerSession.dataSendToMe(ServerResponse.npcHtml(playerSession.actor.fetchId(), html));
             return;
         }
 
         const status = this.getBotStatus(botSession);
         if (!status || !status.available) {
-            playerSession.dataSendToMe(ServerResponse.npcHtml(playerSession.actor.fetchId(), `<html><body><title>Bot Status</title>Bot status unavailable.</body></html>`));
+            const html = Html.page(Html.emptyState('Bot Status', 'Bot status unavailable.'), { title: 'Bot Status' });
+            playerSession.dataSendToMe(ServerResponse.npcHtml(playerSession.actor.fetchId(), html));
             return;
         }
 
@@ -83,26 +93,28 @@ const BotManager = {
         const social = availability.memory ? `${availability.relationship}, trust ${availability.memory.trust}, familiarity ${availability.memory.familiarity}` : 'none';
         const invite = availability.available ? 'available' : availability.reasonText;
 
-        let html = `<html><body><title>Bot Status</title><font color="LEVEL">${status.name}</font><br><br>`;
-        html += `<table width=270>`;
-        html += row('Mode', status.mode);
-        html += row('Intent', status.intent);
-        html += row('Role', status.role);
-        html += row('Home', home);
-        html += row('Vitals', `HP ${pct(status.vitals.hpPct)} / MP ${pct(status.vitals.mpPct)}`);
-        html += row('Target', target);
-        html += row('Party', party);
-        html += row('Spot', spot);
-        html += row('Nearby', `players ${status.nearby.realPlayers}, bots ${status.nearby.friendlyBots}, mobs ${status.nearby.attackableNpcs}`);
-        html += row('Move', status.movement.moving ? `moving (${status.movement.towards})` : 'idle');
-        html += row('Blockers', blockers);
-        html += row('Decision', decision);
-        html += row('Trade', trade);
-        html += row('Social', social);
-        html += row('Invite', invite);
-        html += `</table><br>`;
-        html += `<a action="bypass -h bot-status ${status.name}">Refresh</a>`;
-        html += `</body></html>`;
+        let body = `${Html.font(status.name, Html.COLOR.title)}<br>`;
+        body += Html.statusTable([
+            ['Mode', safe(status.mode)],
+            ['Intent', safe(status.intent)],
+            ['Role', safe(status.role)],
+            ['Home', safe(home)],
+            ['Vitals', safe(`HP ${pct(status.vitals.hpPct)} / MP ${pct(status.vitals.mpPct)}`)],
+            ['Target', safe(target)],
+            ['Party', safe(party)],
+            ['Spot', safe(spot)],
+            ['Nearby', safe(`players ${status.nearby.realPlayers}, bots ${status.nearby.friendlyBots}, mobs ${status.nearby.attackableNpcs}`)],
+            ['Move', safe(status.movement.moving ? `moving (${status.movement.towards})` : 'idle')],
+            ['Blockers', safe(blockers)],
+            ['Decision', safe(decision)],
+            ['Trade', safe(trade)],
+            ['Social', safe(social)],
+            ['Invite', safe(invite)]
+        ]);
+        body += '<br>' + Html.actionFooter([
+            { label: 'Refresh', command: `bot-status ${status.name}` }
+        ]);
+        const html = Html.page(body, { title: 'Bot Status' });
 
         playerSession.dataSendToMe(ServerResponse.npcHtml(playerSession.actor.fetchId(), html));
     },

--- a/src/GameServer/Network/Request/Speak.js
+++ b/src/GameServer/Network/Request/Speak.js
@@ -45,6 +45,11 @@ function consume(session, data) {
             BotParty.render(session);
             return;
         }
+        if (data.text === '.uitest') {
+            const UiTest = invoke('GameServer/World/Generics/NpcBypasses/UiTest');
+            UiTest.render(session);
+            return;
+        }
         if (data.text === '.botstatus' || data.text.startsWith('.botstatus ')) {
             const BotStatus = invoke('GameServer/World/Generics/NpcBypasses/BotStatus');
             const parts = data.text.split(/\s+/);

--- a/src/GameServer/World/Generics/HTML_UI_KIT.md
+++ b/src/GameServer/World/Generics/HTML_UI_KIT.md
@@ -1,0 +1,23 @@
+# C2 HTML UI Kit
+
+`HtmlKit.js` is the shared builder for custom `NpcHtml` windows.
+
+## Rules
+
+- Keep payloads small. The C2 client crashed around large stress pages, so prefer short rows and paged views.
+- Use links for navigation, refresh, close, and dense item actions.
+- Use bitmap buttons only for short primary actions near the top of a page.
+- Avoid native checkbox UI for primary controls. Redraws can jump scroll position.
+- Treat the outer window title as client-controlled. Put the reliable title inside the page body.
+- Use client textures and icons only. Custom external images are not supported by this dialog path.
+
+## Components
+
+- `page(body, options)` wraps a complete centered HTML window.
+- `tabs(tabs, active, commandPrefix)` builds tab navigation.
+- `section(title, body)` groups dense content.
+- `statusTable(rows)` and `statusRow(label, value)` build key/value status panels.
+- `botCard(options)` builds compact bot list entries.
+- `actionFooter(actions)` builds bottom link actions.
+- `emptyState(title, message, actions)` builds safe empty pages.
+- `toggle(label, enabled, command)` is the recommended state toggle pattern.

--- a/src/GameServer/World/Generics/HtmlKit.js
+++ b/src/GameServer/World/Generics/HtmlKit.js
@@ -1,0 +1,222 @@
+// C2 HTML is not browser HTML. Keep payloads small, prefer links for navigation,
+// and use bitmap buttons only for short primary actions near the top of a page.
+const HtmlKit = {
+    WIDTH: 270,
+    COLOR: {
+        title: 'LEVEL',
+        link: '99CCFF',
+        ok: '00FF00',
+        warn: 'FFCC00',
+        danger: 'FF5555',
+        muted: '777777',
+        panel: '222222',
+        row: '333333',
+        weapon: 'FF9900',
+        armor: '99CCFF'
+    },
+    TEXTURE: {
+        line: 'L2UI.SquareWhite',
+        blank: 'L2UI.SquareBlank',
+        defaultButton: 'L2UI.DefaultButton',
+        defaultButtonDown: 'L2UI.DefaultButton_click'
+    }
+};
+
+function attrs(values) {
+    return Object.keys(values || {})
+        .filter((key) => values[key] !== undefined && values[key] !== null && values[key] !== false)
+        .map((key) => `${key}=${values[key]}`)
+        .join(' ');
+}
+
+function esc(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function action(command, hide = true) {
+    return `${hide ? 'bypass -h' : 'bypass'} ${esc(command)}`;
+}
+
+HtmlKit.esc = esc;
+
+HtmlKit.font = function(value, color = HtmlKit.COLOR.muted) {
+    return `<font color="${color}">${esc(value)}</font>`;
+};
+
+HtmlKit.br = function(kind = 'br1') {
+    return `<${kind}>`;
+};
+
+HtmlKit.line = function(texture = HtmlKit.TEXTURE.line, width = HtmlKit.WIDTH, height = 1) {
+    return `<img src="${texture}" width=${width} height=${height}><br1>`;
+};
+
+HtmlKit.spacer = function(height = 4, width = HtmlKit.WIDTH) {
+    return `<img src="${HtmlKit.TEXTURE.blank}" width=${width} height=${height}><br1>`;
+};
+
+HtmlKit.img = function(src, width, height) {
+    return `<img src="${esc(src)}" width=${width} height=${height}>`;
+};
+
+HtmlKit.link = function(label, command, options = {}) {
+    const color = options.color || HtmlKit.COLOR.link;
+    return `<a action="${action(command, options.hide !== false)}"><font color="${color}">${esc(label)}</font></a>`;
+};
+
+HtmlKit.button = function(label, command, options = {}) {
+    const width = options.width || 86;
+    const height = options.height || 21;
+    const fore = options.fore || HtmlKit.TEXTURE.defaultButton;
+    const back = options.back || HtmlKit.TEXTURE.defaultButtonDown;
+    return `<button value="${esc(label)}" action="${action(command, options.hide !== false)}" width=${width} height=${height} back="${back}" fore="${fore}">`;
+};
+
+HtmlKit.cell = function(content, options = {}) {
+    const width = options.width ? ` width=${options.width}` : '';
+    const align = options.align ? ` align=${options.align}` : '';
+    return `<td${width}${align}>${content}</td>`;
+};
+
+HtmlKit.row = function(cells) {
+    return `<tr>${cells.join('')}</tr>`;
+};
+
+HtmlKit.table = function(rows, options = {}) {
+    const tableAttrs = attrs({
+        width: options.width || HtmlKit.WIDTH,
+        bgcolor: options.bgcolor,
+        background: options.background
+    });
+    return `<table ${tableAttrs}>${rows.join('')}</table>`;
+};
+
+HtmlKit.columns = function(cells, options = {}) {
+    return HtmlKit.table([HtmlKit.row(cells)], options);
+};
+
+HtmlKit.section = function(title, body, options = {}) {
+    const header = HtmlKit.table([
+        HtmlKit.row([
+            HtmlKit.cell(HtmlKit.font(title, HtmlKit.COLOR.title))
+        ])
+    ], {
+        width: options.width || HtmlKit.WIDTH,
+        bgcolor: options.bgcolor || HtmlKit.COLOR.panel
+    });
+    return `<br>${header}<br1>${body}`;
+};
+
+HtmlKit.keyValueRows = function(rows, options = {}) {
+    return HtmlKit.table(rows.map(([label, value]) => HtmlKit.row([
+        HtmlKit.cell(esc(label), { width: options.labelWidth || 90 }),
+        HtmlKit.cell(value)
+    ])), { width: options.width || HtmlKit.WIDTH, bgcolor: options.bgcolor });
+};
+
+HtmlKit.statusRow = function(label, value, options = {}) {
+    return HtmlKit.row([
+        HtmlKit.cell(HtmlKit.font(label, options.labelColor || HtmlKit.COLOR.title), { width: options.labelWidth || 80 }),
+        HtmlKit.cell(value, { width: options.valueWidth || 190 })
+    ]);
+};
+
+HtmlKit.statusTable = function(rows, options = {}) {
+    return HtmlKit.table(rows.map(([label, value]) => HtmlKit.statusRow(label, value, options)), {
+        width: options.width || HtmlKit.WIDTH,
+        bgcolor: options.bgcolor
+    });
+};
+
+HtmlKit.tabs = function(tabs, active, commandPrefix, options = {}) {
+    return HtmlKit.table([
+        HtmlKit.row(tabs.map(([id, label]) => {
+            const color = id === active ? HtmlKit.COLOR.title : HtmlKit.COLOR.link;
+            return HtmlKit.cell(HtmlKit.link(label, `${commandPrefix} ${id}`, { color }), { align: 'center' });
+        }))
+    ], { width: options.width || HtmlKit.WIDTH });
+};
+
+HtmlKit.toggle = function(label, enabled, command, options = {}) {
+    const color = enabled ? HtmlKit.COLOR.ok : HtmlKit.COLOR.muted;
+    const text = enabled ? (options.onText || 'ON') : (options.offText || 'OFF');
+    return HtmlKit.columns([
+        HtmlKit.cell(HtmlKit.button(text, command, { width: options.buttonWidth || 75 }), { width: options.labelWidth || 92 }),
+        HtmlKit.cell(HtmlKit.link(label || (enabled ? 'Enabled' : 'Disabled'), command, { color, hide: options.hide !== false }))
+    ]);
+};
+
+HtmlKit.actionFooter = function(actions, options = {}) {
+    return HtmlKit.columns(actions.map((item) => HtmlKit.cell(
+        HtmlKit.link(item.label, item.command, {
+            color: item.color || HtmlKit.COLOR.link,
+            hide: item.hide !== false
+        }),
+        { align: item.align || 'center', width: item.width }
+    )), { width: options.width || HtmlKit.WIDTH });
+};
+
+HtmlKit.emptyState = function(title, message, actions = []) {
+    let body = `${HtmlKit.font(title, HtmlKit.COLOR.title)}<br>`;
+    body += `${HtmlKit.font(message, HtmlKit.COLOR.muted)}<br>`;
+    if (actions.length > 0) {
+        body += '<br1>' + HtmlKit.actionFooter(actions);
+    }
+    return body;
+};
+
+HtmlKit.botCard = function(options = {}) {
+    let body = HtmlKit.table([
+        HtmlKit.row([
+            HtmlKit.cell(HtmlKit.font(options.name || 'Unknown', options.nameColor || HtmlKit.COLOR.ok)),
+            HtmlKit.cell(options.badge || '', { align: 'right', width: options.badgeWidth || 75 })
+        ])
+    ], { width: options.width || HtmlKit.WIDTH, bgcolor: options.bgcolor || HtmlKit.COLOR.row });
+
+    if (options.subtitle) {
+        body += HtmlKit.font(options.subtitle, HtmlKit.COLOR.muted) + '<br1>';
+    }
+    if (options.status) {
+        body += options.status + '<br1>';
+    }
+    if (options.actions && options.actions.length > 0) {
+        body += HtmlKit.actionFooter(options.actions);
+    }
+    return body;
+};
+
+HtmlKit.sizeFooter = function(html) {
+    return HtmlKit.font(`chars: ${html.length} / ucs2: ${Buffer.byteLength(html, 'ucs2')}`, HtmlKit.COLOR.muted);
+};
+
+HtmlKit.page = function(body, options = {}) {
+    const width = options.width || HtmlKit.WIDTH;
+    const chrome = (footer) => [
+        '<html><body>',
+        options.title ? `<title>${esc(options.title)}</title>` : '',
+        '<center>',
+        options.tabs || '',
+        HtmlKit.line(HtmlKit.TEXTURE.line, width),
+        body,
+        '<br>',
+        HtmlKit.line(HtmlKit.TEXTURE.line, width),
+        footer || '',
+        '</center></body></html>'
+    ].join('');
+
+    if (options.showSize !== true) {
+        return chrome(options.footer || '');
+    }
+
+    let html = chrome(HtmlKit.font('chars: ? / ucs2: ?', HtmlKit.COLOR.muted));
+    for (let i = 0; i < 2; i++) {
+        html = chrome(HtmlKit.sizeFooter(html));
+    }
+    return html;
+};
+
+module.exports = HtmlKit;

--- a/src/GameServer/World/Generics/NpcBypasses/BotParty.js
+++ b/src/GameServer/World/Generics/NpcBypasses/BotParty.js
@@ -1,5 +1,6 @@
 const BotAvailability = invoke('GameServer/Bot/AI/BotAvailability');
 const BotManager = invoke('GameServer/Bot/BotManager');
+const Html = invoke('GameServer/World/Generics/HtmlKit');
 const ServerResponse = invoke('GameServer/Network/Response');
 const World = invoke('GameServer/World/World');
 
@@ -20,7 +21,8 @@ function render(session) {
         session,
         BotManager.sessions.filter((botSession) => botSession.plan !== 'merchant')
     ).slice(0, 18);
-    let html = `<html><body><title>Bot Party</title><font color="LEVEL">Available SimPlayers</font><br><br>`;
+    let body = `${Html.font('Available SimPlayers', Html.COLOR.title)}<br1>`;
+    body += `${Html.font('Nearby bots you can invite as real companions.', Html.COLOR.muted)}<br>`;
 
     candidates.forEach((candidate) => {
         const bot = candidate.bot;
@@ -28,25 +30,46 @@ function render(session) {
         const availability = candidate.availability;
         const memory = availability.memory;
         const action = availability.available
-            ? `<a action="bypass -h bot-party invite ${bot.fetchName()}"><font color="00FF00">Invite</font></a>`
-            : `<font color="777777">${availability.reasonText}</font>`;
+            ? Html.link('Invite', `bot-party invite ${bot.fetchName()}`, { color: Html.COLOR.ok })
+            : Html.font(availability.reasonText, Html.COLOR.muted);
+        const name = Html.font(bot.fetchName(), Html.COLOR.title);
+        const role = status?.role || 'dps';
+        const mode = status?.mode || 'unknown';
+        const hp = pct(status?.vitals?.hpPct);
+        const relationship = availability.relationship;
+        const trust = memory.trust;
+        const distance = dist(availability.distance);
 
-        html += `<table width=270><tr>`;
-        html += `<td width=165><font color="LEVEL">${bot.fetchName()}</font> Lv ${bot.fetchLevel()} ${status?.role || 'dps'}</td>`;
-        html += `<td width=105 align=right>${action}</td>`;
-        html += `</tr></table>`;
-        html += `<font color="777777">${status?.mode || 'unknown'} / ${availability.relationship} / trust ${memory.trust} / dist ${dist(availability.distance)} / HP ${pct(status?.vitals?.hpPct)}</font><br>`;
-        html += `<img src="L2UI.SquareBlank" width=270 height=5><br>`;
+        body += Html.table([
+            Html.row([
+                Html.cell(`${name} Lv ${bot.fetchLevel()} ${Html.font(role, Html.COLOR.link)}`, { width: 180 }),
+                Html.cell(action, { width: 90, align: 'right' })
+            ])
+        ]);
+        body += Html.font(`${mode} / ${relationship} / trust ${trust} / dist ${distance} / HP ${hp}`, Html.COLOR.muted);
+        body += '<br1>' + Html.line(Html.TEXTURE.blank, Html.WIDTH, 5);
     });
 
-    html += `<br><a action="bypass -h bot-party refresh">Refresh</a>`;
-    html += `</body></html>`;
+    if (candidates.length === 0) {
+        body += Html.section('No Candidates', Html.font('No available SimPlayers are visible right now.', Html.COLOR.muted));
+    }
+
+    body += '<br>' + Html.columns([
+        Html.cell(Html.link('Refresh', 'bot-party refresh', { color: Html.COLOR.link }), { align: 'center' }),
+        Html.cell(Html.link('Close', 'bot-party close', { color: Html.COLOR.muted }), { align: 'center' })
+    ]);
+
+    const html = Html.page(body, { title: 'Bot Party' });
     session.dataSendToMe(ServerResponse.npcHtml(actor.fetchId(), html));
 }
 
 function botParty(session, parts) {
     const actor = session.actor;
     if (!actor) return;
+
+    if (parts[1] === 'close') {
+        return;
+    }
 
     if (parts[1] === 'invite' && parts[2]) {
         const botName = parts[2];

--- a/src/GameServer/World/Generics/NpcBypasses/BuyMerchantItem.js
+++ b/src/GameServer/World/Generics/NpcBypasses/BuyMerchantItem.js
@@ -1,9 +1,26 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const DataCache      = invoke('GameServer/DataCache');
 const TradeService   = invoke('GameServer/Bot/TradeService');
+const Html           = invoke('GameServer/World/Generics/HtmlKit');
 
 function fold(v) {
     return String(v).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+function itemColor(kind) {
+    if (kind.startsWith('Weapon')) return Html.COLOR.weapon;
+    if (kind.startsWith('Armor') || kind.startsWith('Shield')) return Html.COLOR.armor;
+    return Html.COLOR.title;
+}
+
+function quantityLinks(prefix, selfId, stock) {
+    const links = [
+        Html.link('x1', `${prefix} ${selfId} 1`, { color: Html.COLOR.warn })
+    ];
+    if (stock >= 10) links.push(Html.link('x10', `${prefix} ${selfId} 10`, { color: Html.COLOR.warn }));
+    if (stock >= 100) links.push(Html.link('x100', `${prefix} ${selfId} 100`, { color: Html.COLOR.warn }));
+    if (stock > 1) links.push(Html.link('All', `${prefix} ${selfId} ${stock}`, { color: Html.COLOR.warn }));
+    return links.join('&nbsp;&nbsp;');
 }
 
 function buildShopHtml(session, bot) {
@@ -18,31 +35,30 @@ function buildShopHtml(session, bot) {
         const template = DataCache.items.find(ob => ob.selfId === item.selfId);
         const iname = template?.template?.name ?? 'Unknown';
         const icat = template?.template?.kind ?? '';
-        const clr = icat.startsWith('Weapon') ? 'FF9900' :
-                    icat.startsWith('Armor') || icat.startsWith('Shield') ? '99CCFF' : 'LEVEL';
-
         const c = item.count;
-        let buys = `<a action="bypass -h buy-merchant-item ${item.selfId} 1"><font color="FFCC00">x1</font></a>&nbsp;&nbsp;`;
-        if (c >= 10) buys += `<a action="bypass -h buy-merchant-item ${item.selfId} 10"><font color="FFCC00">x10</font></a>&nbsp;&nbsp;`;
-        if (c >= 100) buys += `<a action="bypass -h buy-merchant-item ${item.selfId} 100"><font color="FFCC00">x100</font></a>&nbsp;&nbsp;`;
-        if (c > 1) buys += `<a action="bypass -h buy-merchant-item ${item.selfId} ${c}"><font color="FFCC00">All</font></a>`;
+        const buys = quantityLinks('buy-merchant-item', item.selfId, c);
 
-        rows += `<table width=270><tr><td><font color="${clr}">${iname}</font></td></tr></table>`;
-        rows += `<table width=270><tr><td width=80>Stock: <font color="99CCFF">${fold(c)}</font></td>`;
-        rows += `<td width=80 align=right>Price: <font color="00FF00">${fold(item.price)}a</font></td>`;
-        rows += `<td width=110 align=right>${buys}</td></tr></table>`;
-        if (i < items.length - 1) rows += `<br1><img src="L2UI_CH3.hegaerectangle" width=270 height=1><br1>`;
+        rows += Html.table([
+            Html.row([Html.cell(Html.font(iname, itemColor(icat)))])
+        ]);
+        rows += Html.table([
+            Html.row([
+                Html.cell(`Stock: ${Html.font(fold(c), Html.COLOR.link)}`, { width: 80 }),
+                Html.cell(`Price: ${Html.font(`${fold(item.price)}a`, Html.COLOR.ok)}`, { width: 80, align: 'right' }),
+                Html.cell(buys, { width: 110, align: 'right' })
+            ])
+        ]);
+        if (i < items.length - 1) rows += Html.line('L2UI_CH3.hegaerectangle');
     }
 
-    return `<html><body>
-<center>
-<font color="FFCC00">${title}</font><br1>
-<font color="00FF00">Adena: ${fold(adena)}a</font><br>
-<img src="L2UI_CH3.hegaerectangle" width=270 height=1><br1>
-${rows}
-<br>
-<a action="bypass -h npc_talk">Close</a>
-</center></body></html>`;
+    let body = `${Html.font(title, Html.COLOR.warn)}<br1>`;
+    body += `${Html.font(`Adena: ${fold(adena)}a`, Html.COLOR.ok)}<br>`;
+    body += Html.line('L2UI_CH3.hegaerectangle');
+    body += rows || Html.emptyState('No Stock', 'This merchant has nothing for sale.');
+    body += '<br>' + Html.actionFooter([
+        { label: 'Close', command: 'npc_talk', color: Html.COLOR.muted }
+    ]);
+    return Html.page(body, { title });
 }
 
 module.exports = async function(session, parts) {

--- a/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
+++ b/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
@@ -2,6 +2,7 @@ const BotManager = invoke('GameServer/Bot/BotManager');
 const ServerResponse = invoke('GameServer/Network/Response');
 const TeleportTo = invoke('GameServer/Actor/Generics/TeleportTo');
 const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
+const Html = invoke('GameServer/World/Generics/HtmlKit');
 
 function companionControl(session, parts) {
     const actor = session.actor;
@@ -84,13 +85,18 @@ function renderCompanionPanel(session) {
     const myCompanions = BotManager.sessions.filter(s => s.followPlayerSession === session && s.partyCompanion === true && s.actor);
 
     if (myCompanions.length === 0) {
-        const html = `<html><body><title>Party Control</title><font color="LEVEL">Companion Panel</font><br><br>You currently have no companions in your party.<br>Target a bot and type <font color="LEVEL">/invite</font> to recruit them!</body></html>`;
+        const html = Html.page(
+            Html.emptyState(
+                'Companion Panel',
+                'You currently have no companions in your party. Target a bot and type /invite to recruit them.'
+            ),
+            { title: 'Party Control' }
+        );
         session.dataSendToMe(ServerResponse.npcHtml(actor.fetchId(), html));
         return;
     }
 
-    let html = `<html><body><title>Party Control</title><font color="LEVEL">Companion Commands</font><br><br>`;
-    html += `<img src="L2UI.SquareWhite" width=270 height=1><br>`;
+    let body = `${Html.font('Companion Commands', Html.COLOR.title)}<br>`;
 
     myCompanions.forEach((companionSession) => {
         const bot = companionSession.actor;
@@ -106,38 +112,36 @@ function renderCompanionPanel(session) {
         const mpPct = status ? Math.round(status.vitals.mpPct * 100) : 0;
         const spotName = status?.spot?.name || 'no spot';
 
-        html += `<font color="00FF00">${bot.fetchName()}</font>: `;
+        const movement = stayActive
+            ? Html.link('[STAYING]', `companion-control follow ${bot.fetchName()}`, { color: Html.COLOR.danger })
+            : Html.link('[FOLLOWING]', `companion-control stay ${bot.fetchName()}`, { color: Html.COLOR.ok });
+        let actions = movement;
 
-        // Follow / Stay buttons
-        if (stayActive) {
-            html += `<a action="bypass -h companion-control follow ${bot.fetchName()}"><font color="FF0000">[STAYING]</font></a>`;
-        } else {
-            html += `<a action="bypass -h companion-control stay ${bot.fetchName()}"><font color="00FF00">[FOLLOWING]</font></a>`;
-        }
-
-        // Taunt button for tanks
         if (isTank) {
-            html += ` | `;
-            if (tauntActive) {
-                html += `<a action="bypass -h companion-control taunt-off ${bot.fetchName()}"><font color="LEVEL">[PULL: ON]</font></a>`;
-            } else {
-                html += `<a action="bypass -h companion-control taunt-on ${bot.fetchName()}"><font color="777777">[PULL: OFF]</font></a>`;
-            }
+            const taunt = tauntActive
+                ? Html.link('[PULL: ON]', `companion-control taunt-off ${bot.fetchName()}`, { color: Html.COLOR.title })
+                : Html.link('[PULL: OFF]', `companion-control taunt-on ${bot.fetchName()}`, { color: Html.COLOR.muted });
+            actions += ` | ${taunt}`;
         }
 
-        html += ` | <a action="bypass -h companion-control summon ${bot.fetchName()}">Summon</a> | <a action="bypass -h bot-status ${bot.fetchName()}">Status</a> | <a action="bypass -h companion-control dismiss ${bot.fetchName()}"><font color="FF5555">Dismiss</font></a><br>`;
-        if (status) {
-            html += `<font color="777777">${status.intent} / HP ${hpPct}% / MP ${mpPct}% / ${spotName}</font><br>`;
-        }
-        html += `<img src="L2UI.SquareBlank" width=270 height=4><br>`;
+        actions += ` | ${Html.link('Summon', `companion-control summon ${bot.fetchName()}`)}`;
+        actions += ` | ${Html.link('Status', `bot-status ${bot.fetchName()}`)}`;
+        actions += ` | ${Html.link('Dismiss', `companion-control dismiss ${bot.fetchName()}`, { color: Html.COLOR.danger })}`;
+
+        body += Html.botCard({
+            name: bot.fetchName(),
+            badge: status ? Html.font(status.role || 'bot', Html.COLOR.link) : '',
+            subtitle: status ? `${status.intent} / HP ${hpPct}% / MP ${mpPct}% / ${spotName}` : 'status unavailable',
+            status: actions
+        });
+        body += Html.spacer(4);
     });
 
-    html += `<img src="L2UI.SquareWhite" width=270 height=1><br>`;
-    html += `<table width=270><tr>`;
-    html += `<td width=270 align=center><a action="bypass -h html 7000">Close Panel</a></td>`;
-    html += `</tr></table>`;
-    html += `</body></html>`;
+    body += Html.actionFooter([
+        { label: 'Close Panel', command: 'html 7000', color: Html.COLOR.muted }
+    ]);
 
+    const html = Html.page(body, { title: 'Party Control' });
     session.dataSendToMe(ServerResponse.npcHtml(actor.fetchId(), html));
 }
 

--- a/src/GameServer/World/Generics/NpcBypasses/SellToMerchantItem.js
+++ b/src/GameServer/World/Generics/NpcBypasses/SellToMerchantItem.js
@@ -1,9 +1,28 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const DataCache      = invoke('GameServer/DataCache');
 const TradeService   = invoke('GameServer/Bot/TradeService');
+const Html           = invoke('GameServer/World/Generics/HtmlKit');
 
 function fold(v) {
     return String(v).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+function itemColor(kind) {
+    if (kind.startsWith('Weapon')) return Html.COLOR.weapon;
+    if (kind.startsWith('Armor') || kind.startsWith('Shield')) return Html.COLOR.armor;
+    return Html.COLOR.title;
+}
+
+function quantityLinks(prefix, selfId, maxSell) {
+    if (maxSell <= 0) return Html.font('None', Html.COLOR.muted);
+
+    const links = [
+        Html.link('x1', `${prefix} ${selfId} 1`, { color: Html.COLOR.warn })
+    ];
+    if (maxSell >= 10) links.push(Html.link('x10', `${prefix} ${selfId} 10`, { color: Html.COLOR.warn }));
+    if (maxSell >= 100) links.push(Html.link('x100', `${prefix} ${selfId} 100`, { color: Html.COLOR.warn }));
+    if (maxSell > 1) links.push(Html.link('All', `${prefix} ${selfId} ${maxSell}`, { color: Html.COLOR.warn }));
+    return links.join('&nbsp;&nbsp;');
 }
 
 function buildShopHtml(session, bot) {
@@ -18,38 +37,32 @@ function buildShopHtml(session, bot) {
         const template = DataCache.items.find(ob => ob.selfId === item.selfId);
         const iname = template?.template?.name ?? 'Unknown';
         const icat = template?.template?.kind ?? '';
-        const clr = icat.startsWith('Weapon') ? 'FF9900' :
-                    icat.startsWith('Armor') || icat.startsWith('Shield') ? '99CCFF' : 'LEVEL';
-
         const playerItem = session.actor.backpack.fetchItemFromSelfId(item.selfId);
         const playerCount = playerItem ? playerItem.fetchAmount() : 0;
         const maxSell = Math.min(item.count, playerCount);
 
-        let btns = '<font color="777777">None</font>';
-        if (maxSell > 0) {
-            btns = `<a action="bypass -h sell-to-merchant-item ${item.selfId} 1"><font color="FFCC00">x1</font></a>&nbsp;&nbsp;`;
-            if (maxSell >= 10) btns += `<a action="bypass -h sell-to-merchant-item ${item.selfId} 10"><font color="FFCC00">x10</font></a>&nbsp;&nbsp;`;
-            if (maxSell >= 100) btns += `<a action="bypass -h sell-to-merchant-item ${item.selfId} 100"><font color="FFCC00">x100</font></a>&nbsp;&nbsp;`;
-            if (maxSell > 1) btns += `<a action="bypass -h sell-to-merchant-item ${item.selfId} ${maxSell}"><font color="FFCC00">All</font></a>`;
-        }
-
-        rows += `<table width=270><tr><td><font color="${clr}">${iname}</font></td></tr></table>`;
-        rows += `<table width=270><tr><td width=80>Have: <font color="99CCFF">${fold(playerCount)}</font></td>`;
-        rows += `<td width=80 align=right>Price: <font color="00FF00">${fold(item.price)}a</font></td>`;
-        rows += `<td width=110 align=right>${btns}</td></tr></table>`;
-        if (i < items.length - 1) rows += `<br1><img src="L2UI_CH3.hegaerectangle" width=270 height=1><br1>`;
+        rows += Html.table([
+            Html.row([Html.cell(Html.font(iname, itemColor(icat)))])
+        ]);
+        rows += Html.table([
+            Html.row([
+                Html.cell(`Have: ${Html.font(fold(playerCount), Html.COLOR.link)}`, { width: 80 }),
+                Html.cell(`Price: ${Html.font(`${fold(item.price)}a`, Html.COLOR.ok)}`, { width: 80, align: 'right' }),
+                Html.cell(quantityLinks('sell-to-merchant-item', item.selfId, maxSell), { width: 110, align: 'right' })
+            ])
+        ]);
+        if (i < items.length - 1) rows += Html.line('L2UI_CH3.hegaerectangle');
     }
 
-    return `<html><body>
-<center>
-<font color="FFCC00">Buying: ${title}</font><br1>
-<font color="777777">No matching items in your inventory.</font><br1>
-<font color="00FF00">Adena: ${fold(adena)}a</font><br>
-<img src="L2UI_CH3.hegaerectangle" width=270 height=1><br1>
-${rows}
-<br>
-<a action="bypass -h npc_talk">Close</a>
-</center></body></html>`;
+    let body = `${Html.font(`Buying: ${title}`, Html.COLOR.warn)}<br1>`;
+    body += `${Html.font('No matching items in your inventory.', Html.COLOR.muted)}<br1>`;
+    body += `${Html.font(`Adena: ${fold(adena)}a`, Html.COLOR.ok)}<br>`;
+    body += Html.line('L2UI_CH3.hegaerectangle');
+    body += rows || Html.emptyState('No Orders', 'This merchant is not buying anything.');
+    body += '<br>' + Html.actionFooter([
+        { label: 'Close', command: 'npc_talk', color: Html.COLOR.muted }
+    ]);
+    return Html.page(body, { title: `Buying: ${title}` });
 }
 
 module.exports = async function(session, parts) {

--- a/src/GameServer/World/Generics/NpcBypasses/UiTest.js
+++ b/src/GameServer/World/Generics/NpcBypasses/UiTest.js
@@ -1,0 +1,365 @@
+const ServerResponse = invoke('GameServer/Network/Response');
+const Html = invoke('GameServer/World/Generics/HtmlKit');
+
+const WIDTH = Html.WIDTH;
+const TABS = [
+    ['overview', 'Overview'],
+    ['buttons', 'Buttons'],
+    ['inputs', 'Inputs'],
+    ['images', 'Images'],
+    ['layout', 'Layout'],
+    ['title', 'Title'],
+    ['stress', 'Size']
+];
+
+function clampPage(value) {
+    return TABS.some(([id]) => id === value) ? value : 'overview';
+}
+
+function resultBlock(state) {
+    if (!state || !state.lastAction) return '';
+
+    const values = state.values || [];
+    let rows = `${Html.font('Last action:', Html.COLOR.link)} ${Html.esc(state.lastAction)}<br1>`;
+    values.forEach((value, index) => {
+        rows += `${Html.font(`arg${index + 1}:`, Html.COLOR.muted)} ${Html.esc(value || '<empty>')}<br1>`;
+    });
+
+    return Html.section('Bypass Result', rows);
+}
+
+function overview() {
+    return [
+        `${Html.font('Custom HTML UI Lab', Html.COLOR.title)}<br1>`,
+        `${Html.font('Opened by .uitest. Use tabs to probe client-safe controls.', Html.COLOR.muted)}<br>`,
+        Html.line(),
+        Html.keyValueRows([
+            ['Packet', 'NpcHtmlMessage 0x0f'],
+            ['Target', 'C2-safe NPC dialog subset'],
+            ['Width', '270 px test baseline']
+        ]),
+        Html.section('Quick Probes', Html.columns([
+            Html.cell(Html.button('Buttons', 'ui-test page buttons')),
+            Html.cell(Html.button('Inputs', 'ui-test page inputs')),
+            Html.cell(Html.button('Images', 'ui-test page images'))
+        ])),
+        Html.section('Observed C2 Notes',
+            `${Html.font('OK:', Html.COLOR.ok)} tables, links, edit, combobox, multiedit, common item/skill icons.<br1>` +
+            `${Html.font('Mixed:', Html.COLOR.warn)} button textures vary; checkbox texture is usable only in small sizes.<br1>` +
+            `${Html.font('UX:', Html.COLOR.warn)} server redraw after deep clicks scrolls the window upward.<br1>` +
+            `${Html.font('Crash:', Html.COLOR.danger)} 60-row payload crashed this client; size probes now stop at 25.`
+        )
+    ].join('');
+}
+
+function buttons(state) {
+    const checked = state?.checkbox === true;
+    const checkText = checked ? 'ON' : 'OFF';
+    const checkColor = checked ? Html.COLOR.ok : Html.COLOR.muted;
+    const checkTexture = checked ? 'L2UI.CheckBox_checked' : 'L2UI.CheckBox';
+    const closeLinkCount = state?.closeLinkCount || 0;
+    const stayLinkCount = state?.stayLinkCount || 0;
+
+    return [
+        `${Html.font('Button Texture Matrix', Html.COLOR.title)}<br1>`,
+        `${Html.font('Use compact labels; C2 button text rendering is fixed and cramped.', Html.COLOR.muted)}<br>`,
+        Html.section('C2/CH3 Candidates', Html.table([
+            Html.row([
+                Html.cell(Html.button('Default', 'ui-test press default', { width: 75 })),
+                Html.cell(Html.button('CH3', 'ui-test press ch3', { width: 75, fore: 'L2UI_ch3.Btn1_normal', back: 'L2UI_ch3.Btn1_normalOn' })),
+                Html.cell(Html.button('Big', 'ui-test press big', { width: 90, fore: 'L2UI_ch3.BigButton3', back: 'L2UI_ch3.BigButton3_over' }))
+            ])
+        ])),
+        Html.section('Maybe Missing On C2', Html.table([
+            Html.row([
+                Html.cell(Html.button('CT1', 'ui-test press ct1', { width: 75, fore: 'L2UI_CT1.Button_DF', back: 'L2UI_CT1.Button_DF_Down' })),
+                Html.cell(Html.button('', 'ui-test press checkbox-on', { width: 18, height: 18, fore: 'L2UI.CheckBox_checked', back: 'L2UI.CheckBox_checked' })),
+                Html.cell(Html.button('', 'ui-test press checkbox-off', { width: 18, height: 18, fore: 'L2UI.CheckBox', back: 'L2UI.CheckBox' }))
+            ])
+        ])),
+        Html.section('Checkbox Texture Probe',
+            Html.table([
+                Html.row([
+                    Html.cell(Html.button('', 'ui-test toggle-checkbox', { width: 14, height: 14, fore: checkTexture, back: checkTexture }), { width: 26 }),
+                    Html.cell(Html.button('', 'ui-test toggle-checkbox', { width: 18, height: 18, fore: checkTexture, back: checkTexture }), { width: 26 }),
+                    Html.cell(`${Html.font(checkText, checkColor)} ${Html.font('small texture fits best', Html.COLOR.muted)}`)
+                ])
+            ]) +
+            '<br1>' +
+            `${Html.font('Click works, but redraw can jump scroll. Do not use deep in long pages.', Html.COLOR.muted)}`
+        ),
+        Html.section('Recommended Toggle',
+            Html.table([
+                Html.row([
+                    Html.cell(Html.button(checked ? 'ON' : 'OFF', 'ui-test toggle-checkbox', { width: 75 }), { width: 92 }),
+                    Html.cell(Html.link(checked ? 'Enabled' : 'Disabled', 'ui-test toggle-checkbox', { color: checkColor, hide: false }))
+                ])
+            ]) +
+            '<br1>' +
+            `${Html.font('Use near the top of a page, or redraw a short page to avoid scroll jumps.', Html.COLOR.muted)}`
+        ),
+        Html.section('Link Fallback',
+            `${Html.link('Plain colored link', 'ui-test press plain-link', { color: Html.COLOR.ok })} ` +
+            `${Html.link('hide-on-click link', 'ui-test press hide-link')}`
+        ),
+        Html.section('Hide / No-Hide Probe',
+            Html.table([
+                Html.row([
+                    Html.cell(Html.link('no -h redraw', 'ui-test stay-link', { hide: false }), { width: 135 }),
+                    Html.cell(Html.link('-h close only', 'ui-test close-link', { color: Html.COLOR.warn }), { width: 135 })
+                ])
+            ]) +
+            `${Html.font(`no -h clicks: ${stayLinkCount} / close-only clicks: ${closeLinkCount}`, Html.COLOR.muted)}<br1>` +
+            Html.table([
+                Html.row([
+                    Html.cell(Html.button('No-hide btn', 'ui-test stay-link', { width: 105, hide: false }), { align: 'center' }),
+                    Html.cell(Html.button('Close btn', 'ui-test close-link', { width: 105 }), { align: 'center' })
+                ])
+            ]) +
+            '<br1>' +
+            `${Html.font('Close button confirmed: -h without redraw closes the window.', Html.COLOR.muted)}`
+        )
+    ].join('');
+}
+
+function inputs() {
+    return [
+        `${Html.font('Input Return Test', Html.COLOR.title)}<br1>`,
+        `${Html.font('The server receives values through $variables in bypass.', Html.COLOR.muted)}<br>`,
+        Html.section('Edit + Combobox',
+            Html.table([
+                Html.row([
+                    Html.cell('Name', { width: 70 }),
+                    Html.cell('<edit var="ui_name" width=130 height=15 length=16>')
+                ]),
+                Html.row([
+                    Html.cell('Amount'),
+                    Html.cell('<edit var="ui_amount" width=70 height=15 length=8>')
+                ]),
+                Html.row([
+                    Html.cell('Choice'),
+                    Html.cell('<combobox var="ui_choice" width=120 height=17 list="Player;Pet;Party;VeryLongValueProbe">')
+                ])
+            ]) +
+            '<br1>' +
+            Html.button('Submit', 'ui-test submit $ui_name $ui_amount $ui_choice', { width: 120 })
+        ),
+        Html.section('Multiedit Probe',
+            '<multiedit var="ui_note" width=220 height=40><br1>' +
+            Html.button('Send Note', 'ui-test note $ui_note', { width: 120 })
+        )
+    ].join('');
+}
+
+function images() {
+    return [
+        `${Html.font('Image And Texture Probe', Html.COLOR.title)}<br1>`,
+        `${Html.font('These names depend on client texture packages.', Html.COLOR.muted)}<br>`,
+        Html.section('Common Lines',
+            Html.line('L2UI.SquareWhite') +
+            Html.line('L2UI.SquareGray') +
+            Html.line('L2UI.SquareBlank', WIDTH, 6) +
+            Html.line('L2UI_CH3.hegaerectangle')
+        ),
+        Html.section('Icons', Html.table([
+            Html.row([
+                Html.cell(`${Html.img('icon.skill0001', 32, 32)}<br1>skill0001`, { align: 'center' }),
+                Html.cell(`${Html.img('icon.skill1077', 32, 32)}<br1>skill1077`, { align: 'center' }),
+                Html.cell(`${Html.img('icon.etc_adena_i00', 32, 32)}<br1>adena`, { align: 'center' })
+            ])
+        ])),
+        Html.section('Risky/Newer Textures', Html.table([
+            Html.row([
+                Html.cell(`${Html.img('L2UI_CT1.Icon_DF_MenuWnd_Skill', 32, 32)}<br1>CT1`, { align: 'center' }),
+                Html.cell(`${Html.img('L2UI_CH3.shortcut_next_down', 16, 16)}<br1>CH3`, { align: 'center' }),
+                Html.cell(`${Html.img('SSQ_dungeon_T.SSQ_fire1_e013', 80, 20)}<br1>SSQ`, { align: 'center' })
+            ])
+        ]))
+    ].join('');
+}
+
+function layout() {
+    return [
+        `${Html.font('Layout Probe', Html.COLOR.title)}<br1>`,
+        `${Html.font('Tables are our main layout primitive.', Html.COLOR.muted)}<br>`,
+        Html.section('Fixed Columns', Html.table([
+            Html.row([
+                Html.cell('Mode', { width: 90 }),
+                Html.cell('Intent', { width: 90, align: 'center' }),
+                Html.cell('HP', { width: 90, align: 'right' })
+            ]),
+            Html.row([
+                Html.cell(Html.font('hunt', Html.COLOR.title)),
+                Html.cell('assist', { align: 'center' }),
+                Html.cell(Html.font('92%', Html.COLOR.ok), { align: 'right' })
+            ]),
+            Html.row([
+                Html.cell(Html.font('rest', Html.COLOR.title)),
+                Html.cell('recover', { align: 'center' }),
+                Html.cell(Html.font('41%', Html.COLOR.warn), { align: 'right' })
+            ])
+        ], { bgcolor: Html.COLOR.row })),
+        Html.section('Background Attribute',
+            Html.table([
+                Html.row([
+                    Html.cell(Html.font('background texture test', Html.COLOR.title), { align: 'center' })
+                ])
+            ], { background: 'L2UI_CH3.hegaerectangle' }) +
+            '<br1>' +
+            Html.table([
+                Html.row([Html.cell('bgcolor test', { align: 'center' })])
+            ], { bgcolor: '444444' })
+        ),
+        Html.section('Inline Gauges',
+            `${Html.font('HP', Html.COLOR.muted)}<br1>${Html.img('L2UI.SquareWhite', 205, 4)}${Html.img('L2UI.SquareBlank', 65, 4)}<br1>` +
+            `${Html.font('MP', Html.COLOR.muted)}<br1>${Html.img('L2UI.SquareWhite', 120, 4)}${Html.img('L2UI.SquareBlank', 150, 4)}<br1>`
+        )
+    ].join('');
+}
+
+function titleProbe(state) {
+    const titleMode = Object.prototype.hasOwnProperty.call(state || {}, 'titleMode')
+        ? state.titleMode
+        : 'UI Test';
+
+    return [
+        `${Html.font('Window Title Probe', Html.COLOR.title)}<br1>`,
+        `${Html.font('If the outer frame still says Chat, C2 ignores <title> for this dialog.', Html.COLOR.muted)}<br>`,
+        Html.keyValueRows([
+            ['HTML title', Html.font(titleMode || '<empty>', Html.COLOR.link)],
+            ['Frame title', 'Check the top bar manually']
+        ]),
+        Html.section('Title Variants', Html.columns([
+            Html.cell(Html.link('Bot Party', 'ui-test title Bot_Party', { color: Html.COLOR.link })),
+            Html.cell(Html.link('UI Test', 'ui-test title UI_Test', { color: Html.COLOR.link })),
+            Html.cell(Html.link('Empty', 'ui-test title none', { color: Html.COLOR.warn }))
+        ])),
+        Html.section('Body Title Fallback',
+            `${Html.font(titleMode || 'Untitled Window', Html.COLOR.title)}<br1>` +
+            `${Html.font('This is the reliable title we can style inside the page body.', Html.COLOR.muted)}`
+        )
+    ].join('');
+}
+
+function stress(parts) {
+    const requested = parseInt(parts[2], 10);
+    const rows = Number.isFinite(requested) ? Math.max(10, Math.min(requested, 25)) : 10;
+    let body = `${Html.font('Payload Size Probe', Html.COLOR.title)}<br1>`;
+    body += `${Html.font('60 rows crashed the C2 client. This page now caps at 25.', Html.COLOR.muted)}<br>`;
+    body += Html.columns([
+        Html.cell(Html.button('10 rows', 'ui-test stress 10', { width: 75 })),
+        Html.cell(Html.button('18 rows', 'ui-test stress 18', { width: 75 })),
+        Html.cell(Html.button('25 edge', 'ui-test stress 25', { width: 75 }))
+    ]) + '<br1>';
+
+    for (let i = 1; i <= rows; i++) {
+        body += Html.table([
+            Html.row([
+                Html.cell(`#${i}`, { width: 40 }),
+                Html.cell('Long row probe with icon'),
+                Html.cell(Html.img('icon.skill0001', 16, 16), { align: 'right' })
+            ])
+        ]);
+    }
+
+    return body;
+}
+
+function pageBody(page, parts, state) {
+    if (page === 'buttons') return buttons(state);
+    if (page === 'inputs') return inputs();
+    if (page === 'images') return images();
+    if (page === 'layout') return layout();
+    if (page === 'title') return titleProbe(state);
+    if (page === 'stress') return stress(parts);
+    return overview() + resultBlock(state);
+}
+
+function buildHtml(page, parts, state) {
+    const title = Object.prototype.hasOwnProperty.call(state || {}, 'titleMode')
+        ? state.titleMode
+        : 'UI Test';
+
+    return Html.page(pageBody(page, parts, state), {
+        title,
+        tabs: Html.tabs(TABS, page, 'ui-test page'),
+        showSize: true
+    });
+}
+
+function render(session, page = 'overview', parts = ['ui-test']) {
+    const actor = session.actor;
+    if (!actor) return;
+
+    const state = session.uiTestState || null;
+    const html = buildHtml(clampPage(page), parts, state);
+    session.dataSendToMe(ServerResponse.npcHtml(actor.fetchId(), html));
+}
+
+function uiTest(session, parts) {
+    const action = parts[1];
+    session.uiTestState = session.uiTestState || {};
+
+    if (action === 'page') {
+        render(session, parts[2], parts);
+        return;
+    }
+
+    if (action === 'toggle-checkbox') {
+        session.uiTestState.checkbox = session.uiTestState.checkbox !== true;
+        session.uiTestState.lastAction = 'toggle-checkbox';
+        session.uiTestState.values = [session.uiTestState.checkbox ? 'ON' : 'OFF'];
+        render(session, 'buttons', parts);
+        return;
+    }
+
+    if (action === 'stay-link') {
+        session.uiTestState.stayLinkCount = (session.uiTestState.stayLinkCount || 0) + 1;
+        session.uiTestState.lastAction = 'stay-link';
+        session.uiTestState.values = ['redraws without -h'];
+        render(session, 'buttons', parts);
+        return;
+    }
+
+    if (action === 'title') {
+        session.uiTestState.titleMode = parts[2] === 'none'
+            ? ''
+            : String(parts[2] || 'UI_Test').replace(/_/g, ' ');
+        session.uiTestState.lastAction = 'title';
+        session.uiTestState.values = [session.uiTestState.titleMode || '<empty>'];
+        render(session, 'title', parts);
+        return;
+    }
+
+    if (action === 'close-link') {
+        session.uiTestState.closeLinkCount = (session.uiTestState.closeLinkCount || 0) + 1;
+        session.uiTestState.lastAction = 'close-link';
+        session.uiTestState.values = ['sent no replacement html'];
+        return;
+    }
+
+    if (action === 'press') {
+        session.uiTestState.lastAction = parts[2] || 'press';
+        session.uiTestState.values = [];
+        render(session, 'overview', parts);
+        return;
+    }
+
+    if (action === 'submit' || action === 'note') {
+        session.uiTestState.lastAction = action;
+        session.uiTestState.values = parts.slice(2);
+        render(session, 'overview', parts);
+        return;
+    }
+
+    if (action === 'stress') {
+        render(session, 'stress', parts);
+        return;
+    }
+
+    render(session, 'overview', parts);
+}
+
+uiTest.render = render;
+
+module.exports = uiTest;


### PR DESCRIPTION
## Summary

- Add a reusable C2 HTML UI kit for custom NPC windows, including page wrappers, tabs, status tables, bot cards, action footers, empty states, links, buttons, and size helpers.
- Add a `.uitest` command with probe pages for buttons, inputs, images, layout, title handling, and payload size limits.
- Migrate bot party, companion control, bot status, and merchant buy/sell windows to shared UI helpers.
- Document the current C2 HTML rules: prefer links for navigation, keep payloads small, treat outer window titles as client-controlled, and use bitmap buttons sparingly.

## Validation

- `node --check` on the changed JS files.
- Mock renders for companion control, buy merchant, sell merchant, and bot status windows.
- `git diff --cached --check`.
- Server smoke boot with `npm run NodeL2` reached AuthServer and GameServer successful init.