### PR TITLE
Ready and equip bots on spawn

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -53,7 +53,6 @@ generatedColdSeedDelayMs = 45000
 activationRadius = 4500
 activationLevelRange = 5
 maxActivationsPerScan = 6
-maxRestingActivationRatio = 0.2
 partyInviteRange = 6000
 devLogPlayerChat = true
 debug = false

--- a/src/GameServer/Bot/AI/BotGear.js
+++ b/src/GameServer/Bot/AI/BotGear.js
@@ -1,0 +1,375 @@
+const Database = invoke('Database');
+const DataCache = invoke('GameServer/DataCache');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
+
+const ARMOR_SLOTS = {
+    earringRight: 1,
+    earringLeft: 2,
+    necklace: 3,
+    ringRight: 4,
+    ringLeft: 5,
+    head: 6,
+    weapon: 7,
+    shield: 8,
+    hands: 9,
+    chest: 10,
+    pants: 11,
+    feet: 12,
+    dual: 14,
+    fullArmor: 15
+};
+
+const GRADE_BANDS = [
+    { rank: 'none', min: 1, max: 19 },
+    { rank: 'd', min: 20, max: 39 },
+    { rank: 'c', min: 40, max: 51 },
+    { rank: 'b', min: 52, max: 60 },
+    { rank: 'a', min: 61, max: 75 },
+    { rank: 's', min: 76, max: 99 }
+];
+
+const RANK_ORDER = ['none', 'd', 'c', 'b', 'a', 's'];
+const WEARABLE_SLOTS = new Set(Object.values(ARMOR_SLOTS));
+
+function gradeForLevel(level) {
+    const value = Number(level || 1);
+    return GRADE_BANDS.find((band) => value >= band.min && value <= band.max) || GRADE_BANDS[0];
+}
+
+function progression(level, band) {
+    const value = Number(level || 1);
+    const span = Math.max(1, band.max - band.min);
+    const inBand = Math.max(0, Math.min(1, (value - band.min) / span));
+    return Math.max(0.20, Math.min(0.78, 0.30 + inBand * 0.42));
+}
+
+function flattenItem(item) {
+    const stats = item.stats || {};
+    const etc = item.etc || {};
+    const template = item.template || {};
+
+    return {
+        selfId: item.selfId,
+        name: template.name,
+        kind: template.kind || '',
+        price: Number(template.price || 0),
+        slot: etc.slot,
+        rank: etc.rank || 'none',
+        pAtk: stats.pAtk || 0,
+        mAtk: stats.mAtk || 0,
+        pDef: stats.pDef || 0,
+        mDef: stats.mDef || 0,
+        maxMp: stats.maxMp || 0
+    };
+}
+
+function allItems() {
+    return (DataCache.items || [])
+        .filter((item) => {
+            const kind = item?.template?.kind || '';
+            return kind.startsWith('Weapon.') || kind.startsWith('Armor.');
+        })
+        .map(flattenItem);
+}
+
+function validRank(item, rank) {
+    return RANK_ORDER.indexOf(item.rank) >= 0 && item.rank === rank;
+}
+
+function notQuestOddity(item) {
+    return item.price > 0;
+}
+
+function candidatesFor(rank, predicate) {
+    return allItems()
+        .filter((item) => validRank(item, rank))
+        .filter(notQuestOddity)
+        .filter(predicate)
+        .sort((a, b) => a.price - b.price || a.selfId - b.selfId);
+}
+
+function choose(rank, level, predicate, score) {
+    const candidates = candidatesFor(rank, predicate);
+    if (candidates.length === 0) return null;
+
+    const band = gradeForLevel(level);
+    const pct = rank === band.rank ? progression(level, band) : 0.55;
+    const priced = candidates.filter((item) => item.price > 0);
+    const sorted = priced.length > 0 ? priced : candidates;
+    const capIndex = Math.max(0, Math.min(sorted.length - 1, Math.floor((sorted.length - 1) * pct)));
+    const priceCap = sorted[capIndex].price;
+    const affordable = candidates.filter((item) => !priceCap || item.price <= priceCap);
+    const pool = affordable.length > 0 ? affordable : candidates;
+
+    return pool.reduce((best, item) => {
+        if (!best) return item;
+        const itemScore = score(item);
+        const bestScore = score(best);
+        if (itemScore !== bestScore) return itemScore > bestScore ? item : best;
+        if (item.price !== best.price) return item.price < best.price ? item : best;
+        return item.selfId < best.selfId ? item : best;
+    }, null);
+}
+
+function weaponKindsFor(role, classId) {
+    if (role === 'archer') return ['Weapon.Bow'];
+    if (role === 'dagger') return ['Weapon.Knife'];
+    if (role === 'mage' || role === 'healer' || role === 'buffer') {
+        return ['Weapon.Sword', 'Weapon.Blunt'];
+    }
+    if ([44, 45, 47, 49, 50, 51, 53, 54, 56].includes(Number(classId))) {
+        return ['Weapon.Blunt'];
+    }
+    return ['Weapon.Sword', 'Weapon.Blunt'];
+}
+
+function armorStyleFor(role) {
+    if (role === 'mage' || role === 'healer' || role === 'buffer') return 'robe';
+    if (role === 'archer' || role === 'dagger') return 'light';
+    return 'heavy';
+}
+
+function chooseWeapon(rank, level, role, classId) {
+    const kinds = weaponKindsFor(role, classId);
+    const prefersOneHander = !(role === 'mage' || role === 'healer' || role === 'buffer' || role === 'archer');
+    const weapon = choose(
+        rank,
+        level,
+        (item) => kinds.includes(item.kind) && (!prefersOneHander || item.slot === ARMOR_SLOTS.weapon),
+        (item) => {
+            if (role === 'mage' || role === 'healer' || role === 'buffer') {
+                return item.mAtk * 3 + item.pAtk;
+            }
+            return item.pAtk * 2 + item.mAtk;
+        }
+    );
+
+    if (weapon) return weapon;
+
+    return choose(
+        rank,
+        level,
+        (item) => item.kind.startsWith('Weapon.'),
+        (item) => item.pAtk + item.mAtk
+    );
+}
+
+function chooseArmorPiece(rank, level, style, slot) {
+    const kind = style === 'robe'
+        ? 'Armor.Fabric'
+        : style === 'light'
+            ? 'Armor.Leather'
+            : 'Armor.Chain';
+
+    return choose(
+        rank,
+        level,
+        (item) => item.kind === kind && item.slot === slot,
+        (item) => item.pDef + item.maxMp
+    );
+}
+
+function chooseWear(rank, level, slot) {
+    return choose(
+        rank,
+        level,
+        (item) => item.kind === 'Armor.Wear' && item.slot === slot,
+        (item) => item.pDef
+    );
+}
+
+function chooseJewel(rank, level, slot) {
+    return choose(
+        rank,
+        level,
+        (item) => item.kind === 'Armor.Jewel' && item.slot === slot,
+        (item) => item.mDef
+    );
+}
+
+function chooseShield(rank, level) {
+    return choose(
+        rank,
+        level,
+        (item) => item.kind === 'Armor.Shield' && item.slot === ARMOR_SLOTS.shield,
+        (item) => item.pDef
+    );
+}
+
+function itemEntry(item, slot) {
+    if (!item) return null;
+    return {
+        selfId: item.selfId,
+        name: item.name,
+        amount: 1,
+        equipped: true,
+        slot: slot || item.slot
+    };
+}
+
+function buildArmor(rank, level, style) {
+    const pieces = [];
+    const chest = chooseArmorPiece(rank, level, style, ARMOR_SLOTS.chest);
+    const pants = chooseArmorPiece(rank, level, style, ARMOR_SLOTS.pants);
+    const full = chooseArmorPiece(rank, level, style, ARMOR_SLOTS.fullArmor);
+
+    if (style === 'robe' && full) {
+        pieces.push(itemEntry(full, ARMOR_SLOTS.fullArmor));
+    } else if (chest && pants) {
+        pieces.push(itemEntry(chest, ARMOR_SLOTS.chest));
+        pieces.push(itemEntry(pants, ARMOR_SLOTS.pants));
+    } else if (full) {
+        pieces.push(itemEntry(full, ARMOR_SLOTS.fullArmor));
+    }
+
+    pieces.push(itemEntry(chooseWear(rank, level, ARMOR_SLOTS.head), ARMOR_SLOTS.head));
+    pieces.push(itemEntry(chooseWear(rank, level, ARMOR_SLOTS.hands), ARMOR_SLOTS.hands));
+    pieces.push(itemEntry(chooseWear(rank, level, ARMOR_SLOTS.feet), ARMOR_SLOTS.feet));
+
+    return pieces.filter(Boolean);
+}
+
+function buildJewels(rank, level) {
+    const earring = chooseJewel(rank, level, ARMOR_SLOTS.earringRight);
+    const necklace = chooseJewel(rank, level, ARMOR_SLOTS.necklace);
+    const ring = chooseJewel(rank, level, ARMOR_SLOTS.ringRight);
+
+    return [
+        itemEntry(earring, ARMOR_SLOTS.earringRight),
+        itemEntry(earring, ARMOR_SLOTS.earringLeft),
+        itemEntry(necklace, ARMOR_SLOTS.necklace),
+        itemEntry(ring, ARMOR_SLOTS.ringRight),
+        itemEntry(ring, ARMOR_SLOTS.ringLeft)
+    ].filter(Boolean);
+}
+
+function planFor(character) {
+    const level = Number(character.level || 1);
+    const classId = Number(character.classId || 0);
+    const role = BotRoles.inferRole(classId);
+    const band = gradeForLevel(level);
+    const rank = band.rank;
+    const style = armorStyleFor(role);
+    const weapon = chooseWeapon(rank, level, role, classId);
+    const plan = [];
+
+    if (weapon) {
+        plan.push(itemEntry(weapon, weapon.slot));
+        if (weapon.slot === ARMOR_SLOTS.weapon && role !== 'dagger' && role !== 'archer') {
+            plan.push(itemEntry(chooseShield(rank, level), ARMOR_SLOTS.shield));
+        }
+    }
+
+    plan.push(...buildArmor(rank, level, style));
+    plan.push(...buildJewels(rank, level));
+
+    return {
+        rank,
+        role,
+        style,
+        items: plan.filter(Boolean)
+    };
+}
+
+function templateFor(selfId) {
+    return allItems().find((item) => Number(item.selfId) === Number(selfId)) || null;
+}
+
+function isWearableRow(row) {
+    const template = templateFor(row.selfId);
+    return !!template && WEARABLE_SLOTS.has(Number(row.slot || template.slot || 0));
+}
+
+function desiredKey(item, index) {
+    return `${item.selfId}:${item.slot}:${index}`;
+}
+
+function assignExistingItems(existing, desired) {
+    const available = new Map();
+    existing.forEach((row) => {
+        const selfId = Number(row.selfId || 0);
+        if (!available.has(selfId)) available.set(selfId, []);
+        available.get(selfId).push(row);
+    });
+
+    return desired.map((item, index) => {
+        const rows = available.get(Number(item.selfId)) || [];
+        const existingRow = rows.shift() || null;
+        return {
+            key: desiredKey(item, index),
+            desired: item,
+            existing: existingRow
+        };
+    });
+}
+
+function createMissingItem(characterId, desired) {
+    return Database.setItem(characterId, {
+        selfId: desired.selfId,
+        name: desired.name,
+        amount: desired.amount || 1,
+        equipped: false,
+        slot: desired.slot
+    }).then((result) => ({
+        id: Number(result.insertId),
+        selfId: desired.selfId,
+        slot: desired.slot,
+        equipped: false
+    }));
+}
+
+function syncAssignments(characterId, existing, assignments) {
+    const assignedIds = new Map();
+    let chain = Promise.resolve();
+    let changed = false;
+
+    assignments.forEach((assignment) => {
+        chain = chain.then(() => {
+            if (assignment.existing) return assignment.existing;
+            changed = true;
+            return createMissingItem(characterId, assignment.desired);
+        }).then((row) => {
+            assignedIds.set(Number(row.id), assignment.desired);
+            if (Number(row.slot) !== Number(assignment.desired.slot) || Number(row.equipped) !== 1) {
+                changed = true;
+                return Database.updateItemEquipState(characterId, row.id, true, assignment.desired.slot);
+            }
+            return null;
+        });
+    });
+
+    existing.filter(isWearableRow).forEach((row) => {
+        chain = chain.then(() => {
+            if (assignedIds.has(Number(row.id))) return null;
+            if (Number(row.equipped) !== 1) return null;
+            changed = true;
+            return Database.updateItemEquipState(characterId, row.id, false, row.slot || 0);
+        });
+    });
+
+    return chain.then(() => changed);
+}
+
+const BotGear = {
+    planFor,
+
+    ensureCharacterGear(character, options = {}) {
+        if (!character || !character.id || options.disabled === true) {
+            return Promise.resolve({ changed: false, plan: null });
+        }
+
+        const plan = planFor(character);
+        if (!plan.items.length) return Promise.resolve({ changed: false, plan });
+
+        return Database.fetchItems(character.id).then((existing) => {
+            const assignments = assignExistingItems(existing || [], plan.items);
+            return syncAssignments(character.id, existing || [], assignments)
+                .then((changed) => ({ changed, plan }));
+        }).catch((err) => {
+            utils.infoWarn('BotGear', 'failed to gear %s: %s', character.name || character.id, err.message);
+            return { changed: false, plan, error: err.message };
+        });
+    }
+};
+
+module.exports = BotGear;

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -11,6 +11,7 @@ const TradeService = invoke('GameServer/Bot/TradeService');
 const BotPopulation = invoke('GameServer/Bot/BotPopulation');
 const BotAvailability = invoke('GameServer/Bot/AI/BotAvailability');
 const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
+const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
 const PopulationService = invoke('GameServer/Bot/Population/PopulationService');
 
 const BOTS_TO_SPAWN = BotPopulation.buildStarterBots();
@@ -224,6 +225,22 @@ const BotManager = {
         });
     },
 
+    prepareBotForSpawn(session, botData = {}) {
+        if (!session || !session.actor) return null;
+
+        const Generics = invoke(path.actor);
+        const actor = session.actor;
+
+        actor.state.setDead(false);
+        if (botData.fullNewbieBlessing !== false && BotBuffs.isNewbieEligible(actor)) {
+            return BotBuffs.applyFullNewbieBlessing(session, actor, Generics);
+        }
+
+        actor.fillupVitals();
+        actor.statusUpdateVitals(actor);
+        return { buffs: [], expiresAt: null };
+    },
+
     loadAndSpawnBot(username, botData = {}) {
         const session = new BotSession(username);
         
@@ -275,12 +292,8 @@ const BotManager = {
                     session.plan = botData.plan || 'hunting';
                     session.backgroundActivity = botData.backgroundActivity || session.plan;
                     session.currentSpot = botData.currentSpot || null;
-                    if (botData.activationRecovery) {
-                        const hpPct = Number(botData.activationRecovery.hpPct || 0.85);
-                        const mpPct = Number(botData.activationRecovery.mpPct || 0.85);
-                        session.actor.setHp(Math.max(session.actor.fetchHp(), Math.round(session.actor.fetchMaxHp() * hpPct)));
-                        session.actor.setMp(Math.max(session.actor.fetchMp(), Math.round(session.actor.fetchMaxMp() * mpPct)));
-                        session.actor.state.setDead(false);
+                    if (botData.spawnReady !== false) {
+                        this.prepareBotForSpawn(session, botData);
                     }
                     session.actor.state.setSeated(session.plan === 'resting');
                 }

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -12,6 +12,7 @@ const BotPopulation = invoke('GameServer/Bot/BotPopulation');
 const BotAvailability = invoke('GameServer/Bot/AI/BotAvailability');
 const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
 const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
+const BotGear = invoke('GameServer/Bot/AI/BotGear');
 const PopulationService = invoke('GameServer/Bot/Population/PopulationService');
 
 const BOTS_TO_SPAWN = BotPopulation.buildStarterBots();
@@ -245,79 +246,89 @@ const BotManager = {
         const session = new BotSession(username);
         
         Shared.fetchCharacters(username).then((characters) => {
-            const character = characters[0];
-            if (!character) return;
+            const firstCharacter = characters[0];
+            if (!firstCharacter) return;
 
-            Shared.fetchClassInformation(character.classId).then((classInfo) => {
+            const firstStoreCfg = merchantConfigFor(botData, firstCharacter.name);
+            const gearReady = firstStoreCfg
+                ? Promise.resolve(characters)
+                : BotGear.ensureCharacterGear(firstCharacter, botData)
+                    .then(() => Shared.fetchCharacters(username));
+
+            gearReady.then((readyCharacters) => {
+                const character = readyCharacters[0];
+                if (!character) return;
                 const storeCfg = merchantConfigFor(botData, character.name);
 
-                if (botData.locX !== undefined) {
-                    character.locX = botData.locX;
-                    character.locY = botData.locY;
-                    character.locZ = botData.locZ;
-                }
-
-                character.locZ = GeodataEngine.getHeight(character.locX, character.locY, character.locZ);
-
-                session.setActor({
-                    ...character, ...utils.crushOb(classInfo)
-                });
-
-                session.homeRegion = botData.homeRegion || null;
-                session.visitor = !!botData.visitor;
-                session.newbieAnchor = !!botData.newbieAnchor;
-                
-                session.initialSpawnCoord = {
-                    locX: character.locX,
-                    locY: character.locY,
-                    locZ: character.locZ
-                };
-
-                if (storeCfg) {
-                    session.plan = 'merchant';
-                    session.actor.state.setSeated(true);
-
-                    session.actor.setTitle(storeCfg.title);
-                    session.actor.setPrivateStoreType(storeCfg.storeType);
-
-                    const storeItems = TradeService.normalizeStoreItems(storeCfg);
-
-                    session.actor.setPrivateStore({
-                        storeType: storeCfg.storeType,
-                        title: storeCfg.title,
-                        town: storeCfg.town,
-                        items: storeItems
-                    });
-                } else {
-                    session.plan = botData.plan || 'hunting';
-                    session.backgroundActivity = botData.backgroundActivity || session.plan;
-                    session.currentSpot = botData.currentSpot || null;
-                    if (botData.spawnReady !== false) {
-                        this.prepareBotForSpawn(session, botData);
+                Shared.fetchClassInformation(character.classId).then((classInfo) => {
+                    if (botData.locX !== undefined) {
+                        character.locX = botData.locX;
+                        character.locY = botData.locY;
+                        character.locZ = botData.locZ;
                     }
-                    session.actor.state.setSeated(session.plan === 'resting');
-                }
 
-                // Spawn the bot actor in the World
-                World.insertUser(session);
-                session.actor.enterWorld();
+                    character.locZ = GeodataEngine.getHeight(character.locX, character.locY, character.locZ);
 
-                // Explicitly send the bot's CharInfo to other players in the world
-                const ServerResponse = invoke('GameServer/Network/Response');
-                session.dataSendToOthers(ServerResponse.charInfo(session.actor), session.actor);
-                session.dataSendToOthers(ServerResponse.relationChanged(session.actor), session.actor);
+                    session.setActor({
+                        ...character, ...utils.crushOb(classInfo)
+                    });
 
-                // Start AI loop
-                BotAI.init(session);
+                    session.homeRegion = botData.homeRegion || null;
+                    session.visitor = !!botData.visitor;
+                    session.newbieAnchor = !!botData.newbieAnchor;
                 
-                this.sessions.push(session);
-                session.populationHotAt = Date.now();
-                PopulationService.markHot(session, 'spawn');
-                let modeText = "[Hunting Mode]";
-                if (session.townGossip) modeText = "[Gossip Mode]";
-                if (session.plan === 'pk_hunting') modeText = "[PK Mode]";
-                if (session.plan === 'merchant') modeText = "[Merchant Mode]";
-                utils.infoSuccess("BotManager", "%s (Level %d) is active in World %s", character.name, character.level, modeText);
+                    session.initialSpawnCoord = {
+                        locX: character.locX,
+                        locY: character.locY,
+                        locZ: character.locZ
+                    };
+
+                    if (storeCfg) {
+                        session.plan = 'merchant';
+                        session.actor.state.setSeated(true);
+
+                        session.actor.setTitle(storeCfg.title);
+                        session.actor.setPrivateStoreType(storeCfg.storeType);
+
+                        const storeItems = TradeService.normalizeStoreItems(storeCfg);
+
+                        session.actor.setPrivateStore({
+                            storeType: storeCfg.storeType,
+                            title: storeCfg.title,
+                            town: storeCfg.town,
+                            items: storeItems
+                        });
+                    } else {
+                        session.plan = botData.plan || 'hunting';
+                        session.backgroundActivity = botData.backgroundActivity || session.plan;
+                        session.currentSpot = botData.currentSpot || null;
+                        if (botData.spawnReady !== false) {
+                            this.prepareBotForSpawn(session, botData);
+                        }
+                        session.actor.state.setSeated(session.plan === 'resting');
+                    }
+
+                    // Spawn the bot actor in the World
+                    World.insertUser(session);
+                    session.actor.enterWorld();
+
+                    // Explicitly send the bot's CharInfo to other players in the world
+                    const ServerResponse = invoke('GameServer/Network/Response');
+                    session.dataSendToOthers(ServerResponse.charInfo(session.actor), session.actor);
+                    session.dataSendToOthers(ServerResponse.relationChanged(session.actor), session.actor);
+
+                    // Start AI loop
+                    BotAI.init(session);
+                
+                    this.sessions.push(session);
+                    session.populationHotAt = Date.now();
+                    PopulationService.markHot(session, 'spawn');
+                    let modeText = "[Hunting Mode]";
+                    if (session.townGossip) modeText = "[Gossip Mode]";
+                    if (session.plan === 'pk_hunting') modeText = "[PK Mode]";
+                    if (session.plan === 'merchant') modeText = "[Merchant Mode]";
+                    utils.infoSuccess("BotManager", "%s (Level %d) is active in World %s", character.name, character.level, modeText);
+                });
             });
         });
     },

--- a/src/GameServer/Bot/Population/HotActivation.js
+++ b/src/GameServer/Bot/Population/HotActivation.js
@@ -8,9 +8,11 @@ const pendingActivations = new Set();
 const HOT_PLANS = new Set(['hunting', 'resting', 'shopping', 'pk_hunting']);
 
 function activationPlan(state, options = {}) {
-    if (options.recoverOnActivation) return 'hunting';
-
     const activity = state?.activity || 'hunting';
+    if (options.recoverOnActivation || (options.readyOnActivation && (activity === 'dead' || activity === 'resting'))) {
+        return 'hunting';
+    }
+
     if (activity === 'dead' || activity === 'resting') return 'resting';
     if (HOT_PLANS.has(activity)) return activity;
     return 'hunting';
@@ -135,10 +137,7 @@ const HotActivation = {
                 plan,
                 backgroundActivity: state.activity || 'hunting',
                 currentSpot: spotSnapshot(placement.spot),
-                activationRecovery: options.recoverOnActivation ? {
-                    hpPct: Config.activationRecoveryHpPct,
-                    mpPct: Config.activationRecoveryMpPct
-                } : null,
+                spawnReady: true,
                 locX: placement.loc?.locX,
                 locY: placement.loc?.locY,
                 locZ: placement.loc?.locZ
@@ -149,7 +148,7 @@ const HotActivation = {
             }, 10000);
 
             console.info(
-                'BotPopulation :: requested activation for %s reason=%s activity=%s plan=%s spot=%s loc=%d,%d,%d playerDist=%s recovery=%s',
+                'BotPopulation :: requested activation for %s reason=%s activity=%s plan=%s spot=%s loc=%d,%d,%d playerDist=%s ready=%s',
                 state.name,
                 reason,
                 state.activity || 'hunting',
@@ -159,7 +158,7 @@ const HotActivation = {
                 placement.loc?.locY || 0,
                 placement.loc?.locZ || 0,
                 activationDistance(placement, options),
-                options.recoverOnActivation ? 'yes' : 'no'
+                (options.recoverOnActivation || options.readyOnActivation) ? 'yes' : 'no'
             );
             Metrics.recordActivation();
             return { ok: true, state, reason };

--- a/src/GameServer/Bot/Population/PopulationConfig.js
+++ b/src/GameServer/Bot/Population/PopulationConfig.js
@@ -24,9 +24,6 @@ const DEFAULTS = {
     activationRadius: 4500,
     activationLevelRange: 5,
     maxActivationsPerScan: 6,
-    maxRestingActivationRatio: 0.2,
-    activationRecoveryHpPct: 0.85,
-    activationRecoveryMpPct: 0.85,
     activationPlacementRadius: 1400,
     activationMinPlayerDistance: 450,
     activationPlacementAttempts: 8,
@@ -61,7 +58,6 @@ const ENV_KEYS = {
     activationRadius: 'BOT_ACTIVATION_RADIUS',
     activationLevelRange: 'BOT_ACTIVATION_LEVEL_RANGE',
     maxActivationsPerScan: 'BOT_MAX_ACTIVATIONS_PER_SCAN',
-    maxRestingActivationRatio: 'BOT_MAX_RESTING_ACTIVATION_RATIO',
     partyInviteRange: 'BOT_PARTY_INVITE_RANGE',
     devLogPlayerChat: 'BOT_DEV_LOG_PLAYER_CHAT',
     debug: 'BOT_POPULATION_DEBUG'

--- a/src/GameServer/Bot/Population/PopulationService.js
+++ b/src/GameServer/Bot/Population/PopulationService.js
@@ -260,7 +260,6 @@ const PopulationService = {
         if (players.length === 0) return Promise.resolve([]);
 
         const activated = [];
-        let restingPresented = 0;
         let chain = Promise.resolve();
 
         players.forEach((playerSession) => {
@@ -277,17 +276,11 @@ const PopulationService = {
                 return LifeState.coldNear(loc, Config.activationRadius, remaining)
                     .then((states) => {
                         const candidates = activationCandidatesForPlayer(states, actor.fetchLevel());
-                        const maxRestingPresented = Math.max(0, Math.floor(candidates.length * Config.maxRestingActivationRatio));
                         return candidates.reduce((stateChain, state) => (
                             stateChain.then(() => {
-                                const restingLike = this.isRestingActivationState(state);
-                                const recoverOnActivation = restingLike && restingPresented >= maxRestingPresented;
-                                if (restingLike && !recoverOnActivation) {
-                                    restingPresented += 1;
-                                }
-
                                 return this.requestActivation(state, 'near_player', {
-                                    recoverOnActivation,
+                                    recoverOnActivation: this.isRestingActivationState(state),
+                                    readyOnActivation: true,
                                     playerLoc: loc
                                 });
                             }).then((result) => {


### PR DESCRIPTION
## Summary
- ready non-merchant bots before they enter the world with full HP/MP and newbie guide buffs when eligible
- activate nearby cold/resting bots as ready hunting bots instead of presenting them seated around players
- add level- and role-aware bot gear planning that equips practical mid-grade weapons, armor, and jewels from the datapack

## Validation
- node --check on changed bot readiness and gear files
- git diff --check
- targeted gear planner smoke across representative classes and levels
- earlier live server smoke verified starter/hot bot activation and DB-equipped paperdolls