### PR TITLE
Tune bot loot requests

### DIFF
--- a/src/GameServer/Bot/AI/BotLootEtiquette.js
+++ b/src/GameServer/Bot/AI/BotLootEtiquette.js
@@ -6,6 +6,18 @@ const ADENA_ID = 57;
 const REQUEST_RANGE = 1600;
 const REQUEST_TTL_MS = 180000;
 const REQUEST_COOLDOWN_MS = 120000;
+const PLAYER_REQUEST_COOLDOWN_MS = 90000;
+const IGNORE_PENALTY_RANGE = REQUEST_RANGE * 1.5;
+const MAX_PENDING_REQUESTS = 1;
+const MIN_DEMAND_SCORE = 3;
+
+const ROLE_CLASSES = {
+    healer: [15, 16, 17, 29, 30, 42, 43],
+    tank: [4, 5, 6, 19, 20, 32, 33],
+    archer: [8, 9, 22, 23, 35, 36, 37],
+    mage: [10, 11, 12, 13, 14, 25, 26, 27, 28, 29, 30, 38, 39, 40, 41, 42, 43, 49, 50, 51, 52],
+    dwarf: [53, 54, 55, 56, 57]
+};
 
 function now() {
     return Date.now();
@@ -55,13 +67,22 @@ function removeRequest(playerSession, botSession, request) {
 function itemInfo(itemDetails, selfId) {
     const template = itemDetails.template || {};
     const kind = template.kind || '';
+    const name = template.name || `item ${selfId}`;
 
     return {
         selfId,
-        name: template.name || `item ${selfId}`,
+        name,
         kind,
         price: Number(template.price || 0),
+        rank: itemDetails.etc?.rank || 'none',
         stackable: !!itemDetails.etc?.stackable,
+        weapon: kind.startsWith('Weapon.'),
+        armor: kind.startsWith('Armor.'),
+        material: kind === 'Other.Material',
+        recipe: kind === 'Other.Recipe',
+        shot: kind === 'Other.Shot',
+        potion: kind === 'Other.Potion',
+        scroll: kind === 'Other.Scroll',
         equipment: kind.startsWith('Weapon.') || kind.startsWith('Armor.'),
         consumable: !!itemDetails.etc?.consumable || kind.includes('Potion') || kind.includes('Shot')
     };
@@ -76,20 +97,67 @@ function isNotable(info, amount) {
     return false;
 }
 
-function candidateScore(botSession, info) {
-    let score = 1;
+function roleForClass(classId) {
+    if (ROLE_CLASSES.healer.includes(classId)) return 'healer';
+    if (ROLE_CLASSES.tank.includes(classId)) return 'tank';
+    if (ROLE_CLASSES.archer.includes(classId)) return 'archer';
+    if (ROLE_CLASSES.mage.includes(classId)) return 'mage';
+    if (ROLE_CLASSES.dwarf.includes(classId)) return 'dwarf';
+    return 'dps';
+}
+
+function addDemand(result, score, reason) {
+    result.score += score;
+    if (reason && !result.reasons.includes(reason)) {
+        result.reasons.push(reason);
+    }
+}
+
+function itemDemand(botSession, info) {
+    const result = { score: 0, reasons: [] };
     const classId = botSession.actor.fetchClassId();
-    const healerClasses = [15, 16, 17, 29, 30, 42, 43];
-    const archerClasses = [8, 9, 22, 23, 35, 36, 37];
-    const mageClasses = [10, 11, 12, 13, 14, 25, 26, 27, 28, 38, 39, 40, 41, 49, 50, 51, 52];
+    const role = roleForClass(classId);
+    const name = info.name.toLowerCase();
+    const weaponType = info.kind.replace('Weapon.', '');
+    const armorType = info.kind.replace('Armor.', '');
 
-    if (info.equipment) score += 4;
-    if (info.consumable) score += 2;
-    if (info.kind.includes('Shot') && (archerClasses.includes(classId) || mageClasses.includes(classId))) score += 2;
-    if (info.kind.includes('Potion') && healerClasses.includes(classId)) score += 1;
-    if (info.price >= 250) score += 2;
+    if (info.weapon) {
+        if (role === 'archer' && weaponType === 'Bow') addDemand(result, 6, 'archer weapon');
+        else if ((role === 'mage' || role === 'healer') && /staff|wand|rod|spellbook|voodoo|scroll/.test(name)) addDemand(result, 6, 'caster weapon');
+        else if (role === 'tank' && ['Sword', 'Blunt', 'Pole'].includes(weaponType)) addDemand(result, 4, 'frontline weapon');
+        else if (role === 'dps' && ['Knife', 'Sword', 'GreatSword', 'Pole', 'Blunt'].includes(weaponType)) addDemand(result, 4, 'damage weapon');
+    }
 
-    return score;
+    if (info.armor) {
+        if (role === 'tank' && ['Shield', 'Chain'].includes(armorType)) addDemand(result, 6, 'tank gear');
+        else if ((role === 'mage' || role === 'healer') && ['Fabric', 'Wear', 'Jewel'].includes(armorType)) addDemand(result, 4, 'caster gear');
+        else if ((role === 'archer' || role === 'dps') && ['Leather', 'Wear', 'Jewel'].includes(armorType)) addDemand(result, 4, 'combat gear');
+    }
+
+    if (info.shot) {
+        if (name.includes('spiritshot') && (role === 'mage' || role === 'healer')) addDemand(result, 5, 'caster shots');
+        else if (name.includes('soulshot') && ['archer', 'tank', 'dps', 'dwarf'].includes(role)) addDemand(result, 4, 'weapon shots');
+    }
+
+    if (info.potion && (role === 'healer' || role === 'tank')) {
+        addDemand(result, 3, 'survival supplies');
+    }
+
+    if ((info.material || info.recipe) && role === 'dwarf') {
+        addDemand(result, info.recipe ? 6 : 5, info.recipe ? 'craft recipe' : 'craft material');
+    }
+
+    if (info.scroll && name.includes('enchant')) {
+        addDemand(result, 3, 'enchant scroll');
+    }
+
+    if (info.price >= 250000) addDemand(result, 3, 'valuable drop');
+    else if (info.price >= 10000) addDemand(result, 1, 'valuable drop');
+
+    return {
+        ...result,
+        reason: result.reasons[0] || 'useful item'
+    };
 }
 
 function findCandidate(playerSession, npc, info) {
@@ -99,7 +167,8 @@ function findCandidate(playerSession, npc, info) {
     cleanup(playerSession);
 
     const existingRequests = requestList(playerSession);
-    if (existingRequests.length >= 2) return null;
+    if (existingRequests.length >= MAX_PENDING_REQUESTS) return null;
+    if (current - (playerSession.lastLootRequestAt || 0) < PLAYER_REQUEST_COOLDOWN_MS) return null;
 
     return BotManager.sessions
         .filter((botSession) => (
@@ -113,9 +182,18 @@ function findCandidate(playerSession, npc, info) {
         ))
         .map((botSession) => ({
             botSession,
-            score: candidateScore(botSession, info)
+            demand: itemDemand(botSession, info)
         }))
-        .sort((a, b) => b.score - a.score)[0]?.botSession || null;
+        .filter((entry) => entry.demand.score >= MIN_DEMAND_SCORE)
+        .sort((a, b) => b.demand.score - a.demand.score)[0] || null;
+}
+
+function shouldRecordIgnoredRequest(request) {
+    if (!request.playerSession?.actor || !request.botSession?.actor) return false;
+    if (request.botSession.followPlayerSession !== request.playerSession) return false;
+    if (request.botSession.partyCompanion !== true) return false;
+
+    return actorDistance(request.playerSession.actor, request.botSession.actor) <= IGNORE_PENALTY_RANGE;
 }
 
 function expireRequest(request) {
@@ -124,13 +202,17 @@ function expireRequest(request) {
 
         request.fulfilled = true;
         removeRequest(request.playerSession, request.botSession, request);
-        BotSocialMemory.recordEvent(
-            request.playerSession,
-            request.botSession,
-            'ignored_loot_request',
-            `${request.amount} ${request.itemName}`
-        );
-        console.info("BotLoot :: %s ignored %s request from %s", actorName(request.playerSession), request.itemName, actorName(request.botSession));
+        if (shouldRecordIgnoredRequest(request)) {
+            BotSocialMemory.recordEvent(
+                request.playerSession,
+                request.botSession,
+                'ignored_loot_request',
+                `${request.amount} ${request.itemName}`
+            );
+            console.info("BotLoot :: %s ignored %s request from %s", actorName(request.playerSession), request.itemName, actorName(request.botSession));
+        } else {
+            console.info("BotLoot :: %s request for %s expired without social penalty", actorName(request.botSession), request.itemName);
+        }
     }, REQUEST_TTL_MS);
 }
 
@@ -144,10 +226,11 @@ const BotLootEtiquette = {
             const info = itemInfo(itemDetails, selfId);
             if (!isNotable(info, amount)) return;
 
-            const botSession = findCandidate(playerSession, npc, info);
-            if (!botSession) return;
+            const candidate = findCandidate(playerSession, npc, info);
+            if (!candidate) return;
 
             const current = now();
+            const { botSession, demand } = candidate;
             const request = {
                 id: `${current}:${playerSession.actor.fetchId()}:${botSession.actor.fetchId()}:${selfId}`,
                 playerSession,
@@ -157,6 +240,8 @@ const BotLootEtiquette = {
                 selfId,
                 itemName: info.name,
                 amount,
+                reason: demand.reason,
+                demandScore: demand.score,
                 requestedAt: current,
                 expiresAt: current + REQUEST_TTL_MS,
                 fulfilled: false
@@ -169,14 +254,16 @@ const BotLootEtiquette = {
                 playerName: actorName(playerSession),
                 itemName: request.itemName,
                 amount,
+                reason: request.reason,
                 requestedAt: current,
                 expiresAt: request.expiresAt
             };
             botSession.lastLootRequestAt = current;
+            playerSession.lastLootRequestAt = current;
 
             const BotManager = invoke('GameServer/Bot/BotManager');
-            BotManager.botTell(botSession, playerSession, `If you don't need ${info.name}, could you trade it to me?`);
-            console.info("BotLoot :: %s requested %d %s from %s", actorName(botSession), amount, info.name, actorName(playerSession));
+            BotManager.botTell(botSession, playerSession, `If you don't need ${info.name}, could you trade it to me? I can use it for ${request.reason}.`);
+            console.info("BotLoot :: %s requested %d %s from %s (%s, score %d)", actorName(botSession), amount, info.name, actorName(playerSession), request.reason, demand.score);
             expireRequest(request);
         });
     },

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -155,6 +155,8 @@ function tradeSnapshot(session, bot) {
             playerName: loot.playerName,
             itemName: loot.itemName,
             amount: loot.amount,
+            reason: loot.reason || null,
+            demandScore: loot.demandScore || null,
             expiresAt: loot.expiresAt
         } : null
     };


### PR DESCRIPTION
## Summary

- Add role-aware demand scoring before companion bots request dropped loot.
- Throttle loot requests to one pending request per player with a short player-level cooldown.
- Avoid social penalties for expired requests when the bot is no longer an active nearby companion.
- Expose loot request reason and demand score through bot status snapshots.

## Why

Loot etiquette should create useful social moments without making companion bots ask for every merely notable item. This keeps requests tied to class role, economy value, and visible player context.

## Validation

- `node --check src/GameServer/Bot/AI/BotLootEtiquette.js`
- `node --check src/GameServer/Bot/AI/BotStatus.js`
- `git diff --check`
- `npm run NodeL2` boot smoke reached DB connection, game server init, bot startup, and BotSocial memory table readiness.