### PR TITLE
Add party role AI

### DIFF
--- a/src/GameServer/Actor/Generics/CalculateStats.js
+++ b/src/GameServer/Actor/Generics/CalculateStats.js
@@ -30,7 +30,10 @@ function setCollectiveTotalLoad(actor) {
 
 function setCollectiveTotalPAtk(actor) {
     const pAtk = actor.backpack.fetchTotalWeaponPAtk() ?? actor.fetchPAtk();
-    const base = Formulas.calcPAtk(actor.fetchLevel(), actor.fetchStr(), pAtk);
+    let base = Formulas.calcPAtk(actor.fetchLevel(), actor.fetchStr(), pAtk);
+    if (actor.activeBuffs && actor.activeBuffs.might && Date.now() < actor.activeBuffs.might) {
+        base = Math.round(base * 1.15); // +15% P.Atk
+    }
     actor.setCollectivePAtk(base);
 }
 

--- a/src/GameServer/Bot/AI/BotBuffs.js
+++ b/src/GameServer/Bot/AI/BotBuffs.js
@@ -11,7 +11,7 @@ const ALL_BUFFS = {
 };
 
 const NEWBIE_BUFF_TYPES = ['windwalk', 'shield', 'haste'];
-const SUPPORT_BUFF_TYPES = ['might'];
+const SUPPORT_BUFF_TYPES = ['might', 'shield', 'haste', 'windwalk'];
 const NEWBIE_BUFFS = Object.fromEntries(NEWBIE_BUFF_TYPES.map((type) => [type, ALL_BUFFS[type]]));
 const SUPPORT_BUFFS = Object.fromEntries(SUPPORT_BUFF_TYPES.map((type) => [type, ALL_BUFFS[type]]));
 
@@ -64,6 +64,10 @@ function refreshActorPackets(session, actor, Generics) {
 function needsBuff(actor, buffType, thresholdMs = REFRESH_THRESHOLD_MS) {
     const buff = ALL_BUFFS[buffType];
     return !!buff && remainingMs(actor, buff.key) <= thresholdMs;
+}
+
+function nextSupportBuff(actor, thresholdMs = REFRESH_THRESHOLD_MS) {
+    return SUPPORT_BUFF_TYPES.find((type) => needsBuff(actor, type, thresholdMs)) || null;
 }
 
 function applyBuff(session, actor, buffType, Generics) {
@@ -138,6 +142,7 @@ module.exports = {
     missingNewbieBuffs,
     needsNewbieRefresh,
     needsBuff,
+    nextSupportBuff,
     remainingMs,
     snapshot
 };

--- a/src/GameServer/Bot/AI/BotBuffs.js
+++ b/src/GameServer/Bot/AI/BotBuffs.js
@@ -3,11 +3,17 @@ const ServerResponse = invoke('GameServer/Network/Response');
 const BUFF_DURATION_MS = 20 * 60 * 1000;
 const REFRESH_THRESHOLD_MS = 2 * 60 * 1000;
 
-const NEWBIE_BUFFS = {
+const ALL_BUFFS = {
     windwalk: { key: 'windWalk', id: 1204, name: 'Wind Walk' },
     shield: { key: 'shield', id: 1040, name: 'Shield' },
-    haste: { key: 'haste', id: 1086, name: 'Haste' }
+    haste: { key: 'haste', id: 1086, name: 'Haste' },
+    might: { key: 'might', id: 1068, name: 'Might' }
 };
+
+const NEWBIE_BUFF_TYPES = ['windwalk', 'shield', 'haste'];
+const SUPPORT_BUFF_TYPES = ['might'];
+const NEWBIE_BUFFS = Object.fromEntries(NEWBIE_BUFF_TYPES.map((type) => [type, ALL_BUFFS[type]]));
+const SUPPORT_BUFFS = Object.fromEntries(SUPPORT_BUFF_TYPES.map((type) => [type, ALL_BUFFS[type]]));
 
 function ensureStore(actor) {
     if (!actor.activeBuffs) {
@@ -30,7 +36,8 @@ function remainingMs(actor, key) {
 }
 
 function missingNewbieBuffs(actor, thresholdMs = 0) {
-    return Object.values(NEWBIE_BUFFS)
+    return NEWBIE_BUFF_TYPES
+        .map((type) => ALL_BUFFS[type])
         .filter((buff) => remainingMs(actor, buff.key) <= thresholdMs)
         .map((buff) => buff.key);
 }
@@ -54,8 +61,13 @@ function refreshActorPackets(session, actor, Generics) {
     }
 }
 
-function applyNewbieBuff(session, actor, buffType, Generics) {
-    const buff = NEWBIE_BUFFS[buffType];
+function needsBuff(actor, buffType, thresholdMs = REFRESH_THRESHOLD_MS) {
+    const buff = ALL_BUFFS[buffType];
+    return !!buff && remainingMs(actor, buff.key) <= thresholdMs;
+}
+
+function applyBuff(session, actor, buffType, Generics) {
+    const buff = ALL_BUFFS[buffType];
     if (!buff || !actor) return null;
 
     const store = ensureStore(actor);
@@ -69,12 +81,22 @@ function applyNewbieBuff(session, actor, buffType, Generics) {
     };
 }
 
+function applyNewbieBuff(session, actor, buffType, Generics) {
+    if (!NEWBIE_BUFFS[buffType]) return null;
+    return applyBuff(session, actor, buffType, Generics);
+}
+
+function applySupportBuff(session, actor, buffType, Generics) {
+    if (!SUPPORT_BUFFS[buffType]) return null;
+    return applyBuff(session, actor, buffType, Generics);
+}
+
 function applyFullNewbieBlessing(session, actor, Generics) {
     if (!actor) return null;
 
     const store = ensureStore(actor);
     const expiresAt = now() + BUFF_DURATION_MS;
-    Object.values(NEWBIE_BUFFS).forEach((buff) => {
+    NEWBIE_BUFF_TYPES.map((type) => ALL_BUFFS[type]).forEach((buff) => {
         store[buff.key] = expiresAt;
     });
 
@@ -83,20 +105,21 @@ function applyFullNewbieBlessing(session, actor, Generics) {
     refreshActorPackets(session, actor, Generics);
 
     return {
-        buffs: Object.values(NEWBIE_BUFFS).map((buff) => buff.key),
+        buffs: NEWBIE_BUFF_TYPES.map((type) => ALL_BUFFS[type].key),
         expiresAt
     };
 }
 
 function snapshot(actor) {
     const buffs = {};
-    Object.values(NEWBIE_BUFFS).forEach((buff) => {
+    Object.values(ALL_BUFFS).forEach((buff) => {
         buffs[buff.key] = Math.round(remainingMs(actor, buff.key) / 1000);
     });
 
     return {
         eligible: isNewbieEligible(actor),
         needsRefresh: needsNewbieRefresh(actor),
+        needsSupportRefresh: SUPPORT_BUFF_TYPES.some((type) => needsBuff(actor, type)),
         ...buffs
     };
 }
@@ -104,12 +127,17 @@ function snapshot(actor) {
 module.exports = {
     BUFF_DURATION_MS,
     REFRESH_THRESHOLD_MS,
+    ALL_BUFFS,
     NEWBIE_BUFFS,
+    SUPPORT_BUFFS,
+    applyBuff,
     applyNewbieBuff,
+    applySupportBuff,
     applyFullNewbieBlessing,
     isNewbieEligible,
     missingNewbieBuffs,
     needsNewbieRefresh,
+    needsBuff,
     remainingMs,
     snapshot
 };

--- a/src/GameServer/Bot/AI/BotBuffs.js
+++ b/src/GameServer/Bot/AI/BotBuffs.js
@@ -1,0 +1,115 @@
+const ServerResponse = invoke('GameServer/Network/Response');
+
+const BUFF_DURATION_MS = 20 * 60 * 1000;
+const REFRESH_THRESHOLD_MS = 2 * 60 * 1000;
+
+const NEWBIE_BUFFS = {
+    windwalk: { key: 'windWalk', id: 1204, name: 'Wind Walk' },
+    shield: { key: 'shield', id: 1040, name: 'Shield' },
+    haste: { key: 'haste', id: 1086, name: 'Haste' }
+};
+
+function ensureStore(actor) {
+    if (!actor.activeBuffs) {
+        actor.activeBuffs = {};
+    }
+    return actor.activeBuffs;
+}
+
+function now() {
+    return Date.now();
+}
+
+function isNewbieEligible(actor) {
+    return actor && actor.fetchLevel() <= 25 && actor.fetchKarma() === 0;
+}
+
+function remainingMs(actor, key) {
+    if (!actor?.activeBuffs?.[key]) return 0;
+    return Math.max(0, actor.activeBuffs[key] - now());
+}
+
+function missingNewbieBuffs(actor, thresholdMs = 0) {
+    return Object.values(NEWBIE_BUFFS)
+        .filter((buff) => remainingMs(actor, buff.key) <= thresholdMs)
+        .map((buff) => buff.key);
+}
+
+function needsNewbieRefresh(actor, thresholdMs = REFRESH_THRESHOLD_MS) {
+    return isNewbieEligible(actor) && missingNewbieBuffs(actor, thresholdMs).length > 0;
+}
+
+function refreshActorPackets(session, actor, Generics) {
+    const actorGenerics = Generics || invoke(path.actor);
+
+    actor.statusUpdateVitals(actor);
+    actorGenerics.calculateStats(session, actor);
+
+    session.dataSendToMe(ServerResponse.userInfo(actor));
+    session.dataSendToMe(ServerResponse.abnormalStatusUpdate.fromActor(actor));
+
+    if (session.accountId && String(session.accountId).startsWith('bot_')) {
+        session.dataSendToOthers(ServerResponse.charInfo(actor), actor);
+        session.dataSendToOthers(ServerResponse.relationChanged(actor), actor);
+    }
+}
+
+function applyNewbieBuff(session, actor, buffType, Generics) {
+    const buff = NEWBIE_BUFFS[buffType];
+    if (!buff || !actor) return null;
+
+    const store = ensureStore(actor);
+    store[buff.key] = now() + BUFF_DURATION_MS;
+    refreshActorPackets(session, actor, Generics);
+
+    return {
+        key: buff.key,
+        name: buff.name,
+        expiresAt: store[buff.key]
+    };
+}
+
+function applyFullNewbieBlessing(session, actor, Generics) {
+    if (!actor) return null;
+
+    const store = ensureStore(actor);
+    const expiresAt = now() + BUFF_DURATION_MS;
+    Object.values(NEWBIE_BUFFS).forEach((buff) => {
+        store[buff.key] = expiresAt;
+    });
+
+    actor.setHp(actor.fetchMaxHp());
+    actor.setMp(actor.fetchMaxMp());
+    refreshActorPackets(session, actor, Generics);
+
+    return {
+        buffs: Object.values(NEWBIE_BUFFS).map((buff) => buff.key),
+        expiresAt
+    };
+}
+
+function snapshot(actor) {
+    const buffs = {};
+    Object.values(NEWBIE_BUFFS).forEach((buff) => {
+        buffs[buff.key] = Math.round(remainingMs(actor, buff.key) / 1000);
+    });
+
+    return {
+        eligible: isNewbieEligible(actor),
+        needsRefresh: needsNewbieRefresh(actor),
+        ...buffs
+    };
+}
+
+module.exports = {
+    BUFF_DURATION_MS,
+    REFRESH_THRESHOLD_MS,
+    NEWBIE_BUFFS,
+    applyNewbieBuff,
+    applyFullNewbieBlessing,
+    isNewbieEligible,
+    missingNewbieBuffs,
+    needsNewbieRefresh,
+    remainingMs,
+    snapshot
+};

--- a/src/GameServer/Bot/AI/BotLootEtiquette.js
+++ b/src/GameServer/Bot/AI/BotLootEtiquette.js
@@ -107,28 +107,25 @@ function itemDemand(botSession, info) {
 
     if (info.weapon) {
         if (role === 'archer' && weaponType === 'Bow') addDemand(result, 6, 'archer weapon');
+        else if (role === 'dagger' && weaponType === 'Knife') addDemand(result, 6, 'dagger weapon');
         else if ((role === 'mage' || role === 'healer' || role === 'buffer') && /staff|wand|rod|spellbook|voodoo|scroll/.test(name)) addDemand(result, 6, 'caster weapon');
         else if (role === 'tank' && ['Sword', 'Blunt', 'Pole'].includes(weaponType)) addDemand(result, 4, 'frontline weapon');
-        else if (role === 'dps' && ['Knife', 'Sword', 'GreatSword', 'Pole', 'Blunt'].includes(weaponType)) addDemand(result, 4, 'damage weapon');
+        else if ((role === 'dps' || role === 'dagger') && ['Knife', 'Sword', 'GreatSword', 'Pole', 'Blunt'].includes(weaponType)) addDemand(result, 4, 'damage weapon');
     }
 
     if (info.armor) {
         if (role === 'tank' && ['Shield', 'Chain'].includes(armorType)) addDemand(result, 6, 'tank gear');
         else if ((role === 'mage' || role === 'healer' || role === 'buffer') && ['Fabric', 'Wear', 'Jewel'].includes(armorType)) addDemand(result, 4, 'caster gear');
-        else if ((role === 'archer' || role === 'dps') && ['Leather', 'Wear', 'Jewel'].includes(armorType)) addDemand(result, 4, 'combat gear');
+        else if ((role === 'archer' || role === 'dagger' || role === 'dps') && ['Leather', 'Wear', 'Jewel'].includes(armorType)) addDemand(result, 4, 'combat gear');
     }
 
     if (info.shot) {
         if (name.includes('spiritshot') && (role === 'mage' || role === 'healer' || role === 'buffer')) addDemand(result, 5, 'caster shots');
-        else if (name.includes('soulshot') && ['archer', 'tank', 'dps', 'dwarf', 'spoiler', 'crafter'].includes(role)) addDemand(result, 4, 'weapon shots');
+        else if (name.includes('soulshot') && ['archer', 'dagger', 'tank', 'dps'].includes(role)) addDemand(result, 4, 'weapon shots');
     }
 
     if (info.potion && (role === 'healer' || role === 'buffer' || role === 'tank')) {
         addDemand(result, 3, 'survival supplies');
-    }
-
-    if ((info.material || info.recipe) && BotRoles.valuesMaterial(role)) {
-        addDemand(result, info.recipe ? 6 : 5, info.recipe ? 'craft recipe' : 'craft material');
     }
 
     if (info.scroll && name.includes('enchant')) {

--- a/src/GameServer/Bot/AI/BotLootEtiquette.js
+++ b/src/GameServer/Bot/AI/BotLootEtiquette.js
@@ -107,23 +107,23 @@ function itemDemand(botSession, info) {
 
     if (info.weapon) {
         if (role === 'archer' && weaponType === 'Bow') addDemand(result, 6, 'archer weapon');
-        else if ((role === 'mage' || role === 'healer') && /staff|wand|rod|spellbook|voodoo|scroll/.test(name)) addDemand(result, 6, 'caster weapon');
+        else if ((role === 'mage' || role === 'healer' || role === 'buffer') && /staff|wand|rod|spellbook|voodoo|scroll/.test(name)) addDemand(result, 6, 'caster weapon');
         else if (role === 'tank' && ['Sword', 'Blunt', 'Pole'].includes(weaponType)) addDemand(result, 4, 'frontline weapon');
         else if (role === 'dps' && ['Knife', 'Sword', 'GreatSword', 'Pole', 'Blunt'].includes(weaponType)) addDemand(result, 4, 'damage weapon');
     }
 
     if (info.armor) {
         if (role === 'tank' && ['Shield', 'Chain'].includes(armorType)) addDemand(result, 6, 'tank gear');
-        else if ((role === 'mage' || role === 'healer') && ['Fabric', 'Wear', 'Jewel'].includes(armorType)) addDemand(result, 4, 'caster gear');
+        else if ((role === 'mage' || role === 'healer' || role === 'buffer') && ['Fabric', 'Wear', 'Jewel'].includes(armorType)) addDemand(result, 4, 'caster gear');
         else if ((role === 'archer' || role === 'dps') && ['Leather', 'Wear', 'Jewel'].includes(armorType)) addDemand(result, 4, 'combat gear');
     }
 
     if (info.shot) {
-        if (name.includes('spiritshot') && (role === 'mage' || role === 'healer')) addDemand(result, 5, 'caster shots');
+        if (name.includes('spiritshot') && (role === 'mage' || role === 'healer' || role === 'buffer')) addDemand(result, 5, 'caster shots');
         else if (name.includes('soulshot') && ['archer', 'tank', 'dps', 'dwarf', 'spoiler', 'crafter'].includes(role)) addDemand(result, 4, 'weapon shots');
     }
 
-    if (info.potion && (role === 'healer' || role === 'tank')) {
+    if (info.potion && (role === 'healer' || role === 'buffer' || role === 'tank')) {
         addDemand(result, 3, 'survival supplies');
     }
 

--- a/src/GameServer/Bot/AI/BotLootEtiquette.js
+++ b/src/GameServer/Bot/AI/BotLootEtiquette.js
@@ -1,6 +1,7 @@
 const DataCache = invoke('GameServer/DataCache');
 const SpeckMath = invoke('GameServer/SpeckMath');
 const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 
 const ADENA_ID = 57;
 const REQUEST_RANGE = 1600;
@@ -10,14 +11,6 @@ const PLAYER_REQUEST_COOLDOWN_MS = 90000;
 const IGNORE_PENALTY_RANGE = REQUEST_RANGE * 1.5;
 const MAX_PENDING_REQUESTS = 1;
 const MIN_DEMAND_SCORE = 3;
-
-const ROLE_CLASSES = {
-    healer: [15, 16, 17, 29, 30, 42, 43],
-    tank: [4, 5, 6, 19, 20, 32, 33],
-    archer: [8, 9, 22, 23, 35, 36, 37],
-    mage: [10, 11, 12, 13, 14, 25, 26, 27, 28, 29, 30, 38, 39, 40, 41, 42, 43, 49, 50, 51, 52],
-    dwarf: [53, 54, 55, 56, 57]
-};
 
 function now() {
     return Date.now();
@@ -97,15 +90,6 @@ function isNotable(info, amount) {
     return false;
 }
 
-function roleForClass(classId) {
-    if (ROLE_CLASSES.healer.includes(classId)) return 'healer';
-    if (ROLE_CLASSES.tank.includes(classId)) return 'tank';
-    if (ROLE_CLASSES.archer.includes(classId)) return 'archer';
-    if (ROLE_CLASSES.mage.includes(classId)) return 'mage';
-    if (ROLE_CLASSES.dwarf.includes(classId)) return 'dwarf';
-    return 'dps';
-}
-
 function addDemand(result, score, reason) {
     result.score += score;
     if (reason && !result.reasons.includes(reason)) {
@@ -116,7 +100,7 @@ function addDemand(result, score, reason) {
 function itemDemand(botSession, info) {
     const result = { score: 0, reasons: [] };
     const classId = botSession.actor.fetchClassId();
-    const role = roleForClass(classId);
+    const role = BotRoles.inferRole(classId);
     const name = info.name.toLowerCase();
     const weaponType = info.kind.replace('Weapon.', '');
     const armorType = info.kind.replace('Armor.', '');
@@ -136,14 +120,14 @@ function itemDemand(botSession, info) {
 
     if (info.shot) {
         if (name.includes('spiritshot') && (role === 'mage' || role === 'healer')) addDemand(result, 5, 'caster shots');
-        else if (name.includes('soulshot') && ['archer', 'tank', 'dps', 'dwarf'].includes(role)) addDemand(result, 4, 'weapon shots');
+        else if (name.includes('soulshot') && ['archer', 'tank', 'dps', 'dwarf', 'spoiler', 'crafter'].includes(role)) addDemand(result, 4, 'weapon shots');
     }
 
     if (info.potion && (role === 'healer' || role === 'tank')) {
         addDemand(result, 3, 'survival supplies');
     }
 
-    if ((info.material || info.recipe) && role === 'dwarf') {
+    if ((info.material || info.recipe) && BotRoles.valuesMaterial(role)) {
         addDemand(result, info.recipe ? 6 : 5, info.recipe ? 'craft recipe' : 'craft material');
     }
 

--- a/src/GameServer/Bot/AI/BotRoles.js
+++ b/src/GameServer/Bot/AI/BotRoles.js
@@ -1,0 +1,73 @@
+const ROLE_CLASSES = {
+    healer: [15, 16, 17, 29, 30, 42, 43],
+    tank: [4, 5, 6, 19, 20, 32, 33],
+    archer: [8, 9, 22, 23, 35, 36, 37],
+    mage: [10, 11, 12, 13, 14, 25, 26, 27, 28, 38, 39, 40, 41, 49, 50, 51, 52],
+    spoiler: [54, 55],
+    crafter: [56, 57],
+    dwarf: [53, 54, 55, 56, 57]
+};
+
+function classIdOf(value) {
+    if (typeof value === 'number') return value;
+    if (value && typeof value.fetchClassId === 'function') return value.fetchClassId();
+    return null;
+}
+
+function inferRole(value) {
+    const classId = classIdOf(value);
+    if (classId === null || classId === undefined) return 'dps';
+
+    if (ROLE_CLASSES.healer.includes(classId)) return 'healer';
+    if (ROLE_CLASSES.tank.includes(classId)) return 'tank';
+    if (ROLE_CLASSES.archer.includes(classId)) return 'archer';
+    if (ROLE_CLASSES.mage.includes(classId)) return 'mage';
+    if (ROLE_CLASSES.spoiler.includes(classId)) return 'spoiler';
+    if (ROLE_CLASSES.crafter.includes(classId)) return 'crafter';
+    if (ROLE_CLASSES.dwarf.includes(classId)) return 'dwarf';
+    return 'dps';
+}
+
+function isRole(value, role) {
+    const classId = classIdOf(value);
+    const classes = ROLE_CLASSES[role];
+    return !!classes && classes.includes(classId);
+}
+
+function isHealer(value) {
+    return isRole(value, 'healer');
+}
+
+function isTank(value) {
+    return isRole(value, 'tank');
+}
+
+function isRanged(roleOrActor) {
+    const role = typeof roleOrActor === 'string' ? roleOrActor : inferRole(roleOrActor);
+    return role === 'archer' || role === 'mage';
+}
+
+function valuesMaterial(role) {
+    return role === 'dwarf' || role === 'spoiler' || role === 'crafter';
+}
+
+function partyRoleStance(role) {
+    if (role === 'healer') return 'support';
+    if (role === 'tank') return 'protector';
+    if (role === 'archer' || role === 'mage') return 'ranged_assist';
+    if (role === 'spoiler') return 'spoil_assist';
+    if (role === 'crafter') return 'economic_support';
+    if (role === 'dwarf') return 'combat_support';
+    return 'assist';
+}
+
+module.exports = {
+    ROLE_CLASSES,
+    inferRole,
+    isRole,
+    isHealer,
+    isTank,
+    isRanged,
+    valuesMaterial,
+    partyRoleStance
+};

--- a/src/GameServer/Bot/AI/BotRoles.js
+++ b/src/GameServer/Bot/AI/BotRoles.js
@@ -2,11 +2,9 @@ const ROLE_CLASSES = {
     healer: [15, 16, 29, 30, 42, 43],
     buffer: [17, 49, 50, 51],
     tank: [4, 5, 6, 19, 20, 32, 33],
-    archer: [8, 9, 22, 23, 35, 36, 37],
-    mage: [10, 11, 12, 13, 14, 25, 26, 27, 28, 38, 39, 40, 41, 52],
-    spoiler: [54, 55],
-    crafter: [56, 57],
-    dwarf: [53, 54, 55, 56, 57]
+    dagger: [7, 8, 23, 35, 36],
+    archer: [9, 22, 24, 37],
+    mage: [10, 11, 12, 13, 14, 25, 26, 27, 28, 38, 39, 40, 41, 52]
 };
 
 function classIdOf(value) {
@@ -22,11 +20,9 @@ function inferRole(value) {
     if (ROLE_CLASSES.healer.includes(classId)) return 'healer';
     if (ROLE_CLASSES.buffer.includes(classId)) return 'buffer';
     if (ROLE_CLASSES.tank.includes(classId)) return 'tank';
+    if (ROLE_CLASSES.dagger.includes(classId)) return 'dagger';
     if (ROLE_CLASSES.archer.includes(classId)) return 'archer';
     if (ROLE_CLASSES.mage.includes(classId)) return 'mage';
-    if (ROLE_CLASSES.spoiler.includes(classId)) return 'spoiler';
-    if (ROLE_CLASSES.crafter.includes(classId)) return 'crafter';
-    if (ROLE_CLASSES.dwarf.includes(classId)) return 'dwarf';
     return 'dps';
 }
 
@@ -53,18 +49,12 @@ function isRanged(roleOrActor) {
     return role === 'archer' || role === 'mage';
 }
 
-function valuesMaterial(role) {
-    return role === 'dwarf' || role === 'spoiler' || role === 'crafter';
-}
-
 function partyRoleStance(role) {
     if (role === 'healer') return 'support';
     if (role === 'buffer') return 'buff_support';
     if (role === 'tank') return 'protector';
+    if (role === 'dagger') return 'flank_assist';
     if (role === 'archer' || role === 'mage') return 'ranged_assist';
-    if (role === 'spoiler') return 'spoil_assist';
-    if (role === 'crafter') return 'economic_support';
-    if (role === 'dwarf') return 'combat_support';
     return 'assist';
 }
 
@@ -76,6 +66,5 @@ module.exports = {
     isTank,
     canBuff,
     isRanged,
-    valuesMaterial,
     partyRoleStance
 };

--- a/src/GameServer/Bot/AI/BotRoles.js
+++ b/src/GameServer/Bot/AI/BotRoles.js
@@ -1,8 +1,9 @@
 const ROLE_CLASSES = {
-    healer: [15, 16, 17, 29, 30, 42, 43],
+    healer: [15, 16, 29, 30, 42, 43],
+    buffer: [17, 49, 50, 51],
     tank: [4, 5, 6, 19, 20, 32, 33],
     archer: [8, 9, 22, 23, 35, 36, 37],
-    mage: [10, 11, 12, 13, 14, 25, 26, 27, 28, 38, 39, 40, 41, 49, 50, 51, 52],
+    mage: [10, 11, 12, 13, 14, 25, 26, 27, 28, 38, 39, 40, 41, 52],
     spoiler: [54, 55],
     crafter: [56, 57],
     dwarf: [53, 54, 55, 56, 57]
@@ -19,6 +20,7 @@ function inferRole(value) {
     if (classId === null || classId === undefined) return 'dps';
 
     if (ROLE_CLASSES.healer.includes(classId)) return 'healer';
+    if (ROLE_CLASSES.buffer.includes(classId)) return 'buffer';
     if (ROLE_CLASSES.tank.includes(classId)) return 'tank';
     if (ROLE_CLASSES.archer.includes(classId)) return 'archer';
     if (ROLE_CLASSES.mage.includes(classId)) return 'mage';
@@ -42,6 +44,10 @@ function isTank(value) {
     return isRole(value, 'tank');
 }
 
+function canBuff(value) {
+    return isRole(value, 'buffer');
+}
+
 function isRanged(roleOrActor) {
     const role = typeof roleOrActor === 'string' ? roleOrActor : inferRole(roleOrActor);
     return role === 'archer' || role === 'mage';
@@ -53,6 +59,7 @@ function valuesMaterial(role) {
 
 function partyRoleStance(role) {
     if (role === 'healer') return 'support';
+    if (role === 'buffer') return 'buff_support';
     if (role === 'tank') return 'protector';
     if (role === 'archer' || role === 'mage') return 'ranged_assist';
     if (role === 'spoiler') return 'spoil_assist';
@@ -67,6 +74,7 @@ module.exports = {
     isRole,
     isHealer,
     isTank,
+    canBuff,
     isRanged,
     valuesMaterial,
     partyRoleStance

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -1,9 +1,4 @@
-const ROLE_CLASSES = {
-    healer: [15, 16, 17, 29, 30, 42, 43],
-    tank: [4, 5, 6, 19, 20, 32, 33],
-    archer: [8, 9, 22, 23, 35, 36, 37],
-    mage: [10, 11, 12, 13, 14, 15, 16, 17, 25, 26, 27, 28, 29, 30, 38, 39, 40, 41, 42, 43, 49, 50, 51, 52]
-};
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 
 function ratio(value, max) {
     if (!max) return 0;
@@ -62,15 +57,6 @@ function findTarget(session, bot) {
         type: 'unknown',
         id: session.currentTargetId
     };
-}
-
-function inferRole(bot) {
-    const classId = bot.fetchClassId();
-    if (ROLE_CLASSES.healer.includes(classId)) return 'healer';
-    if (ROLE_CLASSES.tank.includes(classId)) return 'tank';
-    if (ROLE_CLASSES.archer.includes(classId)) return 'archer';
-    if (ROLE_CLASSES.mage.includes(classId)) return 'mage';
-    return 'dps';
 }
 
 function inferIntent(session, bot, vitals, target) {
@@ -181,12 +167,15 @@ const BotStatus = {
             mpPct: ratio(bot.fetchMp(), bot.fetchMaxMp())
         };
 
+        const role = BotRoles.inferRole(bot);
         const target = findTarget(session, bot);
         const party = session.followPlayerSession && session.partyCompanion === true ? {
             leader: actorSummary(session.followPlayerSession.actor, bot),
-            role: inferRole(bot),
+            role,
             stance: session.botStay ? 'stay' : 'follow',
-            autoTaunt: session.autoTaunt !== false
+            roleStance: BotRoles.partyRoleStance(role),
+            autoTaunt: session.autoTaunt !== false,
+            decision: session.roleDecision || null
         } : null;
 
         const status = {
@@ -197,7 +186,8 @@ const BotStatus = {
             classId: bot.fetchClassId(),
             mode: session.plan || 'hunting',
             intent: undefined,
-            role: inferRole(bot),
+            role,
+            roleDecision: session.roleDecision || null,
             home: {
                 region: session.homeRegion || null,
                 visitor: !!session.visitor
@@ -238,12 +228,13 @@ const BotStatus = {
         const spot = status.spot && status.spot.name ? ` spot=${status.spot.name}` : '';
         const home = status.home && status.home.region ? ` home=${status.home.region}${status.home.visitor ? ':visitor' : ''}` : '';
         const social = status.social ? ` social=${status.social.playerName}:${status.social.relationship}/${status.social.trust}` : '';
+        const roleDecision = status.roleDecision ? ` decision=${status.roleDecision.action}/${status.roleDecision.reason}` : '';
         const blockers = status.blockers.length > 0 ? ` blockers=${status.blockers.join(',')}` : '';
 
-        return `${status.name}: mode=${status.mode} intent=${status.intent} role=${status.role}${home} hp=${hp}% mp=${mp}%${target}${spot}${social}${blockers}`;
+        return `${status.name}: mode=${status.mode} intent=${status.intent} role=${status.role}${home} hp=${hp}% mp=${mp}%${target}${spot}${social}${roleDecision}${blockers}`;
     }
 };
 
-BotStatus.ROLE_CLASSES = ROLE_CLASSES;
+BotStatus.ROLE_CLASSES = BotRoles.ROLE_CLASSES;
 
 module.exports = BotStatus;

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -1,4 +1,5 @@
 const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
+const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
 
 function ratio(value, max) {
     if (!max) return 0;
@@ -202,6 +203,7 @@ const BotStatus = {
                 towards: bot.state.fetchTowards() || false,
                 stuckTicks: session.stuckTicks || 0
             },
+            buffs: BotBuffs.snapshot(bot),
             timers: {
                 deathStartedAt: session.deathTimerStart || null,
                 fleeStartedAt: session.fleeStart || null,
@@ -229,9 +231,10 @@ const BotStatus = {
         const home = status.home && status.home.region ? ` home=${status.home.region}${status.home.visitor ? ':visitor' : ''}` : '';
         const social = status.social ? ` social=${status.social.playerName}:${status.social.relationship}/${status.social.trust}` : '';
         const roleDecision = status.roleDecision ? ` decision=${status.roleDecision.action}/${status.roleDecision.reason}` : '';
+        const buffs = status.buffs?.needsRefresh ? ' buffs=refresh' : '';
         const blockers = status.blockers.length > 0 ? ` blockers=${status.blockers.join(',')}` : '';
 
-        return `${status.name}: mode=${status.mode} intent=${status.intent} role=${status.role}${home} hp=${hp}% mp=${mp}%${target}${spot}${social}${roleDecision}${blockers}`;
+        return `${status.name}: mode=${status.mode} intent=${status.intent} role=${status.role}${home} hp=${hp}% mp=${mp}%${target}${spot}${social}${roleDecision}${buffs}${blockers}`;
     }
 };
 

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -4,6 +4,8 @@ const ServerResponse = invoke('GameServer/Network/Response');
 const BotRoles       = invoke('GameServer/Bot/AI/BotRoles');
 const BotBuffs       = invoke('GameServer/Bot/AI/BotBuffs');
 
+const SUPPORT_BUFF_MP_COST = 20;
+
 function ratio(value, max) {
     if (!max) return 0;
     return Math.max(0, Math.min(1, value / max));
@@ -92,6 +94,13 @@ function leaderAggroCount(player) {
         .length;
 }
 
+function unsafeSupportMoment(session, bot, player, activeMobs) {
+    return !!session.currentTargetId ||
+        !!player.fetchDestId() ||
+        activeMobs > 0 ||
+        isBusy(bot);
+}
+
 function pullBlockReason(session, botVitals, leaderVitals, activeMobs) {
     if (session.autoTaunt === false) return 'manual_pull_off';
     if (session.botStay) return 'stay_order';
@@ -105,6 +114,7 @@ function pullBlockReason(session, botVitals, leaderVitals, activeMobs) {
 
 function assistActionForRole(role) {
     if (role === 'archer' || role === 'mage') return 'ranged_assist';
+    if (role === 'buffer') return 'buff_support';
     if (role === 'spoiler') return 'spoil_target';
     if (role === 'crafter') return 'assist_leader';
     return 'assist_leader';
@@ -203,10 +213,7 @@ module.exports = {
 
         const buffsNeedRefresh = BotBuffs.needsNewbieRefresh(bot);
         if (buffsNeedRefresh) {
-            const unsafeToRefresh = !!session.currentTargetId ||
-                !!player.fetchDestId() ||
-                leaderAggroCount(player) > 0 ||
-                isBusy(bot);
+            const unsafeToRefresh = unsafeSupportMoment(session, bot, player, leaderAggroCount(player));
 
             if (unsafeToRefresh) {
                 recordRoleDecision(session, bot, 'refresh_buffs', 'wait_for_safe_moment', {
@@ -236,6 +243,38 @@ module.exports = {
             }
         }
 
+        if (!acted && BotRoles.canBuff(bot) && BotBuffs.needsBuff(player, 'might')) {
+            const activeMobs = leaderAggroCount(player);
+            if (unsafeSupportMoment(session, bot, player, activeMobs)) {
+                recordRoleDecision(session, bot, 'buff_party', 'wait_for_safe_moment', {
+                    buff: 'might',
+                    targetId: player.fetchId(),
+                    activeMobs
+                });
+                keepRoleDecision = true;
+            } else if (bot.fetchMp() < SUPPORT_BUFF_MP_COST || botVitals.mpRatio < 0.35) {
+                recordRoleDecision(session, bot, 'save_mp', 'low_mp_for_buff', {
+                    buff: 'might',
+                    targetId: player.fetchId()
+                });
+                keepRoleDecision = true;
+            } else {
+                const result = BotBuffs.applySupportBuff(playerSession, player, 'might', Generics);
+                if (result) {
+                    acted = true;
+                    bot.setMp(Math.max(0, bot.fetchMp() - SUPPORT_BUFF_MP_COST));
+                    bot.statusUpdateVitals(bot);
+                    recordRoleDecision(session, bot, 'buff_party', 'might', {
+                        buff: 'might',
+                        targetId: player.fetchId()
+                    });
+                    if (Math.random() < 0.30) {
+                        BotAI.say(session, "Might on " + player.fetchName() + ". Hit harder!");
+                    }
+                }
+            }
+        }
+
         if (Math.random() < 0.015) {
             const chatterPhrases = [
                 "Nice combat, leader!",
@@ -257,6 +296,11 @@ module.exports = {
                     "I will take the aggro, stay behind me!",
                     "Aggression is ready! Pulling them off you.",
                     "I'm tanking this beast!"
+                ],
+                buffer: [
+                    "I'll keep the party buffed.",
+                    "Might is ready when we have a safe moment.",
+                    "Save a little mana before the next pull."
                 ],
                 spoiler: [
                     "I'll watch for spoil targets.",

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -115,15 +115,21 @@ function pullBlockReason(session, botVitals, leaderVitals, activeMobs) {
 function assistActionForRole(role) {
     if (role === 'archer' || role === 'mage') return 'ranged_assist';
     if (role === 'buffer') return 'buff_support';
-    if (role === 'spoiler') return 'spoil_target';
-    if (role === 'crafter') return 'assist_leader';
+    if (role === 'dagger') return 'flank_target';
     return 'assist_leader';
 }
 
 function assistReasonForRole(role) {
-    if (role === 'spoiler') return 'leader_target';
-    if (role === 'crafter') return 'economic_role_combat';
+    if (role === 'dagger') return 'close_assist';
     return 'leader_target';
+}
+
+function supportBuffPhrase(buffType, playerName) {
+    if (buffType === 'might') return "Might on " + playerName + ". Hit harder!";
+    if (buffType === 'shield') return "Shield on " + playerName + ". Stay sturdy.";
+    if (buffType === 'haste') return "Haste on " + playerName + ". Keep the pressure up!";
+    if (buffType === 'windwalk') return "Wind Walk on " + playerName + ". Move fast.";
+    return "Buffing " + playerName + ".";
 }
 
 module.exports = {
@@ -243,33 +249,34 @@ module.exports = {
             }
         }
 
-        if (!acted && BotRoles.canBuff(bot) && BotBuffs.needsBuff(player, 'might')) {
+        const nextSupportBuff = BotBuffs.nextSupportBuff(player);
+        if (!acted && BotRoles.canBuff(bot) && nextSupportBuff) {
             const activeMobs = leaderAggroCount(player);
             if (unsafeSupportMoment(session, bot, player, activeMobs)) {
                 recordRoleDecision(session, bot, 'buff_party', 'wait_for_safe_moment', {
-                    buff: 'might',
+                    buff: nextSupportBuff,
                     targetId: player.fetchId(),
                     activeMobs
                 });
                 keepRoleDecision = true;
             } else if (bot.fetchMp() < SUPPORT_BUFF_MP_COST || botVitals.mpRatio < 0.35) {
                 recordRoleDecision(session, bot, 'save_mp', 'low_mp_for_buff', {
-                    buff: 'might',
+                    buff: nextSupportBuff,
                     targetId: player.fetchId()
                 });
                 keepRoleDecision = true;
             } else {
-                const result = BotBuffs.applySupportBuff(playerSession, player, 'might', Generics);
+                const result = BotBuffs.applySupportBuff(playerSession, player, nextSupportBuff, Generics);
                 if (result) {
                     acted = true;
                     bot.setMp(Math.max(0, bot.fetchMp() - SUPPORT_BUFF_MP_COST));
                     bot.statusUpdateVitals(bot);
-                    recordRoleDecision(session, bot, 'buff_party', 'might', {
-                        buff: 'might',
+                    recordRoleDecision(session, bot, 'buff_party', nextSupportBuff, {
+                        buff: nextSupportBuff,
                         targetId: player.fetchId()
                     });
                     if (Math.random() < 0.30) {
-                        BotAI.say(session, "Might on " + player.fetchName() + ". Hit harder!");
+                        BotAI.say(session, supportBuffPhrase(nextSupportBuff, player.fetchName()));
                     }
                 }
             }
@@ -299,16 +306,13 @@ module.exports = {
                 ],
                 buffer: [
                     "I'll keep the party buffed.",
-                    "Might is ready when we have a safe moment.",
+                    "Buffs are ready when we have a safe moment.",
                     "Save a little mana before the next pull."
                 ],
-                spoiler: [
-                    "I'll watch for spoil targets.",
-                    "Leave useful materials to me if they drop."
-                ],
-                crafter: [
-                    "I am better with recipes than reckless pulls.",
-                    "If materials drop, I can make use of them."
+                dagger: [
+                    "I'll stay close and hit their weak side.",
+                    "Mark a target and I'll get in close.",
+                    "No bow tricks from me, just blades."
                 ]
             };
             const pool = chatterPhrases.concat(classPhrases[role] || []);

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -2,6 +2,7 @@ const SpeckMath      = invoke('GameServer/SpeckMath');
 const World          = invoke('GameServer/World/World');
 const ServerResponse = invoke('GameServer/Network/Response');
 const BotRoles       = invoke('GameServer/Bot/AI/BotRoles');
+const BotBuffs       = invoke('GameServer/Bot/AI/BotBuffs');
 
 function ratio(value, max) {
     if (!max) return 0;
@@ -197,6 +198,44 @@ module.exports = {
             return;
         }
 
+        let acted = false;
+        let keepRoleDecision = false;
+
+        const buffsNeedRefresh = BotBuffs.needsNewbieRefresh(bot);
+        if (buffsNeedRefresh) {
+            const unsafeToRefresh = !!session.currentTargetId ||
+                !!player.fetchDestId() ||
+                leaderAggroCount(player) > 0 ||
+                isBusy(bot);
+
+            if (unsafeToRefresh) {
+                recordRoleDecision(session, bot, 'refresh_buffs', 'wait_for_safe_moment', {
+                    missingBuffs: BotBuffs.missingNewbieBuffs(bot, BotBuffs.REFRESH_THRESHOLD_MS)
+                });
+                keepRoleDecision = true;
+            } else {
+                session.preBuffLocation = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
+                session.preBuffPlan = 'following';
+                session.resumeAfterBuff = {
+                    plan: 'following',
+                    followPlayerSession: playerSession,
+                    partyCompanion: true,
+                    botStay: session.botStay === true,
+                    stayLocation: session.stayLocation ? { ...session.stayLocation } : null,
+                    role
+                };
+                session.plan = 'getting_buffed';
+                session.currentTargetId = undefined;
+                bot.unselect();
+                bot.automation.abortAll(bot);
+                recordRoleDecision(session, bot, 'refresh_buffs', 'newbie_blessing', {
+                    missingBuffs: BotBuffs.missingNewbieBuffs(bot, BotBuffs.REFRESH_THRESHOLD_MS)
+                });
+                BotAI.say(session, "My newbie buffs are fading. Refreshing quickly, then I'll return.");
+                return;
+            }
+        }
+
         if (Math.random() < 0.015) {
             const chatterPhrases = [
                 "Nice combat, leader!",
@@ -232,9 +271,6 @@ module.exports = {
             const text = pool[Math.floor(Math.random() * pool.length)];
             BotAI.say(session, text);
         }
-
-        let acted = false;
-        let keepRoleDecision = false;
 
         if (role === 'healer') {
             const skill = healSkill(bot);

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -1,6 +1,119 @@
 const SpeckMath      = invoke('GameServer/SpeckMath');
 const World          = invoke('GameServer/World/World');
 const ServerResponse = invoke('GameServer/Network/Response');
+const BotRoles       = invoke('GameServer/Bot/AI/BotRoles');
+
+function ratio(value, max) {
+    if (!max) return 0;
+    return Math.max(0, Math.min(1, value / max));
+}
+
+function isBusy(bot) {
+    return !!(bot.state.fetchTowards() || bot.state.fetchHits() || bot.state.fetchCasts());
+}
+
+function point(actor) {
+    return new SpeckMath.Point3D(actor.fetchLocX(), actor.fetchLocY(), actor.fetchLocZ());
+}
+
+function ensureSkill(bot, selfId, data) {
+    let skill = bot.skillset.fetchSkill(selfId);
+    if (skill) return skill;
+
+    const SkillModel = invoke('GameServer/Model/Skill');
+    skill = new SkillModel({
+        selfId,
+        hp: 0,
+        passive: false,
+        ...data
+    });
+    bot.skillset.skills.push(skill);
+    return skill;
+}
+
+function healSkill(bot) {
+    return ensureSkill(bot, 1011, {
+        name: "Heal",
+        level: 1,
+        mp: 15,
+        hitTime: 1500,
+        reuse: 1000,
+        power: 20,
+        distance: 600
+    });
+}
+
+function aggressionSkill(bot) {
+    return ensureSkill(bot, 28, {
+        name: "Aggression",
+        level: 1,
+        mp: 10,
+        hitTime: 1000,
+        reuse: 3000,
+        power: 0,
+        distance: 600
+    });
+}
+
+function recordRoleDecision(session, bot, action, reason, extra = {}) {
+    const role = BotRoles.inferRole(bot);
+    const previous = session.roleDecision;
+    const current = {
+        role,
+        action,
+        reason,
+        at: Date.now(),
+        ...extra
+    };
+
+    session.roleDecision = current;
+
+    const signature = `${role}:${action}:${reason}`;
+    const shouldLog = !previous ||
+        `${previous.role}:${previous.action}:${previous.reason}` !== signature ||
+        current.at - (session.lastRoleDecisionLogAt || 0) > 10000;
+
+    if (shouldLog) {
+        session.lastRoleDecisionLogAt = current.at;
+        console.info("BotRole :: %s %s/%s (%s)", bot.fetchName(), action, reason, role);
+    }
+}
+
+function castSkillOn(session, bot, Generics, target, skillId, ctrl) {
+    session.currentTargetId = target.fetchId();
+    bot.select({ id: target.fetchId() });
+    Generics.skillExec(session, bot, { id: target.fetchId(), selfId: skillId, ctrl });
+}
+
+function leaderAggroCount(player) {
+    return World.fetchNpcsInRadius(player.fetchLocX(), player.fetchLocY(), 900)
+        .filter((npc) => npc.fetchAttackable() && !npc.isDead() && npc.fetchDestId() === player.fetchId())
+        .length;
+}
+
+function pullBlockReason(session, botVitals, leaderVitals, activeMobs) {
+    if (session.autoTaunt === false) return 'manual_pull_off';
+    if (session.botStay) return 'stay_order';
+    if (session.currentTargetId) return 'already_assisting';
+    if (leaderVitals.hpRatio < 0.65) return 'leader_low_hp';
+    if (botVitals.hpRatio < 0.55) return 'tank_low_hp';
+    if (botVitals.mpRatio < 0.25) return 'save_mp';
+    if (activeMobs >= 2) return 'active_mobs';
+    return null;
+}
+
+function assistActionForRole(role) {
+    if (role === 'archer' || role === 'mage') return 'ranged_assist';
+    if (role === 'spoiler') return 'spoil_target';
+    if (role === 'crafter') return 'assist_leader';
+    return 'assist_leader';
+}
+
+function assistReasonForRole(role) {
+    if (role === 'spoiler') return 'leader_target';
+    if (role === 'crafter') return 'economic_role_combat';
+    return 'leader_target';
+}
 
 module.exports = {
     tick(session, bot, Generics, BotAI) {
@@ -8,26 +121,28 @@ module.exports = {
         if (session.partyCompanion !== true) {
             session.plan = 'hunting';
             session.followPlayerSession = null;
+            session.roleDecision = null;
             return;
         }
 
         if (!playerSession || !playerSession.actor || !playerSession.actor.fetchIsOnline()) {
             session.plan = 'hunting';
+            session.roleDecision = null;
             BotAI.say(session, "My companion has disconnected. Heading back to hunt.");
             return;
         }
 
         const player = playerSession.actor;
-        const distance = new SpeckMath.Point3D(bot.fetchLocX(), bot.fetchLocY(), bot.fetchLocZ())
-            .distance(new SpeckMath.Point3D(player.fetchLocX(), player.fetchLocY(), player.fetchLocZ()));
+        const role = BotRoles.inferRole(bot);
+        const distance = point(bot).distance(point(player));
 
         if (distance > 3500) {
             session.plan = 'hunting';
+            session.roleDecision = null;
             BotAI.say(session, "You ran too far away! I'm going back to hunt on my own.");
             return;
         }
 
-        // 1.2 Stuck Detection & Auto-Teleport (Summon) for Companion
         const currentLoc = { x: bot.fetchLocX(), y: bot.fetchLocY() };
         if (!session.lastTickLoc) {
             session.lastTickLoc = currentLoc;
@@ -44,9 +159,9 @@ module.exports = {
             session.stuckTicks = 0;
         }
 
-        // If stuck for 3 ticks (~3-4 seconds) OR if too far behind (> 1000 units)
         if (session.stuckTicks >= 3 || distance > 1000) {
             session.stuckTicks = 0;
+            recordRoleDecision(session, bot, 'follow_leader', distance > 1000 ? 'catch_up' : 'unstuck');
             const TeleportTo = invoke('GameServer/Actor/Generics/TeleportTo');
             if (TeleportTo && typeof TeleportTo === 'function') {
                 const targetLoc = {
@@ -62,24 +177,26 @@ module.exports = {
             return;
         }
 
-        // 1. HP/MP resting check for companion bots
-        const hpRatio = bot.fetchHp() / bot.fetchMaxHp();
-        const mpRatio = bot.fetchMp() / bot.fetchMaxMp();
-        if (hpRatio < 0.30 || mpRatio < 0.15) {
+        const botVitals = {
+            hpRatio: ratio(bot.fetchHp(), bot.fetchMaxHp()),
+            mpRatio: ratio(bot.fetchMp(), bot.fetchMaxMp())
+        };
+        const leaderVitals = {
+            hpRatio: ratio(player.fetchHp(), player.fetchMaxHp()),
+            mpRatio: ratio(player.fetchMp(), player.fetchMaxMp())
+        };
+
+        if (botVitals.hpRatio < 0.30 || botVitals.mpRatio < 0.15) {
             session.plan = 'resting';
             session.currentTargetId = undefined;
             bot.unselect();
             bot.state.setSeated(true);
             session.dataSendToOthers(ServerResponse.sitAndStand(bot), bot);
+            recordRoleDecision(session, bot, botVitals.hpRatio < 0.30 ? 'recover_hp' : 'save_mp', 'resting');
             BotAI.say(session, "Phew! My HP/MP is low. Sitting down to recover.");
             return;
         }
 
-        const classId = bot.fetchClassId();
-        const HEALER_CLASSES = [15, 16, 17, 29, 30, 42, 43];
-        const TANK_CLASSES = [4, 5, 6, 19, 20, 32, 33];
-
-        // Periodic party chatter (e.g. 1.5% chance per tick)
         if (Math.random() < 0.015) {
             const chatterPhrases = [
                 "Nice combat, leader!",
@@ -101,175 +218,117 @@ module.exports = {
                     "I will take the aggro, stay behind me!",
                     "Aggression is ready! Pulling them off you.",
                     "I'm tanking this beast!"
+                ],
+                spoiler: [
+                    "I'll watch for spoil targets.",
+                    "Leave useful materials to me if they drop."
+                ],
+                crafter: [
+                    "I am better with recipes than reckless pulls.",
+                    "If materials drop, I can make use of them."
                 ]
             };
-            let pool = chatterPhrases;
-            if (HEALER_CLASSES.includes(classId)) {
-                pool = pool.concat(classPhrases.healer);
-            } else if (TANK_CLASSES.includes(classId)) {
-                pool = pool.concat(classPhrases.tank);
-            }
+            const pool = chatterPhrases.concat(classPhrases[role] || []);
             const text = pool[Math.floor(Math.random() * pool.length)];
             BotAI.say(session, text);
         }
 
         let acted = false;
+        let keepRoleDecision = false;
 
-        // 2. Execute Healer Role: Heal leader if HP < 70%, heal self if HP < 60%
-        if (HEALER_CLASSES.includes(classId)) {
-            const leaderHpRatio = player.fetchHp() / player.fetchMaxHp();
-            if (leaderHpRatio < 0.70) {
-                const SkillModel = invoke('GameServer/Model/Skill');
-                let skill = bot.skillset.fetchSkill(1011);
-                if (!skill) {
-                    skill = new SkillModel({
-                        selfId: 1011,
-                        name: "Heal",
-                        level: 1,
-                        hp: 0,
-                        mp: 15,
-                        hitTime: 1500,
-                        reuse: 1000,
-                        power: 20,
-                        distance: 600,
-                        passive: false
-                    });
-                    bot.skillset.skills.push(skill);
+        if (role === 'healer') {
+            const skill = healSkill(bot);
+            const canCast = bot.fetchMp() >= skill.fetchConsumedMp() && !isBusy(bot);
+
+            if (leaderVitals.hpRatio < 0.45 && canCast) {
+                acted = true;
+                recordRoleDecision(session, bot, 'heal_leader', 'emergency_heal', { targetId: player.fetchId() });
+                castSkillOn(session, bot, Generics, player, 1011, false);
+                if (Math.random() < 0.15) {
+                    BotAI.say(session, "Emergency heal on " + player.fetchName() + "!");
                 }
-                if (bot.fetchMp() >= skill.fetchConsumedMp()) {
-                    acted = true;
-                    if (!(bot.state.fetchTowards() || bot.state.fetchHits() || bot.state.fetchCasts())) {
-                        session.currentTargetId = player.fetchId();
-                        bot.select({ id: player.fetchId() });
-                        Generics.skillExec(session, bot, { id: player.fetchId(), selfId: 1011, ctrl: false });
-                        if (Math.random() < 0.15) {
-                            BotAI.say(session, "Healing you, " + player.fetchName() + "!");
-                        }
-                    }
+            } else if (leaderVitals.hpRatio < 0.70 && botVitals.mpRatio >= 0.35 && canCast) {
+                acted = true;
+                recordRoleDecision(session, bot, 'heal_leader', 'top_off', { targetId: player.fetchId() });
+                castSkillOn(session, bot, Generics, player, 1011, false);
+                if (Math.random() < 0.15) {
+                    BotAI.say(session, "Healing you, " + player.fetchName() + "!");
                 }
-            } else if (hpRatio < 0.60) {
-                const SkillModel = invoke('GameServer/Model/Skill');
-                let skill = bot.skillset.fetchSkill(1011);
-                if (!skill) {
-                    skill = new SkillModel({
-                        selfId: 1011,
-                        name: "Heal",
-                        level: 1,
-                        hp: 0,
-                        mp: 15,
-                        hitTime: 1500,
-                        reuse: 1000,
-                        power: 20,
-                        distance: 600,
-                        passive: false
-                    });
-                    bot.skillset.skills.push(skill);
+            } else if (leaderVitals.hpRatio < 0.70 && botVitals.mpRatio < 0.35) {
+                recordRoleDecision(session, bot, 'save_mp', leaderVitals.hpRatio < 0.45 ? 'low_mp_emergency' : 'leader_not_critical');
+                keepRoleDecision = true;
+            } else if (botVitals.hpRatio < 0.55 && botVitals.mpRatio >= 0.25 && canCast) {
+                acted = true;
+                recordRoleDecision(session, bot, 'heal_self', 'self_preservation', { targetId: bot.fetchId() });
+                castSkillOn(session, bot, Generics, bot, 1011, false);
+                if (Math.random() < 0.15) {
+                    BotAI.say(session, "Healing myself!");
                 }
-                if (bot.fetchMp() >= skill.fetchConsumedMp()) {
-                    acted = true;
-                    if (!(bot.state.fetchTowards() || bot.state.fetchHits() || bot.state.fetchCasts())) {
-                        session.currentTargetId = bot.fetchId();
-                        bot.select({ id: bot.fetchId() });
-                        Generics.skillExec(session, bot, { id: bot.fetchId(), selfId: 1011, ctrl: false });
-                        if (Math.random() < 0.15) {
-                            BotAI.say(session, "Healing myself!");
-                        }
-                    }
-                }
+            } else if (botVitals.mpRatio < 0.25) {
+                recordRoleDecision(session, bot, 'save_mp', 'low_mp');
+                keepRoleDecision = true;
             }
         }
 
-        // 3. Execute Tank Role: Aggression on mobs attacking the leader
-        if (!acted && TANK_CLASSES.includes(classId)) {
+        if (!acted && role === 'tank') {
             const nearbyNpcs = World.fetchNpcsInRadius(bot.fetchLocX(), bot.fetchLocY(), 800);
-            let monsterToAggro = null;
-            for (const npc of nearbyNpcs) {
-                if (npc.fetchAttackable() && !npc.isDead() && npc.fetchDestId() === player.fetchId()) {
-                    monsterToAggro = npc;
-                    break;
-                }
-            }
+            const monsterToAggro = nearbyNpcs.find((npc) => npc.fetchAttackable() && !npc.isDead() && npc.fetchDestId() === player.fetchId());
 
             if (monsterToAggro) {
-                const SkillModel = invoke('GameServer/Model/Skill');
-                let skill = bot.skillset.fetchSkill(28);
-                if (!skill) {
-                    skill = new SkillModel({
-                        selfId: 28,
-                        name: "Aggression",
-                        level: 1,
-                        hp: 0,
-                        mp: 10,
-                        hitTime: 1000,
-                        reuse: 3000,
-                        power: 0,
-                        distance: 600,
-                        passive: false
-                    });
-                    bot.skillset.skills.push(skill);
-                }
-                if (bot.fetchMp() >= skill.fetchConsumedMp()) {
+                const skill = aggressionSkill(bot);
+                if (bot.fetchMp() >= skill.fetchConsumedMp() && !isBusy(bot)) {
                     acted = true;
-                    if (!(bot.state.fetchTowards() || bot.state.fetchHits() || bot.state.fetchCasts())) {
-                        session.currentTargetId = monsterToAggro.fetchId();
-                        bot.select({ id: monsterToAggro.fetchId() });
-                        Generics.skillExec(session, bot, { id: monsterToAggro.fetchId(), selfId: 28, ctrl: true });
-                        if (Math.random() < 0.20) {
-                            BotAI.say(session, "Hey, " + monsterToAggro.fetchName() + "! Attack me instead!");
+                    recordRoleDecision(session, bot, 'protect_leader', 'leader_targeted', { targetId: monsterToAggro.fetchId() });
+                    castSkillOn(session, bot, Generics, monsterToAggro, 28, true);
+                    if (Math.random() < 0.20) {
+                        BotAI.say(session, "Hey, " + monsterToAggro.fetchName() + "! Attack me instead!");
+                    }
+                } else if (botVitals.mpRatio < 0.25) {
+                    recordRoleDecision(session, bot, 'save_mp', 'low_mp_for_taunt');
+                    keepRoleDecision = true;
+                }
+            }
+        }
+
+        if (!acted && role === 'tank') {
+            const activeMobs = leaderAggroCount(player);
+            const blockReason = pullBlockReason(session, botVitals, leaderVitals, activeMobs);
+
+            if (blockReason) {
+                recordRoleDecision(session, bot, 'avoid_overpull', blockReason, { activeMobs });
+                keepRoleDecision = true;
+            } else {
+                const nearbyNpcs = World.fetchNpcsInRadius(player.fetchLocX(), player.fetchLocY(), 900);
+                let targetMonster = null;
+                let closestDist = 900;
+
+                for (const npc of nearbyNpcs) {
+                    if (npc.fetchAttackable() && !npc.isDead() && npc.fetchDestId() === undefined) {
+                        const distToBot = point(bot).distance(point(npc));
+                        if (distToBot < closestDist) {
+                            closestDist = distToBot;
+                            targetMonster = npc;
+                        }
+                    }
+                }
+
+                if (targetMonster) {
+                    const skill = aggressionSkill(bot);
+                    if (bot.fetchMp() >= skill.fetchConsumedMp() && !isBusy(bot)) {
+                        acted = true;
+                        recordRoleDecision(session, bot, 'pull_target', 'safe_pull', {
+                            targetId: targetMonster.fetchId(),
+                            activeMobs
+                        });
+                        castSkillOn(session, bot, Generics, targetMonster, 28, true);
+                        if (Math.random() < 0.30) {
+                            BotAI.say(session, "Pulling " + targetMonster.fetchName() + " to the group!");
                         }
                     }
                 }
             }
         }
 
-        // 3.5 Execute Tank Pulling if out of combat, following, and autoTaunt is enabled
-        if (!acted && !session.currentTargetId && !session.botStay && TANK_CLASSES.includes(classId) && session.autoTaunt !== false) {
-            const nearbyNpcs = World.fetchNpcsInRadius(player.fetchLocX(), player.fetchLocY(), 1200);
-            let targetMonster = null;
-            let closestDist = 1200;
-
-            for (const npc of nearbyNpcs) {
-                if (npc.fetchAttackable() && !npc.isDead() && npc.fetchDestId() === undefined) {
-                    const distToBot = new SpeckMath.Point3D(bot.fetchLocX(), bot.fetchLocY(), bot.fetchLocZ())
-                        .distance(new SpeckMath.Point3D(npc.fetchLocX(), npc.fetchLocY(), npc.fetchLocZ()));
-                    if (distToBot < closestDist) {
-                        closestDist = distToBot;
-                        targetMonster = npc;
-                    }
-                }
-            }
-
-            if (targetMonster) {
-                const SkillModel = invoke('GameServer/Model/Skill');
-                let skill = bot.skillset.fetchSkill(28);
-                if (!skill) {
-                    skill = new SkillModel({
-                        selfId: 28,
-                        name: "Aggression",
-                        level: 1,
-                        hp: 0,
-                        mp: 10,
-                        hitTime: 1000,
-                        reuse: 3000,
-                        power: 0,
-                        distance: 600,
-                        passive: false
-                    });
-                    bot.skillset.skills.push(skill);
-                }
-                if (bot.fetchMp() >= skill.fetchConsumedMp()) {
-                    acted = true;
-                    session.currentTargetId = targetMonster.fetchId();
-                    bot.select({ id: targetMonster.fetchId() });
-                    Generics.skillExec(session, bot, { id: targetMonster.fetchId(), selfId: 28, ctrl: true });
-                    if (Math.random() < 0.30) {
-                        BotAI.say(session, "Pulling " + targetMonster.fetchName() + " to the group!");
-                    }
-                }
-            }
-        }
-
-        // 4. Execute Combat Support (DPS / Assist)
         if (!acted) {
             const playerTargetId = player.fetchDestId();
             if (playerTargetId && playerTargetId !== bot.fetchId() && playerTargetId !== player.fetchId()) {
@@ -282,23 +341,24 @@ module.exports = {
                     const isAttackablePvPTarget = user.fetchKarma() > 0 || user.fetchPvpFlag() > 0;
 
                     if (!user.state.fetchDead() && !targetIsTeammate && isAttackablePvPTarget) {
-                        // Stay post validation: restrict target engagement
                         if (session.botStay && session.stayLocation) {
                             const stayDist = new SpeckMath.Point3D(session.stayLocation.locX, session.stayLocation.locY, session.stayLocation.locZ)
                                 .distance(new SpeckMath.Point3D(user.fetchLocX(), user.fetchLocY(), user.fetchLocZ()));
                             if (stayDist > 900) {
-                                return; // Too far from post
+                                recordRoleDecision(session, bot, 'hold_position', 'stay_order');
+                                return;
                             }
                         }
 
                         if (session.currentTargetId !== playerTargetId) {
                             session.currentTargetId = playerTargetId;
                             bot.select({ id: playerTargetId });
+                            recordRoleDecision(session, bot, assistActionForRole(role), 'pvp_target', { targetId: playerTargetId });
                             if (Math.random() < 0.20) {
                                 BotAI.say(session, "Assisting you in PvP! Attacking " + user.fetchName() + "!");
                             }
                         }
-                        if (bot.state.fetchTowards() || bot.state.fetchHits() || bot.state.fetchCasts()) {
+                        if (isBusy(bot)) {
                             return;
                         }
                         BotAI.executePvPCombat(session, bot, user, Generics);
@@ -309,23 +369,24 @@ module.exports = {
                 }).catch(() => {
                     World.fetchNpc(playerTargetId).then((npc) => {
                         if (npc.fetchAttackable() && !npc.isDead()) {
-                            // Stay post validation: restrict target engagement
                             if (session.botStay && session.stayLocation) {
                                 const stayDist = new SpeckMath.Point3D(session.stayLocation.locX, session.stayLocation.locY, session.stayLocation.locZ)
                                     .distance(new SpeckMath.Point3D(npc.fetchLocX(), npc.fetchLocY(), npc.fetchLocZ()));
                                 if (stayDist > 900) {
-                                    return; // Too far from post
+                                    recordRoleDecision(session, bot, 'hold_position', 'stay_order');
+                                    return;
                                 }
                             }
 
                             if (session.currentTargetId !== playerTargetId) {
                                 session.currentTargetId = playerTargetId;
                                 bot.select({ id: playerTargetId });
+                                recordRoleDecision(session, bot, assistActionForRole(role), assistReasonForRole(role), { targetId: playerTargetId });
                                 if (Math.random() < 0.20) {
                                     BotAI.say(session, "Assisting you! Smashing that " + npc.fetchName() + "!");
                                 }
                             }
-                            if (bot.state.fetchTowards() || bot.state.fetchHits() || bot.state.fetchCasts()) {
+                            if (isBusy(bot)) {
                                 return;
                             }
                             BotAI.executeCombat(session, bot, npc, Generics);
@@ -344,11 +405,16 @@ module.exports = {
             }
         }
 
-        // 5. Follow player or return to stay location post
         if (!session.currentTargetId && !acted) {
             if (session.botStay && session.stayLocation) {
-                const stayDist = new SpeckMath.Point3D(bot.fetchLocX(), bot.fetchLocY(), bot.fetchLocZ())
-                    .distance(new SpeckMath.Point3D(session.stayLocation.locX, session.stayLocation.locY, session.stayLocation.locZ));
+                const stayDist = point(bot).distance(new SpeckMath.Point3D(
+                    session.stayLocation.locX,
+                    session.stayLocation.locY,
+                    session.stayLocation.locZ
+                ));
+                if (!keepRoleDecision) {
+                    recordRoleDecision(session, bot, 'hold_position', 'stay_order');
+                }
                 if (stayDist > 100) {
                     bot.moveTo({
                         from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
@@ -356,10 +422,17 @@ module.exports = {
                     });
                 }
             } else if (distance > 250) {
+                if (!keepRoleDecision) {
+                    recordRoleDecision(session, bot, 'follow_leader', 'keep_range');
+                }
                 bot.moveTo({
                     from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
                     to: { locX: player.fetchLocX() + utils.oneFromSpan(-60, 60), locY: player.fetchLocY() + utils.oneFromSpan(-60, 60), locZ: player.fetchLocZ() }
                 });
+            } else {
+                if (!keepRoleDecision) {
+                    recordRoleDecision(session, bot, BotRoles.partyRoleStance(role), 'ready');
+                }
             }
         }
     }

--- a/src/GameServer/Bot/AI/States/GettingBuffedState.js
+++ b/src/GameServer/Bot/AI/States/GettingBuffedState.js
@@ -1,5 +1,48 @@
 const SpeckMath      = invoke('GameServer/SpeckMath');
-const ServerResponse = invoke('GameServer/Network/Response');
+const BotBuffs       = invoke('GameServer/Bot/AI/BotBuffs');
+
+function returnLocation(session) {
+    const resume = session.resumeAfterBuff;
+    if (resume?.plan === 'following' && resume.followPlayerSession?.actor?.fetchIsOnline()) {
+        if (resume.botStay && resume.stayLocation) {
+            return resume.stayLocation;
+        }
+
+        const leader = resume.followPlayerSession.actor;
+        return {
+            locX: leader.fetchLocX() + utils.oneFromSpan(-60, 60),
+            locY: leader.fetchLocY() + utils.oneFromSpan(-60, 60),
+            locZ: leader.fetchLocZ()
+        };
+    }
+
+    return session.preBuffLocation || session.initialSpawnCoord || null;
+}
+
+function resumePreviousPlan(session, bot) {
+    const resume = session.resumeAfterBuff;
+    if (resume?.plan === 'following' && resume.followPlayerSession?.actor?.fetchIsOnline()) {
+        session.plan = 'following';
+        session.followPlayerSession = resume.followPlayerSession;
+        session.partyCompanion = true;
+        session.botStay = resume.botStay;
+        session.stayLocation = resume.stayLocation;
+        session.roleDecision = {
+            role: resume.role,
+            action: 'refresh_buffs',
+            reason: 'newbie_blessing_done',
+            at: Date.now()
+        };
+    } else {
+        session.plan = session.preBuffPlan || 'hunting';
+    }
+
+    session.resumeAfterBuff = undefined;
+    session.preBuffPlan = undefined;
+    session.preBuffLocation = undefined;
+    session.currentTargetId = undefined;
+    bot.unselect();
+}
 
 module.exports = {
     tick(session, bot, Generics, BotAI) {
@@ -21,30 +64,13 @@ module.exports = {
                 }
             }
         } else {
-            if (!bot.activeBuffs) {
-                bot.activeBuffs = {};
-            }
-            const duration = Date.now() + 20 * 60 * 1000;
-            bot.activeBuffs.windWalk = duration;
-            bot.activeBuffs.shield = duration;
-            bot.activeBuffs.haste = duration;
+            BotBuffs.applyFullNewbieBlessing(session, bot, Generics);
+            BotAI.say(session, session.resumeAfterBuff ? "Thank you, Newbie Guide! Fully blessed and returning to the party!" : "Thank you, Newbie Guide! Fully blessed and ready to hunt!");
 
-            bot.setHp(bot.fetchMaxHp());
-            bot.setMp(bot.fetchMaxMp());
-            bot.statusUpdateVitals(bot);
-            
-            Generics.calculateStats(session, bot);
-            session.dataSendToMe(ServerResponse.userInfo(bot));
-            
-            BotAI.say(session, "Thank you, Newbie Guide! Fully blessed and ready to hunt!");
-            session.plan = 'hunting';
-
-            // Teleport back to original hunting spot
-            if (session.preBuffLocation) {
-                Generics.teleportTo(session, bot, session.preBuffLocation);
-                session.preBuffLocation = undefined;
-            } else if (session.initialSpawnCoord) {
-                Generics.teleportTo(session, bot, session.initialSpawnCoord);
+            const target = returnLocation(session);
+            resumePreviousPlan(session, bot);
+            if (target) {
+                Generics.teleportTo(session, bot, target);
             }
         }
     }

--- a/src/GameServer/Bot/AI/States/HuntingState.js
+++ b/src/GameServer/Bot/AI/States/HuntingState.js
@@ -4,6 +4,7 @@ const ServerResponse = invoke('GameServer/Network/Response');
 const GeodataEngine  = invoke('GameServer/Geodata/GeodataEngine');
 const SpotService    = invoke('GameServer/Bot/AI/SpotService');
 const DecisionService = invoke('GameServer/Bot/AI/BotDecisionService');
+const BotBuffs       = invoke('GameServer/Bot/AI/BotBuffs');
 
 function isSoloHunter(session) {
     return session.plan === 'hunting' && session.partyCompanion !== true && !session.followPlayerSession;
@@ -54,10 +55,10 @@ function findPreferredMonster(session, bot, radius, options = {}) {
 module.exports = {
     tick(session, bot, Generics, BotAI) {
         // 1. Expire buffs check for hunting bots
-        if (bot.fetchLevel() <= 25 && bot.fetchKarma() === 0 && !session.followPlayerSession) {
-            const buffsExpired = !bot.activeBuffs || !bot.activeBuffs.windWalk || Date.now() > bot.activeBuffs.windWalk;
-            if (buffsExpired) {
+        if (!session.followPlayerSession) {
+            if (BotBuffs.needsNewbieRefresh(bot, 0)) {
                 session.preBuffLocation = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
+                session.preBuffPlan = 'hunting';
                 session.plan = 'getting_buffed';
                 session.currentTargetId = undefined;
                 bot.automation.abortAll(bot);

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -2,6 +2,7 @@ const ServerResponse = invoke('GameServer/Network/Response');
 const GeodataEngine  = invoke('GameServer/Geodata/GeodataEngine');
 const BotStatus      = invoke('GameServer/Bot/AI/BotStatus');
 const BotBrain       = invoke('GameServer/Bot/AI/BotBrain');
+const BotRoles       = invoke('GameServer/Bot/AI/BotRoles');
 
 const CHAT_PHRASES = {
     foundTarget: [
@@ -388,14 +389,11 @@ const BotAI = {
     },
 
     executeCombat(session, bot, npc, Generics) {
-        const classId = bot.fetchClassId();
+        const role = BotRoles.inferRole(bot);
         const MAGE_ATTACK_RANGE = 600;
         const ARCHER_ATTACK_RANGE = 700;
 
-        const MAGE_CLASSES = [10, 11, 12, 13, 14, 15, 16, 17, 25, 26, 27, 28, 29, 30, 38, 39, 40, 41, 42, 43];
-        const ARCHER_CLASSES = [8, 9, 22, 23, 35, 36];
-
-        if (MAGE_CLASSES.includes(classId)) {
+        if (role === 'mage' || role === 'healer' || role === 'buffer') {
             const SkillModel = invoke('GameServer/Model/Skill');
             let skill = bot.skillset.fetchSkill(1177);
             if (!skill) {
@@ -418,7 +416,7 @@ const BotAI = {
                 return;
             }
         }
-        else if (ARCHER_CLASSES.includes(classId)) {
+        else if (role === 'archer') {
             const SkillModel = invoke('GameServer/Model/Skill');
             let skill = bot.skillset.fetchSkill(56);
             if (!skill) {

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -88,6 +88,9 @@ const BotManager = {
         const roleDecision = status.roleDecision ? `${status.roleDecision.action} / ${status.roleDecision.reason}` : null;
         const huntDecision = botSession.lastDecision ? `${botSession.lastDecision.action} / ${botSession.lastDecision.reason}${botSession.lastDecision.spotName ? ` / ${botSession.lastDecision.spotName}` : ''}` : null;
         const decision = roleDecision || huntDecision || 'none';
+        const buffs = status.buffs?.eligible
+            ? `WW ${status.buffs.windWalk}s / Shield ${status.buffs.shield}s / Haste ${status.buffs.haste}s${status.buffs.needsRefresh ? ' / refresh' : ''}`
+            : 'not eligible';
         const trade = status.trade?.last ? status.trade.last :
             status.trade?.shoppingTarget ? `going to ${status.trade.shoppingTarget.name}` :
             status.trade?.store ? `${status.trade.store.type} / ${status.trade.store.title}` : 'none';
@@ -109,6 +112,7 @@ const BotManager = {
             ['Move', safe(status.movement.moving ? `moving (${status.movement.towards})` : 'idle')],
             ['Blockers', safe(blockers)],
             ['Decision', safe(decision)],
+            ['Buffs', safe(buffs)],
             ['Trade', safe(trade)],
             ['Social', safe(social)],
             ['Invite', safe(invite)]

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -89,8 +89,8 @@ const BotManager = {
         const huntDecision = botSession.lastDecision ? `${botSession.lastDecision.action} / ${botSession.lastDecision.reason}${botSession.lastDecision.spotName ? ` / ${botSession.lastDecision.spotName}` : ''}` : null;
         const decision = roleDecision || huntDecision || 'none';
         const buffs = status.buffs?.eligible
-            ? `WW ${status.buffs.windWalk}s / Shield ${status.buffs.shield}s / Haste ${status.buffs.haste}s${status.buffs.needsRefresh ? ' / refresh' : ''}`
-            : 'not eligible';
+            ? `WW ${status.buffs.windWalk}s / Shield ${status.buffs.shield}s / Haste ${status.buffs.haste}s / Might ${status.buffs.might}s${status.buffs.needsRefresh ? ' / refresh' : ''}`
+            : `Might ${status.buffs?.might ?? 0}s`;
         const trade = status.trade?.last ? status.trade.last :
             status.trade?.shoppingTarget ? `going to ${status.trade.shoppingTarget.name}` :
             status.trade?.store ? `${status.trade.store.type} / ${status.trade.store.title}` : 'none';

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -82,10 +82,12 @@ const BotManager = {
 
         const spot = status.spot ? `${status.spot.name} / Lv ${status.spot.minLevel}-${status.spot.maxLevel} / density ${status.spot.density}` : 'none';
         const target = status.target ? `${status.target.type}:${status.target.name || status.target.id}` : 'none';
-        const party = status.party ? `${status.party.role}, ${status.party.stance}, leader ${status.party.leader?.name || 'unknown'}` : 'none';
+        const party = status.party ? `${status.party.role}, ${status.party.stance}/${status.party.roleStance}, leader ${status.party.leader?.name || 'unknown'}` : 'none';
         const home = status.home?.region ? `${status.home.region}${status.home.visitor ? ' visitor' : ''}` : 'unknown';
         const blockers = status.blockers.length > 0 ? status.blockers.join(', ') : 'none';
-        const decision = botSession.lastDecision ? `${botSession.lastDecision.action} / ${botSession.lastDecision.reason}${botSession.lastDecision.spotName ? ` / ${botSession.lastDecision.spotName}` : ''}` : 'none';
+        const roleDecision = status.roleDecision ? `${status.roleDecision.action} / ${status.roleDecision.reason}` : null;
+        const huntDecision = botSession.lastDecision ? `${botSession.lastDecision.action} / ${botSession.lastDecision.reason}${botSession.lastDecision.spotName ? ` / ${botSession.lastDecision.spotName}` : ''}` : null;
+        const decision = roleDecision || huntDecision || 'none';
         const trade = status.trade?.last ? status.trade.last :
             status.trade?.shoppingTarget ? `going to ${status.trade.shoppingTarget.name}` :
             status.trade?.store ? `${status.trade.store.type} / ${status.trade.store.title}` : 'none';
@@ -587,6 +589,7 @@ const BotManager = {
                     .slice(0, 10)
                     .map((session) => {
                         const summary = BotAI.summarizeStatus(session);
+                        if (session.roleDecision) return `${summary} roleDecision=${session.roleDecision.action}/${session.roleDecision.reason}`;
                         if (!session.lastDecision) return summary;
                         return `${summary} decision=${session.lastDecision.action}/${session.lastDecision.reason}`;
                     });

--- a/src/GameServer/Network/Response/AbnormalStatusUpdate.js
+++ b/src/GameServer/Network/Response/AbnormalStatusUpdate.js
@@ -39,6 +39,13 @@ abnormalStatusUpdate.fromActor = function(actor) {
                 duration: Math.round((actor.activeBuffs.haste - now) / 1000)
             });
         }
+        if (actor.activeBuffs.might && now < actor.activeBuffs.might) {
+            buffs.push({
+                id: 1068, // Might
+                level: 2,
+                duration: Math.round((actor.activeBuffs.might - now) / 1000)
+            });
+        }
     }
     return abnormalStatusUpdate(buffs);
 };

--- a/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
+++ b/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
@@ -110,6 +110,7 @@ function renderCompanionPanel(session) {
         const mpPct = status ? Math.round(status.vitals.mpPct * 100) : 0;
         const spotName = status?.spot?.name || 'no spot';
         const roleDecision = status?.roleDecision ? `${status.roleDecision.action}/${status.roleDecision.reason}` : status?.intent;
+        const buffText = status?.buffs?.needsRefresh ? ' / buffs low' : '';
 
         const movement = stayActive
             ? Html.link('[STAYING]', `companion-control follow ${bot.fetchName()}`, { color: Html.COLOR.danger })
@@ -130,7 +131,7 @@ function renderCompanionPanel(session) {
         body += Html.botCard({
             name: bot.fetchName(),
             badge: status ? Html.font(status.role || 'bot', Html.COLOR.link) : '',
-            subtitle: status ? `${roleDecision} / HP ${hpPct}% / MP ${mpPct}% / ${spotName}` : 'status unavailable',
+            subtitle: status ? `${roleDecision} / HP ${hpPct}% / MP ${mpPct}% / ${spotName}${buffText}` : 'status unavailable',
             status: actions
         });
         body += Html.spacer(4);

--- a/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
+++ b/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
@@ -2,6 +2,7 @@ const BotManager = invoke('GameServer/Bot/BotManager');
 const ServerResponse = invoke('GameServer/Network/Response');
 const TeleportTo = invoke('GameServer/Actor/Generics/TeleportTo');
 const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 const Html = invoke('GameServer/World/Generics/HtmlKit');
 
 function companionControl(session, parts) {
@@ -100,10 +101,7 @@ function renderCompanionPanel(session) {
 
     myCompanions.forEach((companionSession) => {
         const bot = companionSession.actor;
-        const classId = bot.fetchClassId();
-
-        const TANK_CLASSES = [4, 5, 6, 19, 20, 32, 33];
-        const isTank = TANK_CLASSES.includes(classId);
+        const isTank = BotRoles.isTank(bot);
 
         const stayActive = companionSession.botStay === true;
         const tauntActive = companionSession.autoTaunt !== false; // default true for tanks
@@ -111,6 +109,7 @@ function renderCompanionPanel(session) {
         const hpPct = status ? Math.round(status.vitals.hpPct * 100) : 0;
         const mpPct = status ? Math.round(status.vitals.mpPct * 100) : 0;
         const spotName = status?.spot?.name || 'no spot';
+        const roleDecision = status?.roleDecision ? `${status.roleDecision.action}/${status.roleDecision.reason}` : status?.intent;
 
         const movement = stayActive
             ? Html.link('[STAYING]', `companion-control follow ${bot.fetchName()}`, { color: Html.COLOR.danger })
@@ -131,7 +130,7 @@ function renderCompanionPanel(session) {
         body += Html.botCard({
             name: bot.fetchName(),
             badge: status ? Html.font(status.role || 'bot', Html.COLOR.link) : '',
-            subtitle: status ? `${status.intent} / HP ${hpPct}% / MP ${mpPct}% / ${spotName}` : 'status unavailable',
+            subtitle: status ? `${roleDecision} / HP ${hpPct}% / MP ${mpPct}% / ${spotName}` : 'status unavailable',
             status: actions
         });
         body += Html.spacer(4);

--- a/src/GameServer/World/Generics/NpcBypasses/NewbieBuff.js
+++ b/src/GameServer/World/Generics/NpcBypasses/NewbieBuff.js
@@ -1,4 +1,5 @@
 const ServerResponse = invoke('GameServer/Network/Response');
+const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
 
 module.exports = function(session, parts) {
     const actor = session.actor;
@@ -9,34 +10,18 @@ module.exports = function(session, parts) {
         return;
     }
 
-    if (!actor.activeBuffs) {
-        actor.activeBuffs = {};
-    }
-
     const buffType = parts[1];
-    console.log("NewbieBuff.js executed. actor:", actor.fetchName(), "level:", actor.fetchLevel(), "buffType:", buffType);
 
     if (buffType === 'windwalk') {
-        actor.activeBuffs.windWalk = Date.now() + 20 * 60 * 1000;
-        console.log("Run speed before calculateStats:", actor.fetchCollectiveRunSpd());
-        invoke(path.actor).calculateStats(session, actor);
-        console.log("Run speed after calculateStats:", actor.fetchCollectiveRunSpd());
-        session.dataSendToMe(ServerResponse.userInfo(actor));
-        session.dataSendToMe(ServerResponse.abnormalStatusUpdate.fromActor(actor));
+        BotBuffs.applyNewbieBuff(session, actor, 'windwalk');
         session.dataSendToMe(ServerResponse.speak(actor, { kind: 0, text: "Newbie Guide: Bestowed Wind Walk! May the wind guide your steps." }));
     }
     else if (buffType === 'shield') {
-        actor.activeBuffs.shield = Date.now() + 20 * 60 * 1000;
-        invoke(path.actor).calculateStats(session, actor);
-        session.dataSendToMe(ServerResponse.userInfo(actor));
-        session.dataSendToMe(ServerResponse.abnormalStatusUpdate.fromActor(actor));
+        BotBuffs.applyNewbieBuff(session, actor, 'shield');
         session.dataSendToMe(ServerResponse.speak(actor, { kind: 0, text: "Newbie Guide: Bestowed Shield! May your defenses be unbreakable." }));
     }
     else if (buffType === 'haste') {
-        actor.activeBuffs.haste = Date.now() + 20 * 60 * 1000;
-        invoke(path.actor).calculateStats(session, actor);
-        session.dataSendToMe(ServerResponse.userInfo(actor));
-        session.dataSendToMe(ServerResponse.abnormalStatusUpdate.fromActor(actor));
+        BotBuffs.applyNewbieBuff(session, actor, 'haste');
         session.dataSendToMe(ServerResponse.speak(actor, { kind: 0, text: "Newbie Guide: Bestowed Haste! Strike with the speed of lightning." }));
     }
     else if (buffType === 'heal') {


### PR DESCRIPTION
## Summary

Adds the first Phase 4 party-role AI slice for companion bots:

- centralizes bot role inference for tank, healer, buffer, archer, mage, dagger, and generic DPS
- exposes role decisions in bot status, companion panels, and status logs
- gives tanks safer protect/pull behavior with overpull guards
- gives healers emergency/top-off healing with MP conservation decisions
- gives buffers a basic support package with real stat/icon effects and safe refresh timing
- gives dagger classes a close-assist role instead of treating them as archers
- keeps spoilers and crafters on the generic DPS branch until their economy systems exist

## Validation

- `node --check` on changed JavaScript files
- `git diff --check`
- `npm run NodeL2` boot smoke reached DB/datapack/AuthServer/GameServer/BotSocial/bot population startup

## Follow-up

- live-client validation with tank/healer/buffer/dagger party
- verify `.botstatus` and companion panel show `protect_leader`, `save_mp`, `avoid_overpull`, `refresh_buffs`, `buff_party/...`, and `flank_target`
- tune thresholds/messages if the live loop is too noisy or too quiet