### PR TITLE
Fix bot trade memory event

### DIFF
--- a/src/GameServer/Network/Request/TradeDone.js
+++ b/src/GameServer/Network/Request/TradeDone.js
@@ -31,7 +31,12 @@ async function tradeDone(session, buffer) {
 
         const detail = describeMovedItems(result.moved);
         const lootRequest = BotLootEtiquette.resolveTrade(session, result.partnerSession, result.moved);
-        BotSocialMemory.recordEvent(session, result.partnerSession, 'gave_useful_loot', detail);
+        BotSocialMemory.recordEvent(
+            session,
+            result.partnerSession,
+            lootRequest ? 'gave_useful_loot' : 'trade_completed',
+            detail
+        );
         BotManager.botTell(
             result.partnerSession,
             session,


### PR DESCRIPTION
## Summary

- Record ordinary direct bot trades as `trade_completed`.
- Keep `gave_useful_loot` only for trades that fulfill a pending bot loot request.

## Why

The loot etiquette flow should distinguish a normal handoff from a requested useful-loot handoff. Without that distinction, ordinary bot trades can inflate the social memory fields that are meant to represent useful loot sharing.

## Validation

- `node --check src/GameServer/Network/Request/TradeDone.js`
- `git diff --check`
- `npm run NodeL2` boot smoke reached DB connection, game server init, bot startup, and BotSocial memory table readiness.