### PR TITLE
Add spoil sweep and admin shop fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ L2Solo is judged by what the world feels like in the client, not by how many ser
 - [x] Inspect companion, social memory, and bot state through `.botstatus`, companion `Status` links, and server-side status logs.
 - [x] Trade directly with targeted SimPlayers through the native C2 trade window, with `.trade` as a fallback while testing.
 - [x] See companion bots ask for useful non-junk drops, then satisfy the request by handing the item over through the real trade flow.
+- [x] Use basic dwarf Spoil/Sweeper mechanics: spoil a living monster, kill it, then sweep the marked corpse for spoil-table rewards.
 - [x] Run with role-aware companions: tanks protect/pull cautiously, healers conserve MP and heal, buffers refresh support buffs, daggers close-assist, and ranged roles assist at range.
 - [x] Inspect role decisions, buff timers, and pending loot requests through bot status surfaces.
 - [x] Encounter merchant SimPlayers in Talking Island, Gludio, Dion, Giran, and Oren with private buy/sell stores and occasional trade-chat ads.
@@ -41,7 +42,7 @@ L2Solo is judged by what the world feels like in the client, not by how many ser
 - [ ] More natural long-term SimPlayer memory: level history, wipes, insults, deeper relationships, and personal routines should persist instead of feeling reset between sessions.
 - [ ] Better starter-zone ecology: race-specific bot ratios, class mix, routes, and town/field behavior need more tuning by location.
 - [ ] Bot progression that feels earned: levels, gear, and class growth should come from real activity, not from hidden scaling.
-- [ ] Richer party play: live tuning for role thresholds, travel together, loot timing, spoiler/sweeper behavior, and crafter/economy roles.
+- [ ] Richer party play: live tuning for role thresholds, travel together, loot timing, bot spoiler behavior, and crafter/economy roles.
 - [ ] More believable economy loops: local buyers, sellers, stock pressure, restocking, and player-visible trade behavior.
 - [ ] More social chatter that sounds like players talking about the world, drops, prices, spots, danger, and plans.
 - [ ] Optional OpenRouter-backed bot brain is available for player-visible moments, but still needs more personality tuning.
@@ -184,11 +185,14 @@ Player-to-bot trade uses the normal C2 trade flow. Target a SimPlayer and use th
 
 Grouped companion bots also watch notable drops. They ignore Adena and obvious junk, score item usefulness by role, throttle requests, and ask only when a nearby companion has a reason to want the item. If the player trades the requested item to that bot before the request expires, the handoff records `gave_useful_loot`; ignored requests are only remembered when the bot is still an active nearby companion.
 
+Dwarven Spoil/Sweeper uses the normal skill flow. Use `Spoil` on a living monster with spoil-table rewards, kill it, then use `Sweeper` on the sweepable corpse before it decays. Spoil rewards are rolled from `data/Npcs/Rewards/rewards.json` and are added to the player's inventory.
+
 Useful debug surfaces:
 
 - `.botstatus <name>` shows `trade.lootRequest`, demand reason, and score.
 - `BotTrade :: ...` logs native trade open/add/complete events.
 - `BotLoot :: ...` logs requested, fulfilled, and ignored loot requests.
+- `SpoilSweep :: ...` logs successful spoil and sweep events.
 - `BotSocial :: ...` logs trust and relationship deltas.
 
 ## OpenRouter Bot Brain

--- a/src/GameServer/Actor/Generics/SkillExec.js
+++ b/src/GameServer/Actor/Generics/SkillExec.js
@@ -3,9 +3,20 @@ const World = invoke('GameServer/World/World');
 function skillExec(session, actor, data) {
     const skill = actor.skillset.fetchSkill(data.selfId);
     if (!skill) return;
+    const SpoilSweep = invoke('GameServer/Npc/SpoilSweep');
 
     World.fetchNpc(data.id).then((npc) => {
         actor.automation.scheduleAction(session, actor, npc, skill.fetchDistance(), () => {
+            if (SpoilSweep.isSpoilSkill(data.selfId)) {
+                SpoilSweep.castSpoil(session, actor, npc, skill);
+                return;
+            }
+
+            if (SpoilSweep.isSweepSkill(data.selfId)) {
+                SpoilSweep.castSweep(session, actor, npc, skill);
+                return;
+            }
+
             if (npc.fetchAttackable() || data.ctrl) {
                 actor.attack.remoteHit(session, npc, skill);
             }

--- a/src/GameServer/ConsoleText.js
+++ b/src/GameServer/ConsoleText.js
@@ -23,6 +23,7 @@ const ConsoleText = {
         dropped           : 298,
         unequipped        : 417,
         loadLimitExceeded : 422,
+        spoilActivated    : 612,
     },
 
     kind: {

--- a/src/GameServer/Network/Request/Purchase.js
+++ b/src/GameServer/Network/Request/Purchase.js
@@ -48,6 +48,7 @@ function purchase(session, buffer) {
 async function consume(session, data) {
     const trade = session.activeMerchantTrade;
     const store = trade && trade.store;
+    const adminShop = session.activeAdminShop;
 
     if (store && store.storeType === 1) {
         try {
@@ -71,6 +72,18 @@ async function consume(session, data) {
             utils.infoWarn('Purchase', 'merchant purchase error: %s', err.message || err);
             session.dataSendToMe(ServerResponse.actionFailed());
         }
+        return;
+    }
+
+    if (adminShop) {
+        const allowed = data.list.every((item) => adminShop.itemIds.has(item.selfId));
+        if (!allowed) {
+            session.activeAdminShop = null;
+            session.dataSendToMe(ServerResponse.actionFailed());
+            return;
+        }
+
+        World.purchaseItems(session, data.list, { free: true });
         return;
     }
 

--- a/src/GameServer/Network/Response/Die.js
+++ b/src/GameServer/Network/Response/Die.js
@@ -1,6 +1,6 @@
 const SendPacket = invoke('Packet/Send');
 
-function die(id) {
+function die(id, sweepable = false) {
     const packet = new SendPacket(0x06);
 
     packet
@@ -9,7 +9,7 @@ function die(id) {
         .writeD(0x00)  // ?
         .writeD(0x00)  // Castle
         .writeD(0x00)  // HQ
-        .writeD(0x00)  // Sweepable
+        .writeD(sweepable ? 0x01 : 0x00)  // Sweepable
         .writeD(0x00); // Fixed
 
     return packet.fetchBuffer();

--- a/src/GameServer/Npc/Generics/Die.js
+++ b/src/GameServer/Npc/Generics/Die.js
@@ -1,9 +1,11 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 
 function die(session, actor, npc) {
+    const SpoilSweep = invoke('GameServer/Npc/SpoilSweep');
+
     npc.destructor(session);
     npc.state.setDead(true);
-    session.dataSendToMeAndOthers(ServerResponse.die(npc.fetchId()), npc);
+    session.dataSendToMeAndOthers(ServerResponse.die(npc.fetchId(), SpoilSweep.isSweepable(npc)), npc);
     invoke(path.actor).npcDied(session, actor, npc);
 }
 

--- a/src/GameServer/Npc/SpoilSweep.js
+++ b/src/GameServer/Npc/SpoilSweep.js
@@ -1,0 +1,190 @@
+const DataCache      = invoke('GameServer/DataCache');
+const ServerResponse = invoke('GameServer/Network/Response');
+const ConsoleText    = invoke('GameServer/ConsoleText');
+
+const SPOIL_SKILL_ID = 254;
+const SWEEP_SKILL_ID = 42;
+const SPOILED_CORPSE_TIME = 30000;
+
+function fetchSpoilGroups(npc) {
+    let spoils = [];
+    DataCache.fetchNpcRewardsFromSelfId(npc.fetchSelfId(), (result) => {
+        spoils = result.spoils ?? [];
+    });
+    return spoils;
+}
+
+function hasSpoils(npc) {
+    return fetchSpoilGroups(npc).some((group) => (group.items ?? []).length > 0);
+}
+
+function rollSpoils(npc) {
+    const optn = options.default.General;
+    const awarded = [];
+
+    fetchSpoilGroups(npc).forEach((group) => {
+        if (Math.random() * 100 > group.overall * optn.dropChanceRate) {
+            return;
+        }
+
+        let number = Math.random() * 100;
+        let rewardPartition = 0;
+
+        for (const item of group.items ?? []) {
+            rewardPartition += item.chance;
+
+            if (number <= rewardPartition) {
+                awarded.push({
+                    selfId: item.selfId,
+                    name: item.name,
+                    amount: utils.oneFromSpan(item.min, item.max)
+                });
+                break;
+            }
+        }
+    });
+
+    return awarded;
+}
+
+function spendSkillMp(session, actor, skill) {
+    if (actor.fetchMp() < skill.fetchConsumedMp()) {
+        ConsoleText.transmit(session, ConsoleText.caption.depletedMp);
+        return false;
+    }
+
+    actor.setMp(actor.fetchMp() - skill.fetchConsumedMp());
+    actor.statusUpdateVitals(actor);
+    actor.automation.replenishVitals(actor);
+    return true;
+}
+
+function castUtilitySkill(session, actor, target, skill, effect) {
+    if (actor.state.fetchCasts()) {
+        session.dataSendToMe(ServerResponse.actionFailed());
+        return;
+    }
+
+    if (actor.fetchMp() < skill.fetchConsumedMp()) {
+        ConsoleText.transmit(session, ConsoleText.caption.depletedMp);
+        return;
+    }
+
+    skill.setCalculatedHitTime(skill.fetchHitTime());
+    session.dataSendToMeAndOthers(ServerResponse.skillStarted(actor, target.fetchId(), skill), actor);
+    session.dataSendToMe(ServerResponse.skillDurationBar(skill.fetchCalculatedHitTime()));
+    actor.state.setCasts(true);
+
+    setTimeout(() => {
+        actor.state.setCasts(false);
+        if (actor.isDead()) {
+            return;
+        }
+        if (!spendSkillMp(session, actor, skill)) {
+            return;
+        }
+        effect();
+    }, skill.fetchCalculatedHitTime());
+}
+
+const SpoilSweep = {
+    isSpoilSkill(selfId) {
+        return Number(selfId) === SPOIL_SKILL_ID;
+    },
+
+    isSweepSkill(selfId) {
+        return Number(selfId) === SWEEP_SKILL_ID;
+    },
+
+    isSweepable(npc) {
+        return !!npc.model.spoil?.spoiled && !npc.model.spoil?.swept && hasSpoils(npc);
+    },
+
+    corpseTime(npc) {
+        const corpseTime = Number(npc.fetchCorpseTime()) || 0;
+        return this.isSweepable(npc) ? Math.max(corpseTime, SPOILED_CORPSE_TIME) : corpseTime;
+    },
+
+    castSpoil(session, actor, npc, skill) {
+        if (!npc.fetchAttackable() || npc.isDead()) {
+            session.dataSendToMe(ServerResponse.actionFailed());
+            return;
+        }
+
+        if (!hasSpoils(npc)) {
+            session.dataSendToMe(ServerResponse.actionFailed());
+            return;
+        }
+
+        if (npc.model.spoil?.spoiled) {
+            session.dataSendToMe(ServerResponse.actionFailed());
+            return;
+        }
+
+        castUtilitySkill(session, actor, npc, skill, () => {
+            if (npc.isDead()) {
+                session.dataSendToMe(ServerResponse.actionFailed());
+                return;
+            }
+
+            npc.model.spoil = {
+                spoiled: true,
+                swept: false,
+                spoilerId: actor.fetchId(),
+                spoilerName: actor.fetchName(),
+                spoiledAt: Date.now()
+            };
+
+            console.info('SpoilSweep :: %s spoiled %s', actor.fetchName(), npc.fetchName());
+            ConsoleText.transmit(session, ConsoleText.caption.spoilActivated);
+            npc.enterCombatState(session, actor);
+        });
+    },
+
+    castSweep(session, actor, npc, skill) {
+        if (!npc.isDead()) {
+            session.dataSendToMe(ServerResponse.actionFailed());
+            return;
+        }
+
+        if (!this.isSweepable(npc)) {
+            session.dataSendToMe(ServerResponse.actionFailed());
+            return;
+        }
+
+        if (npc.model.spoil?.spoilerId && npc.model.spoil.spoilerId !== actor.fetchId()) {
+            session.dataSendToMe(ServerResponse.actionFailed());
+            return;
+        }
+
+        castUtilitySkill(session, actor, npc, skill, () => {
+            if (!this.isSweepable(npc)) {
+                session.dataSendToMe(ServerResponse.actionFailed());
+                return;
+            }
+
+            const awarded = rollSpoils(npc);
+            npc.model.spoil.swept = true;
+
+            if (awarded.length === 0) {
+                session.dataSendToMe(ServerResponse.actionFailed());
+            } else {
+                awarded.forEach((item) => {
+                    invoke('GameServer/World/World').purchaseItem(session, item.selfId, item.amount);
+                    const textName = { kind: ConsoleText.kind.item, value: item.selfId };
+                    const textAmount = { kind: ConsoleText.kind.number, value: item.amount };
+                    item.amount > 1
+                        ? ConsoleText.transmit(session, ConsoleText.caption.pickupAmountOf, [textName, textAmount])
+                        : ConsoleText.transmit(session, ConsoleText.caption.pickup, [textName]);
+                    console.info('SpoilSweep :: %s swept %d %s from %s', actor.fetchName(), item.amount, item.name, npc.fetchName());
+                });
+            }
+
+            session.dataSendToMeAndOthers(ServerResponse.deleteOb(npc.fetchId()), npc);
+            const World = invoke('GameServer/World/World');
+            World.npc.spawns = World.npc.spawns.filter((ob) => ob.fetchId() !== npc.fetchId());
+        });
+    }
+};
+
+module.exports = SpoilSweep;

--- a/src/GameServer/World/Generics/NpcBypasses/AdminShop.js
+++ b/src/GameServer/World/Generics/NpcBypasses/AdminShop.js
@@ -3,9 +3,21 @@ const Item           = invoke('GameServer/Item/Item');
 const DataCache      = invoke('GameServer/DataCache');
 
 module.exports = function(session, parts) {
+    const itemIds = DataCache.adminShop[parts[1]];
+    if (!itemIds) {
+        session.dataSendToMe(ServerResponse.actionFailed());
+        return;
+    }
+
+    session.activeMerchantTrade = null;
+    session.activeAdminShop = {
+        category: parts[1],
+        itemIds: new Set(itemIds)
+    };
+
     let list = [];
 
-    DataCache.adminShop[parts[1]].forEach((selfId) => {
+    itemIds.forEach((selfId) => {
         DataCache.fetchItemFromSelfId(selfId, (item) => {
             item.template.price = 0; // Admin prices :)
             const nextId = invoke('GameServer/World/Generics/NpcTalkResponse').items.nextId++;

--- a/src/GameServer/World/Generics/NpcBypasses/BuyBotShop.js
+++ b/src/GameServer/World/Generics/NpcBypasses/BuyBotShop.js
@@ -4,6 +4,8 @@ const DataCache      = invoke('GameServer/DataCache');
 const BotManager     = invoke('GameServer/Bot/BotManager');
 
 module.exports = function(session, parts) {
+    session.activeAdminShop = null;
+
     const player = session.actor;
     if (!player) return;
 

--- a/src/GameServer/World/Generics/NpcBypasses/BuyShop.js
+++ b/src/GameServer/World/Generics/NpcBypasses/BuyShop.js
@@ -4,6 +4,7 @@ const DataCache      = invoke('GameServer/DataCache');
 
 module.exports = function(session, parts) {
     session.activeMerchantTrade = null;
+    session.activeAdminShop = null;
 
     let list = [];
     let itemIds = [];

--- a/src/GameServer/World/Generics/PurchaseItems.js
+++ b/src/GameServer/World/Generics/PurchaseItems.js
@@ -1,15 +1,17 @@
 const DataCache = invoke('GameServer/DataCache');
 const ServerResponse = invoke('GameServer/Network/Response');
 
-function purchaseItems(session, items) {
+function purchaseItems(session, items, purchaseOptions = {}) {
     // 1. Calculate total cost
     let totalCost = 0;
-    for (const item of items) {
-        let price = 0;
-        DataCache.fetchItemFromSelfId(item.selfId, (itemDetails) => {
-            price = itemDetails.template.price ?? 0;
-        });
-        totalCost += price * item.amount;
+    if (!purchaseOptions.free) {
+        for (const item of items) {
+            let price = 0;
+            DataCache.fetchItemFromSelfId(item.selfId, (itemDetails) => {
+                price = itemDetails.template.price ?? 0;
+            });
+            totalCost += price * item.amount;
+        }
     }
 
     const actor = session.actor;

--- a/src/GameServer/World/Generics/RemoveNpc.js
+++ b/src/GameServer/World/Generics/RemoveNpc.js
@@ -1,4 +1,5 @@
 const ServerResponse = invoke('GameServer/Network/Response');
+const SpoilSweep     = invoke('GameServer/Npc/SpoilSweep');
 
 function removeNpc(session, npc) {
     const npcId = npc.fetchId();
@@ -8,7 +9,7 @@ function removeNpc(session, npc) {
     setTimeout(() => {
         session.dataSendToMeAndOthers(ServerResponse.deleteOb(npcId), npc);
         this.npc.spawns = this.npc.spawns.filter(ob => ob.fetchId() !== npcId);
-    }, npc.fetchCorpseTime()); // TODO: Depends if NPC is spoiled too
+    }, SpoilSweep.corpseTime(npc));
 }
 
 module.exports = removeNpc;


### PR DESCRIPTION
## Summary

- Add player-facing Spoil/Sweep handling for C2-style dwarf gameplay: Spoil marks valid living monsters, death packets expose sweepable corpses, Sweeper rolls spoil rewards into inventory, and spoiled corpses stay long enough to sweep.
- Use the native system message for successful Spoil activation instead of speaking as the player.
- Make admin shop purchases free through a scoped admin-shop purchase path, and clear that state when opening normal or bot shops.
- Update the README checklist with the new playable Spoil/Sweeper coverage.

## Validation

- `node -c` on all changed JavaScript files.
- `git diff --check --cached`.
- Live client validation: dwarf character tested Spoil/Sweeper successfully, including corrected system-message feedback.
- Full server boot was not rerun for this commit because a live server process was already listening on the game port; the running server needs a restart to pick up the committed code.

## Notes

- Admin shop purchase flow was statically validated and scoped to item IDs from the active admin category; it still needs an in-client click-through after the next server restart.
