### PR TITLE
Add live world observer map

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -57,3 +57,8 @@ maxRestingActivationRatio = 0.2
 partyInviteRange = 6000
 devLogPlayerChat = true
 debug = false
+
+[WorldObserver]
+enabled = true
+hostname = 127.0.0.1
+port = 8088

--- a/src/GameServer/Bot/Population/BotLifeEvents.js
+++ b/src/GameServer/Bot/Population/BotLifeEvents.js
@@ -97,6 +97,31 @@ const BotLifeEvents = {
         });
     },
 
+    recent(limit = 24) {
+        const safeLimit = Math.max(1, Math.min(80, Number(limit) || 24));
+        const ready = initialized ? Promise.resolve(true) : this.init();
+
+        return ready.then((isReady) => {
+            if (!isReady) return [];
+            return Database.execute([
+                `SELECT characterId, eventType, summary, weight, createdAt
+                FROM ${TABLE}
+                ORDER BY createdAt DESC, weight DESC
+                LIMIT ${safeLimit}`,
+                []
+            ]);
+        }).then((rows) => (rows || []).map((row) => ({
+            characterId: Number(row.characterId || 0),
+            type: row.eventType,
+            summary: row.summary,
+            weight: Number(row.weight || 1),
+            createdAt: Number(row.createdAt || 0)
+        }))).catch((err) => {
+            utils.infoWarn('BotLife', 'failed to read recent observer events: %s', err.message);
+            return [];
+        });
+    },
+
     prune(characterId) {
         return Database.execute([
             `DELETE FROM ${TABLE}

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -795,6 +795,13 @@ const BotLifeState = {
         return counts;
     },
 
+    allStates(limit = 500) {
+        const safeLimit = Math.max(1, Math.min(2000, Number(limit) || 500));
+        return Array.from(cache.values())
+            .sort((a, b) => Number(b.updatedAt || 0) - Number(a.updatedAt || 0))
+            .slice(0, safeLimit);
+    },
+
     levelHistogram() {
         if (!initialized) {
             return Promise.resolve({ levels: [], phases: {}, total: 0 });

--- a/src/NodeL2.js
+++ b/src/NodeL2.js
@@ -10,6 +10,7 @@ const Server      = invoke('Server');
 const BotManager  = invoke('GameServer/Bot/BotManager');
 const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
 const DevConsole = invoke('GameServer/DevConsole');
+const WorldObserver = invoke('WorldObserver/WorldObserverServer');
 
 console.info('\n\
     + ================================== \n\
@@ -36,5 +37,6 @@ Database.init(() => {
     });
 
     BotManager.init();
+    WorldObserver.init();
     DevConsole.init();
 });

--- a/src/WorldObserver/WorldObserverServer.js
+++ b/src/WorldObserver/WorldObserverServer.js
@@ -1,0 +1,332 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PUBLIC_DIR = path.join(__dirname, 'public');
+const MIME_TYPES = {
+    '.html': 'text/html; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.js': 'application/javascript; charset=utf-8',
+    '.json': 'application/json; charset=utf-8',
+    '.svg': 'image/svg+xml; charset=utf-8'
+};
+
+const WORLD_BOUNDS = {
+    minX: -131072,
+    maxX: 229376,
+    minY: -262144,
+    maxY: 262144
+};
+
+const MAP_TILES = {
+    source: 'https://github.com/npetrovski/l2-world-map',
+    rawBaseUrl: 'https://raw.githubusercontent.com/npetrovski/l2-world-map/main/Maps',
+    blockSize: 32768,
+    blockPx: 900,
+    x: { min: 16, max: 26, mid: 20 },
+    y: { min: 10, max: 25, mid: 18 },
+    hiddenRanges: [
+        { x1: 16, x2: 16, y1: 11, y2: 13 },
+        { x1: 17, x2: 22, y1: 10, y2: 13 },
+        { x1: 26, x2: 26, y1: 10, y2: 25 }
+    ],
+    alternatives: [
+        {
+            name: 'L2J C2 Aden',
+            url: 'https://l2j.ru/freya/img/maps/c2_aden.jpg',
+            note: 'clean poster map; needs manual coordinate calibration'
+        },
+        {
+            name: 'L2J C2 Elmore',
+            url: 'https://l2j.ru/freya/img/maps/c2_elmore.jpg',
+            note: 'clean poster map; separate northern continent image'
+        }
+    ]
+};
+
+const REGION_LABELS = [
+    { name: 'Talking Island', locX: -84318, locY: 244579, kind: 'town' },
+    { name: 'Gludin', locX: -80826, locY: 149775, kind: 'town' },
+    { name: 'Gludio', locX: -12672, locY: 122776, kind: 'town' },
+    { name: 'Dion', locX: 15664, locY: 142979, kind: 'town' },
+    { name: 'Giran', locX: 83400, locY: 147943, kind: 'town' },
+    { name: 'Oren', locX: 82960, locY: 53177, kind: 'town' },
+    { name: 'Heine', locX: 111395, locY: 219000, kind: 'town' },
+    { name: 'Elven Village', locX: 46934, locY: 51467, kind: 'starter' },
+    { name: 'Dark Elven Village', locX: 9745, locY: 15606, kind: 'starter' },
+    { name: 'Orc Village', locX: -44133, locY: -113911, kind: 'starter' },
+    { name: 'Dwarven Village', locX: 115120, locY: -178212, kind: 'starter' }
+];
+
+function isEnabled() {
+    const config = options.default.WorldObserver || {};
+    return config.enabled !== false && String(config.enabled || 'true').toLowerCase() !== 'false';
+}
+
+function safePercent(value) {
+    const number = Number(value || 0);
+    return Math.max(0, Math.min(100, Math.round(number * 100)));
+}
+
+function actorLoc(actor) {
+    return {
+        locX: actor.fetchLocX(),
+        locY: actor.fetchLocY(),
+        locZ: actor.fetchLocZ()
+    };
+}
+
+function actorVitals(actor) {
+    return {
+        hp: actor.fetchHp(),
+        maxHp: actor.fetchMaxHp(),
+        hpPct: safePercent(actor.fetchHp() / Math.max(1, actor.fetchMaxHp())),
+        mp: actor.fetchMp(),
+        maxMp: actor.fetchMaxMp(),
+        mpPct: safePercent(actor.fetchMp() / Math.max(1, actor.fetchMaxMp()))
+    };
+}
+
+function realPlayerSessions() {
+    const World = invoke('GameServer/World/World');
+    return (World.user?.sessions || []).filter((session) => (
+        session.actor &&
+        session.accountId &&
+        !String(session.accountId).startsWith('bot_')
+    ));
+}
+
+function compactPlayer(session) {
+    const actor = session.actor;
+    return {
+        id: actor.fetchId(),
+        name: actor.fetchName(),
+        level: actor.fetchLevel(),
+        loc: actorLoc(actor),
+        vitals: actorVitals(actor),
+        online: !!actor.fetchIsOnline()
+    };
+}
+
+function compactHotBot(status) {
+    return {
+        id: status.id,
+        name: status.name,
+        phase: 'hot',
+        level: status.level,
+        classId: status.classId,
+        mode: status.mode,
+        intent: status.intent,
+        role: status.role,
+        home: status.home,
+        loc: status.loc,
+        vitals: {
+            hpPct: safePercent(status.vitals?.hpPct),
+            mpPct: safePercent(status.vitals?.mpPct)
+        },
+        target: status.target ? {
+            type: status.target.type,
+            name: status.target.name || null,
+            distance: status.target.distance ? Math.round(status.target.distance) : null
+        } : null,
+        party: status.party ? {
+            leader: status.party.leader?.name || null,
+            stance: status.party.stance,
+            role: status.party.role
+        } : null,
+        spot: status.spot ? {
+            id: status.spot.id,
+            name: status.spot.name,
+            minLevel: status.spot.minLevel,
+            maxLevel: status.spot.maxLevel,
+            density: status.spot.density
+        } : null,
+        movement: status.movement,
+        nearby: status.nearby,
+        trade: status.trade,
+        blockers: status.blockers || [],
+        lastSocialEvent: status.lastSocialEvent || null,
+        roleDecision: status.roleDecision || null
+    };
+}
+
+function compactStateBot(state, hotIds) {
+    if (hotIds.has(Number(state.characterId))) return null;
+    return {
+        id: Number(state.characterId),
+        name: state.name || 'Bot',
+        phase: state.phase || 'cold',
+        level: Number(state.level || 1),
+        mode: state.activity || 'hunting',
+        intent: state.phase === 'warm' ? 'background_active' : 'background_resolve',
+        role: state.party?.role || state.stats?.role || 'dps',
+        home: {
+            region: state.homeRegion || state.currentRegion || null,
+            visitor: false
+        },
+        loc: state.loc || { locX: 0, locY: 0, locZ: 0 },
+        vitals: {
+            hpPct: safePercent(Number(state.vitals?.hp || 0) / Math.max(1, Number(state.vitals?.maxHp || 1))),
+            mpPct: safePercent(Number(state.vitals?.mp || 0) / Math.max(1, Number(state.vitals?.maxMp || 1)))
+        },
+        target: null,
+        party: state.party?.partyId ? {
+            id: state.party.partyId,
+            role: state.party.role || state.stats?.role || 'dps',
+            leaderId: state.party.leaderId || null
+        } : null,
+        spot: state.spotId ? { id: state.spotId, name: state.spotId } : null,
+        movement: { moving: false, towards: false, stuckTicks: 0 },
+        nearby: null,
+        trade: null,
+        blockers: [],
+        updatedAt: state.updatedAt || 0
+    };
+}
+
+function countBy(items, field) {
+    return items.reduce((counts, item) => {
+        const value = item[field] || 'unknown';
+        counts[value] = (counts[value] || 0) + 1;
+        return counts;
+    }, {});
+}
+
+function buildSyntheticEvents(bots) {
+    return bots
+        .filter((bot) => bot.phase === 'hot')
+        .slice(0, 8)
+        .map((bot) => {
+            const detail = bot.target?.name ? `targeting ${bot.target.name}` :
+                bot.spot?.name ? `near ${bot.spot.name}` :
+                bot.party?.leader ? `following ${bot.party.leader}` :
+                bot.intent;
+            return {
+                type: bot.mode || 'bot',
+                summary: `${bot.name} is ${detail}`,
+                createdAt: Date.now(),
+                weight: 1
+            };
+        });
+}
+
+function snapshot() {
+    const BotManager = invoke('GameServer/Bot/BotManager');
+    const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
+    const LifeEvents = invoke('GameServer/Bot/Population/BotLifeEvents');
+    const PopulationStatus = invoke('GameServer/Bot/Population/PopulationStatus');
+
+    const hotBots = BotManager.getAllBotStatuses()
+        .filter((status) => status && status.available)
+        .map(compactHotBot);
+    const hotIds = new Set(hotBots.map((bot) => Number(bot.id)));
+    const stateBots = LifeState.allStates(700)
+        .map((state) => compactStateBot(state, hotIds))
+        .filter(Boolean);
+    const bots = [...hotBots, ...stateBots];
+    const players = realPlayerSessions().map(compactPlayer);
+    const memory = process.memoryUsage();
+
+    return LifeEvents.recent(18).then((events) => ({
+        generatedAt: Date.now(),
+        uptimeMs: Math.round(process.uptime() * 1000),
+        bounds: WORLD_BOUNDS,
+        mapTiles: MAP_TILES,
+        labels: REGION_LABELS,
+        population: PopulationStatus.counts(),
+        runtime: {
+            heapUsedMb: Math.round(memory.heapUsed / 1024 / 1024),
+            rssMb: Math.round(memory.rss / 1024 / 1024)
+        },
+        players,
+        bots,
+        stats: {
+            botsByPhase: countBy(bots, 'phase'),
+            botsByMode: countBy(bots, 'mode'),
+            botsByRole: countBy(bots, 'role'),
+            activeTargets: hotBots.filter((bot) => bot.target).length,
+            moving: hotBots.filter((bot) => bot.movement?.moving).length,
+            blockers: hotBots.filter((bot) => bot.blockers?.length).length
+        },
+        events: events.length > 0 ? events : buildSyntheticEvents(bots)
+    }));
+}
+
+function sendJson(response, data, statusCode = 200) {
+    response.writeHead(statusCode, {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store'
+    });
+    response.end(JSON.stringify(data));
+}
+
+function sendFile(response, filePath) {
+    fs.readFile(filePath, (err, body) => {
+        if (err) {
+            response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+            response.end('Not found');
+            return;
+        }
+
+        response.writeHead(200, {
+            'Content-Type': MIME_TYPES[path.extname(filePath)] || 'application/octet-stream',
+            'Cache-Control': 'no-cache'
+        });
+        response.end(body);
+    });
+}
+
+function route(request, response) {
+    const url = new URL(request.url, 'http://localhost');
+    if (url.pathname === '/' || url.pathname === '/observer') {
+        response.writeHead(302, { Location: '/observer/' });
+        response.end();
+        return;
+    }
+
+    if (url.pathname === '/observer/api/snapshot') {
+        snapshot()
+            .then((data) => sendJson(response, data))
+            .catch((err) => sendJson(response, { error: err.message }, 500));
+        return;
+    }
+
+    if (url.pathname.startsWith('/observer/')) {
+        const relative = url.pathname.replace(/^\/observer\/?/, '') || 'index.html';
+        const safeRelative = path.normalize(relative).replace(/^(\.\.[/\\])+/, '');
+        const filePath = path.join(PUBLIC_DIR, safeRelative);
+        if (!filePath.startsWith(PUBLIC_DIR)) {
+            response.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+            response.end('Forbidden');
+            return;
+        }
+        sendFile(response, filePath);
+        return;
+    }
+
+    response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    response.end('Not found');
+}
+
+const WorldObserverServer = {
+    server: null,
+
+    init() {
+        if (!isEnabled() || this.server) return;
+
+        const config = options.default.WorldObserver || {};
+        const hostname = config.hostname || '127.0.0.1';
+        const port = Number(config.port || 8088);
+
+        this.server = http.createServer(route);
+        this.server.listen(port, hostname, () => {
+            utils.infoSuccess('Observer', 'world observer ready at http://%s:%d/observer/', hostname, port);
+        });
+
+        this.server.on('error', (err) => {
+            utils.infoWarn('Observer', 'world observer failed: %s', err.message);
+        });
+    }
+};
+
+module.exports = WorldObserverServer;

--- a/src/WorldObserver/public/app.js
+++ b/src/WorldObserver/public/app.js
@@ -1,0 +1,586 @@
+const state = {
+    snapshot: null,
+    selectedId: null,
+    phase: 'all',
+    live: true,
+    fit: false,
+    renderedTileKey: null,
+    viewport: null,
+    drag: null
+};
+
+const COLORS = {
+    hot: '#63d37b',
+    warm: '#e2a84f',
+    cold: '#7aa7ff',
+    player: '#57c7e8',
+    merchant: '#d8b96d',
+    dead: '#e66d61'
+};
+
+const els = {
+    serverLine: document.querySelector('#serverLine'),
+    liveToggle: document.querySelector('#liveToggle'),
+    fitButton: document.querySelector('#fitButton'),
+    filterStrip: document.querySelector('#filterStrip'),
+    worldMap: document.querySelector('#worldMap'),
+    tileLayer: document.querySelector('#tileLayer'),
+    gridLines: document.querySelector('#gridLines'),
+    regionLabels: document.querySelector('#regionLabels'),
+    pointsLayer: document.querySelector('#pointsLayer'),
+    selectedCard: document.querySelector('#selectedCard'),
+    botsTotal: document.querySelector('#botsTotal'),
+    playersTotal: document.querySelector('#playersTotal'),
+    movingTotal: document.querySelector('#movingTotal'),
+    targetsTotal: document.querySelector('#targetsTotal'),
+    phaseBars: document.querySelector('#phaseBars'),
+    modeList: document.querySelector('#modeList'),
+    actorList: document.querySelector('#actorList'),
+    eventList: document.querySelector('#eventList'),
+    lastRefresh: document.querySelector('#lastRefresh'),
+    heapLine: document.querySelector('#heapLine'),
+    visibleCount: document.querySelector('#visibleCount')
+};
+
+const DEFAULT_TILES = {
+    rawBaseUrl: 'https://raw.githubusercontent.com/npetrovski/l2-world-map/main/Maps',
+    blockSize: 32768,
+    blockPx: 900,
+    x: { min: 16, max: 26, mid: 20 },
+    y: { min: 10, max: 25, mid: 18 },
+    hiddenRanges: [
+        { x1: 16, x2: 16, y1: 11, y2: 13 },
+        { x1: 17, x2: 22, y1: 10, y2: 13 },
+        { x1: 26, x2: 26, y1: 10, y2: 25 }
+    ]
+};
+
+function svgEl(name, attrs = {}) {
+    const node = document.createElementNS('http://www.w3.org/2000/svg', name);
+    Object.entries(attrs).forEach(([key, value]) => node.setAttribute(key, value));
+    return node;
+}
+
+function formatDuration(ms) {
+    const totalSeconds = Math.max(0, Math.floor(Number(ms || 0) / 1000));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    if (minutes > 0) return `${minutes}m ${seconds}s`;
+    return `${seconds}s`;
+}
+
+function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+}
+
+function clampViewport(viewport) {
+    const tiles = mapMeta();
+    const minWidth = 700;
+    const minHeight = 500;
+    const width = clamp(viewport.width, minWidth, tiles.width);
+    const height = clamp(viewport.height, minHeight, tiles.height);
+    return {
+        x: clamp(viewport.x, 0, Math.max(0, tiles.width - width)),
+        y: clamp(viewport.y, 0, Math.max(0, tiles.height - height)),
+        width,
+        height
+    };
+}
+
+function mapMeta() {
+    const tiles = state.snapshot?.mapTiles || DEFAULT_TILES;
+    const width = (tiles.x.max - tiles.x.min + 1) * tiles.blockPx;
+    const height = (tiles.y.max - tiles.y.min + 1) * tiles.blockPx;
+    return { ...tiles, width, height };
+}
+
+function worldToMap(loc) {
+    const tiles = mapMeta();
+    const blockX = Math.floor(Number(loc.locX || 0) / tiles.blockSize) + tiles.x.mid;
+    const blockY = Math.floor(Number(loc.locY || 0) / tiles.blockSize) + tiles.y.mid;
+    let modX = (Number(loc.locX || 0) / tiles.blockSize) % 1;
+    let modY = (Number(loc.locY || 0) / tiles.blockSize) % 1;
+    if (modX < 0) modX += 1;
+    if (modY < 0) modY += 1;
+
+    return {
+        x: ((blockX - tiles.x.min) * tiles.blockPx) + (modX * tiles.blockPx),
+        y: ((blockY - tiles.y.min) * tiles.blockPx) + (modY * tiles.blockPx)
+    };
+}
+
+function project(loc) {
+    const point = worldToMap(loc);
+    const tiles = mapMeta();
+    return {
+        x: clamp(point.x, 18, tiles.width - 18),
+        y: clamp(point.y, 18, tiles.height - 18)
+    };
+}
+
+function setSvgViewBox() {
+    const tiles = mapMeta();
+    els.worldMap.querySelector('.sea').setAttribute('width', tiles.width);
+    els.worldMap.querySelector('.sea').setAttribute('height', tiles.height);
+
+    if (!state.viewport) {
+        state.viewport = { x: 0, y: 0, width: tiles.width, height: tiles.height };
+    }
+
+    if (!state.fit || !state.snapshot) {
+        const viewport = clampViewport(state.viewport);
+        state.viewport = viewport;
+        els.worldMap.setAttribute('viewBox', `${viewport.x} ${viewport.y} ${viewport.width} ${viewport.height}`);
+        return;
+    }
+
+    const locs = [...state.snapshot.bots, ...state.snapshot.players].map((item) => item.loc).filter(Boolean);
+    if (locs.length < 2) {
+        state.viewport = { x: 0, y: 0, width: tiles.width, height: tiles.height };
+        els.worldMap.setAttribute('viewBox', `0 0 ${tiles.width} ${tiles.height}`);
+        return;
+    }
+
+    const points = locs.map(worldToMap);
+    const xs = points.map((point) => point.x);
+    const ys = points.map((point) => point.y);
+    const pad = 900;
+    const minX = clamp(Math.min(...xs) - pad, 0, tiles.width);
+    const minY = clamp(Math.min(...ys) - pad, 0, tiles.height);
+    const maxX = clamp(Math.max(...xs) + pad, 0, tiles.width);
+    const maxY = clamp(Math.max(...ys) + pad, 0, tiles.height);
+    state.viewport = clampViewport({
+        x: minX,
+        y: minY,
+        width: Math.max(1800, maxX - minX),
+        height: Math.max(1200, maxY - minY)
+    });
+    els.worldMap.setAttribute('viewBox', `${state.viewport.x} ${state.viewport.y} ${state.viewport.width} ${state.viewport.height}`);
+}
+
+function clientToMapPoint(clientX, clientY) {
+    const rect = els.worldMap.getBoundingClientRect();
+    const viewport = state.viewport || {
+        x: 0,
+        y: 0,
+        width: mapMeta().width,
+        height: mapMeta().height
+    };
+    return {
+        x: viewport.x + ((clientX - rect.left) / rect.width) * viewport.width,
+        y: viewport.y + ((clientY - rect.top) / rect.height) * viewport.height
+    };
+}
+
+function applyViewport(viewport) {
+    state.fit = false;
+    els.fitButton.classList.remove('is-live');
+    state.viewport = clampViewport(viewport);
+    els.worldMap.setAttribute('viewBox', `${state.viewport.x} ${state.viewport.y} ${state.viewport.width} ${state.viewport.height}`);
+}
+
+function phaseColor(item) {
+    if (item.kind === 'player') return COLORS.player;
+    if (item.mode === 'merchant') return COLORS.merchant;
+    if (item.blockers && item.blockers.includes('dead')) return COLORS.dead;
+    return COLORS[item.phase] || COLORS.cold;
+}
+
+function isVisible(item) {
+    if (state.phase === 'all') return true;
+    if (state.phase === 'players') return item.kind === 'player';
+    return item.kind !== 'player' && item.phase === state.phase;
+}
+
+function renderGrid() {
+    const tiles = mapMeta();
+    els.gridLines.innerHTML = '';
+    for (let x = 0; x <= tiles.width; x += tiles.blockPx) {
+        els.gridLines.appendChild(svgEl('line', { x1: x, x2: x, y1: 0, y2: tiles.height }));
+    }
+    for (let y = 0; y <= tiles.height; y += tiles.blockPx) {
+        els.gridLines.appendChild(svgEl('line', { x1: 0, x2: tiles.width, y1: y, y2: y }));
+    }
+}
+
+function renderTiles() {
+    const tiles = mapMeta();
+    const hiddenKey = JSON.stringify(tiles.hiddenRanges || []);
+    const tileKey = `${tiles.rawBaseUrl}|${tiles.x.min}-${tiles.x.max}|${tiles.y.min}-${tiles.y.max}|${tiles.blockPx}|${hiddenKey}`;
+    if (state.renderedTileKey === tileKey) return;
+
+    els.tileLayer.innerHTML = '';
+
+    for (let x = tiles.x.min; x <= tiles.x.max; x += 1) {
+        for (let y = tiles.y.min; y <= tiles.y.max; y += 1) {
+            const hidden = (tiles.hiddenRanges || []).some((range) => (
+                x >= range.x1 && x <= range.x2 && y >= range.y1 && y <= range.y2
+            ));
+            if (hidden) continue;
+
+            const image = svgEl('image', {
+                href: `${tiles.rawBaseUrl}/${x}_${y}.jpg`,
+                x: (x - tiles.x.min) * tiles.blockPx,
+                y: (y - tiles.y.min) * tiles.blockPx,
+                width: tiles.blockPx,
+                height: tiles.blockPx,
+                preserveAspectRatio: 'none'
+            });
+            els.tileLayer.appendChild(image);
+        }
+    }
+
+    state.renderedTileKey = tileKey;
+}
+
+function renderLabels() {
+    const snap = state.snapshot;
+    els.regionLabels.innerHTML = '';
+    if (!snap) return;
+
+    snap.labels.forEach((label) => {
+        const point = project(label);
+        els.regionLabels.appendChild(svgEl('circle', {
+            cx: point.x,
+            cy: point.y,
+            r: label.kind === 'town' ? 48 : 36
+        }));
+        const text = svgEl('text', {
+            x: point.x + 85,
+            y: point.y - 70
+        });
+        text.textContent = label.name;
+        els.regionLabels.appendChild(text);
+    });
+}
+
+function renderPoints() {
+    const snap = state.snapshot;
+    els.pointsLayer.innerHTML = '';
+    if (!snap) return;
+
+    const actors = [
+        ...snap.bots.map((bot) => ({ ...bot, kind: 'bot' })),
+        ...snap.players.map((player) => ({
+            ...player,
+            kind: 'player',
+            phase: 'player',
+            mode: 'player',
+            role: 'player',
+            intent: player.online ? 'online' : 'offline'
+        }))
+    ];
+
+    actors.forEach((actor) => {
+        if (!actor.loc) return;
+
+        const point = project(actor.loc);
+        const color = phaseColor(actor);
+        const visible = isVisible(actor);
+        const group = svgEl('g', {
+            class: `point${visible ? '' : ' is-muted'}`,
+            transform: `translate(${point.x}, ${point.y})`,
+            tabindex: 0,
+            role: 'button',
+            'data-actor-id': actor.id,
+            'data-actor-kind': actor.kind,
+            'aria-label': actor.name
+        });
+        group.addEventListener('pointerdown', (event) => {
+            event.stopPropagation();
+        });
+        group.addEventListener('pointerup', (event) => {
+            event.stopPropagation();
+            selectActor(actor.id, actor.kind);
+        });
+        group.addEventListener('click', (event) => {
+            event.stopPropagation();
+            selectActor(actor.id, actor.kind);
+        });
+        group.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                selectActor(actor.id, actor.kind);
+            }
+        });
+
+        const radius = actor.kind === 'player' ? 72 : actor.phase === 'hot' ? 62 : 45;
+        group.appendChild(svgEl('circle', {
+            class: 'point-hit',
+            r: radius + 92,
+            fill: 'transparent'
+        }));
+        group.appendChild(svgEl('circle', {
+            class: 'point-ring',
+            r: radius + 58,
+            stroke: color,
+            opacity: visible ? 0.45 : 0.12
+        }));
+        group.appendChild(svgEl('circle', {
+            class: 'point-core',
+            r: radius,
+            fill: color
+        }));
+
+        if (actor.phase === 'hot' || actor.kind === 'player') {
+            const text = svgEl('text', {
+                class: 'point-label',
+                x: radius + 84,
+                y: 42
+            });
+            text.textContent = actor.name;
+            group.appendChild(text);
+        }
+
+        els.pointsLayer.appendChild(group);
+    });
+
+    els.visibleCount.textContent = `${actors.filter(isVisible).length} visible`;
+}
+
+function sortedEntries(object) {
+    return Object.entries(object || {}).sort((a, b) => b[1] - a[1]);
+}
+
+function renderPhaseBars() {
+    const counts = state.snapshot?.stats?.botsByPhase || {};
+    const total = Math.max(1, Object.values(counts).reduce((sum, value) => sum + value, 0));
+    els.phaseBars.innerHTML = '';
+
+    ['hot', 'warm', 'cold'].forEach((phase) => {
+        const count = counts[phase] || 0;
+        const row = document.createElement('div');
+        row.className = 'bar-row';
+        row.innerHTML = `
+            <span>${phase}</span>
+            <div class="bar-track"><div class="bar-fill" style="width:${Math.max(2, (count / total) * 100)}%;background:${COLORS[phase]}"></div></div>
+            <strong>${count}</strong>
+        `;
+        els.phaseBars.appendChild(row);
+    });
+}
+
+function renderModeList() {
+    const entries = sortedEntries(state.snapshot?.stats?.botsByMode).slice(0, 8);
+    els.modeList.innerHTML = '';
+
+    entries.forEach(([mode, count]) => {
+        const row = document.createElement('div');
+        row.className = 'mode-row';
+        row.innerHTML = `<span>${mode}</span><strong>${count}</strong>`;
+        els.modeList.appendChild(row);
+    });
+}
+
+function renderActorList() {
+    const bots = [...(state.snapshot?.bots || [])]
+        .sort((a, b) => {
+            const phaseRank = { hot: 0, warm: 1, cold: 2 };
+            return (phaseRank[a.phase] ?? 9) - (phaseRank[b.phase] ?? 9) || String(a.name).localeCompare(String(b.name));
+        })
+        .slice(0, 70);
+
+    els.actorList.innerHTML = '';
+    bots.forEach((bot) => {
+        const button = document.createElement('button');
+        button.className = 'actor-row';
+        button.type = 'button';
+        button.addEventListener('click', () => selectActor(bot.id, 'bot'));
+        button.innerHTML = `
+            <span class="phase-dot" style="background:${phaseColor(bot)}"></span>
+            <span class="actor-main">
+                <strong>${bot.name}</strong>
+                <span>${bot.phase} / ${bot.mode} / Lv ${bot.level}</span>
+            </span>
+            <span class="actor-vitals">
+                <span>HP ${bot.vitals?.hpPct ?? 0}%</span>
+                <span>MP ${bot.vitals?.mpPct ?? 0}%</span>
+            </span>
+        `;
+        els.actorList.appendChild(button);
+    });
+}
+
+function renderEvents() {
+    const events = state.snapshot?.events || [];
+    els.eventList.innerHTML = '';
+
+    events.slice(0, 18).forEach((event) => {
+        const row = document.createElement('div');
+        row.className = 'event-row';
+        row.innerHTML = `
+            <strong>${event.type || 'event'}</strong>
+            <p>${event.summary || 'No summary'}</p>
+        `;
+        els.eventList.appendChild(row);
+    });
+}
+
+function actorById(id, kind) {
+    const snap = state.snapshot;
+    if (!snap) return null;
+    if (kind === 'player') return snap.players.find((player) => String(player.id) === String(id));
+    return snap.bots.find((bot) => String(bot.id) === String(id));
+}
+
+function selectActor(id, kind = 'bot') {
+    state.selectedId = { id, kind };
+    renderSelected();
+}
+
+function renderSelected() {
+    if (!state.selectedId) return;
+    const actor = actorById(state.selectedId.id, state.selectedId.kind);
+    if (!actor) return;
+
+    const loc = actor.loc ? `${Math.round(actor.loc.locX)}, ${Math.round(actor.loc.locY)}, ${Math.round(actor.loc.locZ || 0)}` : 'unknown';
+    const hpPct = actor.vitals?.hpPct ?? 0;
+    const mpPct = actor.vitals?.mpPct ?? 0;
+    const detail = actor.kind === 'player' || state.selectedId.kind === 'player'
+        ? `Player / ${actor.online ? 'online' : 'offline'}`
+        : `${actor.phase} / ${actor.mode} / ${actor.intent || 'idle'} / ${actor.role}`;
+    const target = actor.target?.name ? `Target: ${actor.target.name}` : actor.spot?.name ? `Spot: ${actor.spot.name}` : 'No target';
+
+    els.selectedCard.innerHTML = `
+        <span class="eyeline">Selected</span>
+        <strong>${actor.name}</strong>
+        <p class="selected-meta">Lv ${actor.level} / ${detail}</p>
+        <div class="selected-bars" aria-label="Selected actor vitals">
+            <div class="selected-bar">
+                <span>HP</span>
+                <div class="selected-bar-track"><div class="selected-bar-fill hp" style="width:${hpPct}%"></div></div>
+                <strong>${hpPct}%</strong>
+            </div>
+            <div class="selected-bar">
+                <span>MP</span>
+                <div class="selected-bar-track"><div class="selected-bar-fill mp" style="width:${mpPct}%"></div></div>
+                <strong>${mpPct}%</strong>
+            </div>
+        </div>
+        <p>${target}<br>Loc ${loc}</p>
+    `;
+}
+
+function renderSnapshot() {
+    const snap = state.snapshot;
+    if (!snap) return;
+
+    els.botsTotal.textContent = snap.bots.length;
+    els.playersTotal.textContent = snap.players.length;
+    els.movingTotal.textContent = snap.stats.moving || 0;
+    els.targetsTotal.textContent = snap.stats.activeTargets || 0;
+    els.lastRefresh.textContent = new Date(snap.generatedAt).toLocaleTimeString();
+    els.heapLine.textContent = `heap ${snap.runtime.heapUsedMb} MB`;
+    els.serverLine.textContent = `uptime ${formatDuration(snap.uptimeMs)} / hot ${snap.population.hot} / warm ${snap.population.warm} / cold ${snap.population.cold}`;
+
+    setSvgViewBox();
+    renderTiles();
+    renderGrid();
+    renderLabels();
+    renderPoints();
+    renderPhaseBars();
+    renderModeList();
+    renderActorList();
+    renderEvents();
+    renderSelected();
+}
+
+async function refresh() {
+    if (!state.live) return;
+    try {
+        const response = await fetch('/observer/api/snapshot', { cache: 'no-store' });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        state.snapshot = await response.json();
+        renderSnapshot();
+    } catch (err) {
+        els.serverLine.textContent = `Observer snapshot failed: ${err.message}`;
+    }
+}
+
+els.liveToggle.addEventListener('click', () => {
+    state.live = !state.live;
+    els.liveToggle.classList.toggle('is-live', state.live);
+    els.liveToggle.title = state.live ? 'Pause live refresh' : 'Resume live refresh';
+    els.liveToggle.lastChild.textContent = state.live ? 'Live' : 'Paused';
+    if (state.live) refresh();
+});
+
+els.fitButton.addEventListener('click', () => {
+    state.fit = true;
+    els.fitButton.classList.add('is-live');
+    setSvgViewBox();
+    renderLabels();
+    renderPoints();
+});
+
+els.filterStrip.addEventListener('click', (event) => {
+    const button = event.target.closest('[data-phase]');
+    if (!button) return;
+    state.phase = button.dataset.phase;
+    els.filterStrip.querySelectorAll('.filter').forEach((item) => {
+        item.classList.toggle('is-active', item === button);
+    });
+    renderPoints();
+});
+
+els.worldMap.addEventListener('wheel', (event) => {
+    event.preventDefault();
+    const viewport = state.viewport || {
+        x: 0,
+        y: 0,
+        width: mapMeta().width,
+        height: mapMeta().height
+    };
+    const focus = clientToMapPoint(event.clientX, event.clientY);
+    const zoomFactor = event.deltaY < 0 ? 0.82 : 1.22;
+    const nextWidth = viewport.width * zoomFactor;
+    const nextHeight = viewport.height * zoomFactor;
+    const focusRatioX = (focus.x - viewport.x) / viewport.width;
+    const focusRatioY = (focus.y - viewport.y) / viewport.height;
+
+    applyViewport({
+        x: focus.x - nextWidth * focusRatioX,
+        y: focus.y - nextHeight * focusRatioY,
+        width: nextWidth,
+        height: nextHeight
+    });
+}, { passive: false });
+
+els.worldMap.addEventListener('pointerdown', (event) => {
+    if (event.button !== 0) return;
+    els.worldMap.setPointerCapture(event.pointerId);
+    state.drag = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        viewport: { ...(state.viewport || { x: 0, y: 0, width: mapMeta().width, height: mapMeta().height }) }
+    };
+    els.worldMap.classList.add('is-dragging');
+});
+
+els.worldMap.addEventListener('pointermove', (event) => {
+    if (!state.drag || state.drag.pointerId !== event.pointerId) return;
+    const rect = els.worldMap.getBoundingClientRect();
+    const dx = ((event.clientX - state.drag.startX) / rect.width) * state.drag.viewport.width;
+    const dy = ((event.clientY - state.drag.startY) / rect.height) * state.drag.viewport.height;
+
+    applyViewport({
+        ...state.drag.viewport,
+        x: state.drag.viewport.x - dx,
+        y: state.drag.viewport.y - dy
+    });
+});
+
+function finishDrag(event) {
+    if (!state.drag || state.drag.pointerId !== event.pointerId) return;
+    state.drag = null;
+    els.worldMap.classList.remove('is-dragging');
+}
+
+els.worldMap.addEventListener('pointerup', finishDrag);
+els.worldMap.addEventListener('pointercancel', finishDrag);
+
+refresh();
+setInterval(refresh, 2000);

--- a/src/WorldObserver/public/index.html
+++ b/src/WorldObserver/public/index.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>World Observer</title>
+    <link rel="icon" href="data:,">
+    <link rel="stylesheet" href="/observer/styles.css">
+</head>
+<body>
+    <main class="observer-shell">
+        <section class="map-panel" aria-label="World map">
+            <header class="topbar">
+                <div>
+                    <h1>World Observer</h1>
+                    <p id="serverLine">Waiting for server snapshot</p>
+                </div>
+                <div class="topbar-actions">
+                    <button class="icon-button" id="fitButton" title="Fit all points" aria-label="Fit all points">
+                        <span>F</span>
+                    </button>
+                    <button class="live-toggle is-live" id="liveToggle" title="Pause live refresh" aria-label="Pause live refresh">
+                        <span class="pulse"></span>
+                        Live
+                    </button>
+                </div>
+            </header>
+
+            <div class="filter-strip" id="filterStrip" aria-label="Map filters">
+                <button class="filter is-active" data-phase="all">All</button>
+                <button class="filter" data-phase="hot">Hot</button>
+                <button class="filter" data-phase="warm">Warm</button>
+                <button class="filter" data-phase="cold">Cold</button>
+                <button class="filter" data-phase="players">Players</button>
+            </div>
+
+            <div class="map-stage">
+                <svg id="worldMap" viewBox="0 0 1200 760" role="img" aria-label="Lineage II C2 world observer map">
+                    <defs>
+                        <radialGradient id="seaGlow" cx="50%" cy="45%" r="70%">
+                            <stop offset="0%" stop-color="#172d31"></stop>
+                            <stop offset="100%" stop-color="#081114"></stop>
+                        </radialGradient>
+                        <linearGradient id="landGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                            <stop offset="0%" stop-color="#796b48"></stop>
+                            <stop offset="45%" stop-color="#3c513e"></stop>
+                            <stop offset="100%" stop-color="#222f31"></stop>
+                        </linearGradient>
+                        <filter id="pinGlow" x="-80%" y="-80%" width="260%" height="260%">
+                            <feGaussianBlur stdDeviation="4" result="blur"></feGaussianBlur>
+                            <feMerge>
+                                <feMergeNode in="blur"></feMergeNode>
+                                <feMergeNode in="SourceGraphic"></feMergeNode>
+                            </feMerge>
+                        </filter>
+                    </defs>
+                    <rect class="sea" x="0" y="0" width="1200" height="760"></rect>
+                    <g class="tile-layer" id="tileLayer"></g>
+                    <g class="grid-lines" id="gridLines"></g>
+                    <g class="region-labels" id="regionLabels"></g>
+                    <g class="points" id="pointsLayer"></g>
+                </svg>
+
+                <div class="selected-card" id="selectedCard">
+                    <span class="eyeline">Selected</span>
+                    <strong>No actor selected</strong>
+                    <p>Click any bot or player point on the map.</p>
+                </div>
+            </div>
+        </section>
+
+        <aside class="side-panel" aria-label="World statistics">
+            <section class="metric-grid">
+                <div class="metric">
+                    <span>Bots</span>
+                    <strong id="botsTotal">0</strong>
+                </div>
+                <div class="metric">
+                    <span>Players</span>
+                    <strong id="playersTotal">0</strong>
+                </div>
+                <div class="metric">
+                    <span>Moving</span>
+                    <strong id="movingTotal">0</strong>
+                </div>
+                <div class="metric">
+                    <span>Targets</span>
+                    <strong id="targetsTotal">0</strong>
+                </div>
+            </section>
+
+            <section class="panel-section">
+                <div class="section-title">
+                    <h2>Population</h2>
+                    <span id="lastRefresh">--</span>
+                </div>
+                <div class="phase-bars" id="phaseBars"></div>
+            </section>
+
+            <section class="panel-section">
+                <div class="section-title">
+                    <h2>Mode Mix</h2>
+                    <span id="heapLine">heap -- MB</span>
+                </div>
+                <div class="mode-list" id="modeList"></div>
+            </section>
+
+            <section class="panel-section actor-list-section">
+                <div class="section-title">
+                    <h2>Active Bots</h2>
+                    <span id="visibleCount">0 visible</span>
+                </div>
+                <div class="actor-list" id="actorList"></div>
+            </section>
+
+            <section class="panel-section events-section">
+                <div class="section-title">
+                    <h2>Events</h2>
+                    <span>recent</span>
+                </div>
+                <div class="event-list" id="eventList"></div>
+            </section>
+        </aside>
+    </main>
+
+    <script src="/observer/app.js"></script>
+</body>
+</html>

--- a/src/WorldObserver/public/styles.css
+++ b/src/WorldObserver/public/styles.css
@@ -1,0 +1,542 @@
+:root {
+    --bg: #071012;
+    --panel: #10191b;
+    --panel-2: #152124;
+    --line: rgba(189, 178, 135, 0.18);
+    --text: #edf0e8;
+    --muted: #9aa59f;
+    --faint: #6f7b76;
+    --gold: #d8b96d;
+    --green: #63d37b;
+    --cyan: #57c7e8;
+    --amber: #e2a84f;
+    --blue: #7aa7ff;
+    --red: #e66d61;
+    --shadow: 0 18px 60px rgba(0, 0, 0, 0.35);
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    color: var(--text);
+    background:
+        linear-gradient(135deg, rgba(216, 185, 109, 0.08), transparent 28%),
+        linear-gradient(180deg, #0a1517 0%, var(--bg) 100%);
+}
+
+button {
+    font: inherit;
+}
+
+.observer-shell {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 380px;
+    gap: 18px;
+    height: 100vh;
+    overflow: hidden;
+    padding: 18px;
+}
+
+.map-panel,
+.side-panel {
+    min-width: 0;
+}
+
+.map-panel {
+    display: grid;
+    grid-template-rows: auto auto minmax(0, 1fr);
+    gap: 12px;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.topbar {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: center;
+    padding: 8px 2px 0;
+}
+
+h1,
+h2,
+p {
+    margin: 0;
+}
+
+h1 {
+    font-size: 30px;
+    line-height: 1.05;
+    font-weight: 760;
+    letter-spacing: 0;
+}
+
+.topbar p {
+    margin-top: 7px;
+    color: var(--muted);
+    font-size: 13px;
+}
+
+.topbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.icon-button,
+.live-toggle,
+.filter {
+    border: 1px solid var(--line);
+    color: var(--text);
+    background: rgba(16, 25, 27, 0.86);
+    cursor: pointer;
+}
+
+.icon-button {
+    width: 38px;
+    height: 38px;
+    border-radius: 8px;
+    font-weight: 800;
+}
+
+.live-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 38px;
+    padding: 0 13px;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.pulse {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--faint);
+}
+
+.is-live .pulse {
+    background: var(--green);
+    box-shadow: 0 0 18px rgba(99, 211, 123, 0.9);
+}
+
+.filter-strip {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.filter {
+    min-width: 72px;
+    height: 34px;
+    padding: 0 12px;
+    border-radius: 8px;
+    color: var(--muted);
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.filter.is-active {
+    color: #111712;
+    background: var(--gold);
+    border-color: transparent;
+}
+
+.map-stage {
+    position: relative;
+    overflow: hidden;
+    min-height: 0;
+    height: 100%;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: #081113;
+    box-shadow: var(--shadow);
+}
+
+#worldMap {
+    display: block;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    background: #081113;
+    cursor: grab;
+    touch-action: none;
+    user-select: none;
+}
+
+#worldMap.is-dragging {
+    cursor: grabbing;
+}
+
+.sea {
+    fill: url("#seaGlow");
+}
+
+.tile-layer image {
+    opacity: 0.92;
+}
+
+.grid-lines line {
+    stroke: rgba(237, 240, 232, 0.11);
+    stroke-width: 9;
+}
+
+.region-labels text {
+    fill: rgba(237, 240, 232, 0.68);
+    font-size: 150px;
+    font-weight: 700;
+    paint-order: stroke;
+    stroke: rgba(7, 16, 18, 0.86);
+    stroke-width: 44px;
+}
+
+.region-labels circle {
+    fill: rgba(216, 185, 109, 0.18);
+    stroke: rgba(216, 185, 109, 0.68);
+    stroke-width: 12;
+}
+
+.point {
+    cursor: pointer;
+    filter: url("#pinGlow");
+}
+
+.point-hit {
+    pointer-events: all;
+}
+
+.point-ring {
+    fill: transparent;
+    stroke-width: 24;
+}
+
+.point-core {
+    stroke: rgba(7, 16, 18, 0.8);
+    stroke-width: 12;
+}
+
+.point-label {
+    fill: var(--text);
+    font-size: 128px;
+    font-weight: 760;
+    paint-order: stroke;
+    stroke: rgba(7, 16, 18, 0.9);
+    stroke-width: 34px;
+    pointer-events: none;
+}
+
+.point.is-muted {
+    opacity: 0.22;
+}
+
+.selected-card {
+    position: absolute;
+    left: 18px;
+    bottom: 18px;
+    width: min(360px, calc(100% - 36px));
+    padding: 14px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: rgba(10, 17, 19, 0.84);
+    backdrop-filter: blur(14px);
+    pointer-events: none;
+}
+
+.eyeline {
+    display: block;
+    margin-bottom: 6px;
+    color: var(--gold);
+    font-size: 11px;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.selected-card strong {
+    display: block;
+    font-size: 18px;
+}
+
+.selected-card p {
+    margin-top: 6px;
+    color: var(--muted);
+    font-size: 13px;
+    line-height: 1.45;
+}
+
+.selected-meta {
+    margin-top: 5px;
+}
+
+.selected-bars {
+    display: grid;
+    gap: 7px;
+    margin-top: 11px;
+    margin-bottom: 9px;
+}
+
+.selected-bar {
+    display: grid;
+    grid-template-columns: 24px minmax(0, 1fr) 42px;
+    align-items: center;
+    gap: 8px;
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 800;
+}
+
+.selected-bar-track {
+    height: 8px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(237, 240, 232, 0.1);
+}
+
+.selected-bar-fill {
+    height: 100%;
+    min-width: 2px;
+    border-radius: inherit;
+}
+
+.selected-bar-fill.hp {
+    background: var(--green);
+}
+
+.selected-bar-fill.mp {
+    background: var(--cyan);
+}
+
+.selected-bar strong {
+    color: var(--text);
+    font-size: 11px;
+    text-align: right;
+}
+
+.side-panel {
+    display: grid;
+    grid-template-rows: auto auto auto minmax(200px, 1fr) minmax(160px, 0.72fr);
+    gap: 12px;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.metric-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+}
+
+.metric,
+.panel-section {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: rgba(16, 25, 27, 0.88);
+    box-shadow: 0 14px 40px rgba(0, 0, 0, 0.22);
+}
+
+.metric {
+    min-height: 82px;
+    padding: 14px;
+}
+
+.metric span {
+    display: block;
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 760;
+}
+
+.metric strong {
+    display: block;
+    margin-top: 8px;
+    font-size: 30px;
+    line-height: 1;
+}
+
+.panel-section {
+    min-height: 0;
+    padding: 14px;
+}
+
+.section-title {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.section-title h2 {
+    font-size: 14px;
+    font-weight: 800;
+}
+
+.section-title span {
+    color: var(--faint);
+    font-size: 12px;
+    font-weight: 700;
+}
+
+.phase-bars,
+.mode-list,
+.actor-list,
+.event-list {
+    display: grid;
+    gap: 8px;
+}
+
+.bar-row {
+    display: grid;
+    grid-template-columns: 54px minmax(0, 1fr) 34px;
+    align-items: center;
+    gap: 9px;
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 700;
+}
+
+.bar-track {
+    height: 8px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(237, 240, 232, 0.08);
+}
+
+.bar-fill {
+    height: 100%;
+    min-width: 2px;
+    border-radius: inherit;
+}
+
+.mode-row,
+.actor-row,
+.event-row {
+    border: 1px solid rgba(237, 240, 232, 0.08);
+    border-radius: 8px;
+    background: rgba(237, 240, 232, 0.035);
+}
+
+.mode-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 9px 10px;
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 760;
+}
+
+.actor-list-section,
+.events-section {
+    min-height: 0;
+    overflow: hidden;
+}
+
+.actor-list,
+.event-list {
+    max-height: 100%;
+    overflow: auto;
+    padding-right: 2px;
+}
+
+.actor-row {
+    display: grid;
+    grid-template-columns: 10px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 10px;
+    color: var(--text);
+    text-align: left;
+    cursor: pointer;
+}
+
+.phase-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+}
+
+.actor-main strong {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 13px;
+}
+
+.actor-main span {
+    display: block;
+    margin-top: 3px;
+    overflow: hidden;
+    color: var(--muted);
+    font-size: 12px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.actor-vitals {
+    display: grid;
+    gap: 4px;
+    color: var(--faint);
+    font-size: 11px;
+    font-weight: 800;
+    text-align: right;
+}
+
+.event-row {
+    padding: 10px;
+}
+
+.event-row strong {
+    display: block;
+    color: var(--gold);
+    font-size: 11px;
+    text-transform: uppercase;
+}
+
+.event-row p {
+    margin-top: 4px;
+    color: var(--muted);
+    font-size: 12px;
+    line-height: 1.35;
+}
+
+@media (max-width: 1080px) {
+    .observer-shell {
+        grid-template-columns: 1fr;
+    }
+
+    .side-panel {
+        grid-template-rows: auto;
+    }
+}
+
+@media (max-width: 680px) {
+    .observer-shell {
+        padding: 12px;
+    }
+
+    .topbar {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    h1 {
+        font-size: 24px;
+    }
+
+    .metric-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .filter {
+        min-width: 64px;
+    }
+}


### PR DESCRIPTION
## Summary
- add a local World Observer web page that starts with NodeL2 and serves `/observer/`
- expose a read-only observer snapshot with players, bot phases, population counts, recent bot-life events, and runtime stats
- render a live Lineage II world map with bot/player markers, phase filters, pan/zoom, fit-to-actors, and selected-actor HP/MP bars

## Validation
- git diff --cached --check
- node --check src/NodeL2.js
- node --check src/GameServer/Bot/Population/BotLifeEvents.js
- node --check src/GameServer/Bot/Population/BotLifeState.js
- node --check src/WorldObserver/WorldObserverServer.js
- node --check src/WorldObserver/public/app.js
- browser smoke: observer page loaded with 700 actor points and 133 map tiles; pan/zoom, point selection, selected actor bars, and live refresh were checked
