### PR TITLE
Add local server launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,17 @@ npm start
 
 That command will:
 
+- open the local launcher at `http://127.0.0.1:8090/`;
+- show the current server state;
+- start and stop the server from the launcher;
+- open the world observer map when the server is running.
+
+Press `Start` in the launcher to run the normal server bootstrap. That start action will:
+
 - install Node dependencies if `node_modules` is missing;
 - create or start a local `nodel2-mariadb` Docker container when the configured database host is `127.0.0.1` or `localhost`;
 - import `database/sql/database.sql` on first boot if database `nodel2` does not exist;
-- start the auth server on `2106` and the game server on `7777`.
+- start the auth server on `2106`, the game server on `7777`, and the world observer on `8088`.
 
 If you run MariaDB yourself, set:
 
@@ -225,6 +232,8 @@ Run a full boot check:
 ```bash
 npm start
 ```
+
+Then press `Start` in the launcher.
 
 Expected healthy boot signs:
 

--- a/scripts/run-server.js
+++ b/scripts/run-server.js
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawn, spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const containerName = process.env.L2NODE_DB_CONTAINER || 'nodel2-mariadb';
+const imageName = process.env.L2NODE_DB_IMAGE || 'mariadb:10.6';
+const isWindows = process.platform === 'win32';
+const npmCommand = isWindows ? 'npm.cmd' : 'npm';
+const dockerCommand = isWindows ? 'docker.exe' : 'docker';
+
+let serverChild = null;
+let shuttingDown = false;
+
+function log(message) {
+    console.info(`Startup    :: ${message}`);
+}
+
+function warn(message) {
+    console.warn(`Startup    :: ${message}`);
+}
+
+function sleep(ms) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function run(command, args, options = {}) {
+    return spawnSync(command, args, {
+        cwd: rootDir,
+        encoding: 'utf8',
+        ...options
+    });
+}
+
+function commandAvailable(command) {
+    const result = run(command, ['--version'], { stdio: 'ignore' });
+    return result.status === 0;
+}
+
+function parseIni(raw) {
+    const config = {};
+    let section = config;
+
+    raw.split(/\r?\n/).forEach((line) => {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith(';') || trimmed.startsWith('#')) {
+            return;
+        }
+
+        const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
+        if (sectionMatch) {
+            section = config[sectionMatch[1]] = config[sectionMatch[1]] || {};
+            return;
+        }
+
+        const separator = trimmed.indexOf('=');
+        if (separator === -1) {
+            return;
+        }
+
+        const key = trimmed.slice(0, separator).trim();
+        const value = trimmed.slice(separator + 1).trim();
+        section[key] = value;
+    });
+
+    return config;
+}
+
+function mergeConfig(base, override) {
+    Object.keys(override || {}).forEach((key) => {
+        const baseValue = base[key];
+        const overrideValue = override[key];
+
+        if (
+            baseValue &&
+            overrideValue &&
+            typeof baseValue === 'object' &&
+            typeof overrideValue === 'object' &&
+            !Array.isArray(baseValue) &&
+            !Array.isArray(overrideValue)
+        ) {
+            mergeConfig(baseValue, overrideValue);
+        } else {
+            base[key] = overrideValue;
+        }
+    });
+
+    return base;
+}
+
+function readConfig() {
+    const defaultPath = path.join(rootDir, 'config', 'default.ini');
+    const localPath = path.join(rootDir, 'config', 'local.ini');
+    const config = parseIni(fs.readFileSync(defaultPath, 'utf8'));
+
+    if (fs.existsSync(localPath)) {
+        mergeConfig(config, parseIni(fs.readFileSync(localPath, 'utf8')));
+    }
+
+    return config;
+}
+
+function ensureDependencies() {
+    if (fs.existsSync(path.join(rootDir, 'node_modules'))) {
+        return;
+    }
+
+    log('node_modules not found; running npm install');
+    const result = run(npmCommand, ['install'], { stdio: 'inherit' });
+    if (result.status !== 0) {
+        process.exit(result.status || 1);
+    }
+}
+
+function isLocalDatabase(dbConfig) {
+    const hostname = String(dbConfig.hostname || '').toLowerCase();
+    return hostname === '127.0.0.1' || hostname === 'localhost';
+}
+
+function dockerInspect(format) {
+    return run(dockerCommand, ['inspect', '-f', format, containerName]);
+}
+
+function ensureDockerDatabase(dbConfig) {
+    if (process.env.L2NODE_SKIP_DOCKER === '1') {
+        warn('L2NODE_SKIP_DOCKER=1; assuming MariaDB is already reachable');
+        return;
+    }
+
+    if (!isLocalDatabase(dbConfig)) {
+        warn(`database host is ${dbConfig.hostname}; skipping local Docker bootstrap`);
+        return;
+    }
+
+    if (!commandAvailable(dockerCommand)) {
+        warn('Docker is not available; assuming MariaDB is already reachable');
+        return;
+    }
+
+    const password = dbConfig.password || '';
+    const port = String(dbConfig.port || '3306');
+    const databaseName = dbConfig.databaseName || 'nodel2';
+    let containerCreated = false;
+
+    const exists = dockerInspect('{{.Name}}').status === 0;
+    if (!exists) {
+        log(`creating ${containerName} (${imageName}) on port ${port}`);
+        const result = run(dockerCommand, [
+            'run',
+            '-d',
+            '--name',
+            containerName,
+            '-p',
+            `${port}:3306`,
+            '-e',
+            `MARIADB_ROOT_PASSWORD=${password}`,
+            imageName
+        ], { stdio: 'inherit' });
+
+        if (result.status !== 0) {
+            warn('could not create MariaDB container; server startup will try the configured database anyway');
+            return;
+        }
+
+        containerCreated = true;
+    } else {
+        const running = dockerInspect('{{.State.Running}}');
+        if (String(running.stdout).trim() !== 'true') {
+            log(`starting ${containerName}`);
+            const result = run(dockerCommand, ['start', containerName], { stdio: 'inherit' });
+            if (result.status !== 0) {
+                warn('could not start MariaDB container; server startup will try the configured database anyway');
+                return;
+            }
+        }
+    }
+
+    waitForDatabase(password);
+
+    if (containerCreated || !databaseExists(password, databaseName)) {
+        importDatabase(password);
+    }
+}
+
+function waitForDatabase(password) {
+    const passwordArg = `-p${password}`;
+
+    for (let attempt = 1; attempt <= 30; attempt += 1) {
+        const result = run(dockerCommand, [
+            'exec',
+            containerName,
+            'mariadb',
+            '-u',
+            'root',
+            passwordArg,
+            '-e',
+            'SELECT 1;'
+        ], { stdio: 'ignore' });
+
+        if (result.status === 0) {
+            return;
+        }
+
+        sleep(1000);
+    }
+
+    warn('MariaDB did not become ready in 30s; server startup will continue and report any DB error');
+}
+
+function databaseExists(password, databaseName) {
+    const passwordArg = `-p${password}`;
+    const result = run(dockerCommand, [
+        'exec',
+        containerName,
+        'mariadb',
+        '-u',
+        'root',
+        passwordArg,
+        '-N',
+        '-s',
+        '-e',
+        `SHOW DATABASES LIKE '${databaseName.replace(/'/g, "''")}';`
+    ]);
+
+    return result.status === 0 && String(result.stdout).trim() === databaseName;
+}
+
+function importDatabase(password) {
+    const sqlPath = path.join(rootDir, 'database', 'sql', 'database.sql');
+    const sql = fs.readFileSync(sqlPath, 'utf8');
+    const passwordArg = `-p${password}`;
+
+    log('importing database/sql/database.sql');
+    const result = run(dockerCommand, [
+        'exec',
+        '-i',
+        containerName,
+        'mariadb',
+        '-u',
+        'root',
+        passwordArg
+    ], {
+        input: sql,
+        stdio: ['pipe', 'inherit', 'inherit']
+    });
+
+    if (result.status !== 0) {
+        process.exit(result.status || 1);
+    }
+}
+
+function stopServer(signal) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+
+    if (!serverChild || serverChild.killed) {
+        process.exit(0);
+        return;
+    }
+
+    serverChild.once('exit', () => process.exit(0));
+    serverChild.kill(signal || 'SIGTERM');
+
+    setTimeout(() => {
+        if (serverChild && !serverChild.killed) {
+            serverChild.kill('SIGKILL');
+        }
+    }, 5000).unref();
+}
+
+function startServer() {
+    log('starting NodeL2');
+    serverChild = spawn(process.execPath, ['--openssl-legacy-provider', 'src/NodeL2'], {
+        cwd: rootDir,
+        stdio: 'inherit',
+        env: process.env
+    });
+
+    serverChild.on('exit', (code, signal) => {
+        serverChild = null;
+
+        if (shuttingDown) {
+            process.exit(0);
+            return;
+        }
+
+        if (signal) {
+            process.kill(process.pid, signal);
+            return;
+        }
+
+        process.exit(code || 0);
+    });
+}
+
+function main() {
+    const config = readConfig();
+    ensureDependencies();
+    ensureDockerDatabase(config.Database || {});
+    startServer();
+}
+
+process.on('SIGINT', () => stopServer('SIGINT'));
+process.on('SIGTERM', () => stopServer('SIGTERM'));
+
+main();

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -2,39 +2,30 @@
 'use strict';
 
 const { spawn, spawnSync } = require('child_process');
+const http = require('http');
 const fs = require('fs');
 const path = require('path');
 
 const rootDir = path.resolve(__dirname, '..');
-const containerName = process.env.L2NODE_DB_CONTAINER || 'nodel2-mariadb';
-const imageName = process.env.L2NODE_DB_IMAGE || 'mariadb:10.6';
 const isWindows = process.platform === 'win32';
-const npmCommand = isWindows ? 'npm.cmd' : 'npm';
-const dockerCommand = isWindows ? 'docker.exe' : 'docker';
+const host = process.env.L2NODE_LAUNCHER_HOST || '127.0.0.1';
+const port = Number(process.env.L2NODE_LAUNCHER_PORT || 8090);
+const maxLogLines = 80;
+
+const state = {
+    phase: 'stopped',
+    child: null,
+    startedAt: null,
+    lastExit: null,
+    logs: []
+};
 
 function log(message) {
-    console.info(`Startup    :: ${message}`);
+    console.info(`Launcher  :: ${message}`);
 }
 
 function warn(message) {
-    console.warn(`Startup    :: ${message}`);
-}
-
-function sleep(ms) {
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function run(command, args, options = {}) {
-    return spawnSync(command, args, {
-        cwd: rootDir,
-        encoding: 'utf8',
-        ...options
-    });
-}
-
-function commandAvailable(command) {
-    const result = run(command, ['--version'], { stdio: 'ignore' });
-    return result.status === 0;
+    console.warn(`Launcher  :: ${message}`);
 }
 
 function parseIni(raw) {
@@ -58,9 +49,7 @@ function parseIni(raw) {
             return;
         }
 
-        const key = trimmed.slice(0, separator).trim();
-        const value = trimmed.slice(separator + 1).trim();
-        section[key] = value;
+        section[trimmed.slice(0, separator).trim()] = trimmed.slice(separator + 1).trim();
     });
 
     return config;
@@ -100,178 +89,468 @@ function readConfig() {
     return config;
 }
 
-function ensureDependencies() {
-    if (fs.existsSync(path.join(rootDir, 'node_modules'))) {
-        return;
-    }
-
-    log('node_modules not found; running npm install');
-    const result = run(npmCommand, ['install'], { stdio: 'inherit' });
-    if (result.status !== 0) {
-        process.exit(result.status || 1);
-    }
+function observerUrl() {
+    const config = readConfig().WorldObserver || {};
+    const observerHost = config.hostname === '0.0.0.0' ? '127.0.0.1' : (config.hostname || '127.0.0.1');
+    const observerPort = Number(config.port || 8088);
+    return `http://${observerHost}:${observerPort}/observer/`;
 }
 
-function isLocalDatabase(dbConfig) {
-    const hostname = String(dbConfig.hostname || '').toLowerCase();
-    return hostname === '127.0.0.1' || hostname === 'localhost';
+function launcherUrl() {
+    return `http://${host}:${port}/`;
 }
 
-function dockerInspect(format) {
-    return run(dockerCommand, ['inspect', '-f', format, containerName]);
-}
-
-function ensureDockerDatabase(dbConfig) {
-    if (process.env.L2NODE_SKIP_DOCKER === '1') {
-        warn('L2NODE_SKIP_DOCKER=1; assuming MariaDB is already reachable');
-        return;
-    }
-
-    if (!isLocalDatabase(dbConfig)) {
-        warn(`database host is ${dbConfig.hostname}; skipping local Docker bootstrap`);
-        return;
-    }
-
-    if (!commandAvailable(dockerCommand)) {
-        warn('Docker is not available; assuming MariaDB is already reachable');
-        return;
-    }
-
-    const password = dbConfig.password || '';
-    const port = String(dbConfig.port || '3306');
-    const databaseName = dbConfig.databaseName || 'nodel2';
-    let containerCreated = false;
-
-    const exists = dockerInspect('{{.Name}}').status === 0;
-    if (!exists) {
-        log(`creating ${containerName} (${imageName}) on port ${port}`);
-        const result = run(dockerCommand, [
-            'run',
-            '-d',
-            '--name',
-            containerName,
-            '-p',
-            `${port}:3306`,
-            '-e',
-            `MARIADB_ROOT_PASSWORD=${password}`,
-            imageName
-        ], { stdio: 'inherit' });
-
-        if (result.status !== 0) {
-            warn('could not create MariaDB container; server startup will try the configured database anyway');
-            return;
-        }
-
-        containerCreated = true;
-    } else {
-        const running = dockerInspect('{{.State.Running}}');
-        if (String(running.stdout).trim() !== 'true') {
-            log(`starting ${containerName}`);
-            const result = run(dockerCommand, ['start', containerName], { stdio: 'inherit' });
-            if (result.status !== 0) {
-                warn('could not start MariaDB container; server startup will try the configured database anyway');
-                return;
+function appendLog(source, chunk) {
+    String(chunk)
+        .split(/\r?\n/)
+        .map((line) => line.trimEnd())
+        .filter(Boolean)
+        .forEach((line) => {
+            if (line.includes('GameServer :: successful init')) {
+                state.phase = 'running';
             }
-        }
-    }
 
-    waitForDatabase(password);
+            state.logs.push({
+                at: Date.now(),
+                source,
+                line
+            });
+        });
 
-    if (containerCreated || !databaseExists(password, databaseName)) {
-        importDatabase(password);
+    if (state.logs.length > maxLogLines) {
+        state.logs.splice(0, state.logs.length - maxLogLines);
     }
 }
 
-function waitForDatabase(password) {
-    const passwordArg = `-p${password}`;
-
-    for (let attempt = 1; attempt <= 30; attempt += 1) {
-        const result = run(dockerCommand, [
-            'exec',
-            containerName,
-            'mariadb',
-            '-u',
-            'root',
-            passwordArg,
-            '-e',
-            'SELECT 1;'
-        ], { stdio: 'ignore' });
-
-        if (result.status === 0) {
-            return;
-        }
-
-        sleep(1000);
-    }
-
-    warn('MariaDB did not become ready in 30s; server startup will continue and report any DB error');
-}
-
-function databaseExists(password, databaseName) {
-    const passwordArg = `-p${password}`;
-    const result = run(dockerCommand, [
-        'exec',
-        containerName,
-        'mariadb',
-        '-u',
-        'root',
-        passwordArg,
-        '-N',
-        '-s',
-        '-e',
-        `SHOW DATABASES LIKE '${databaseName.replace(/'/g, "''")}';`
-    ]);
-
-    return result.status === 0 && String(result.stdout).trim() === databaseName;
-}
-
-function importDatabase(password) {
-    const sqlPath = path.join(rootDir, 'database', 'sql', 'database.sql');
-    const sql = fs.readFileSync(sqlPath, 'utf8');
-    const passwordArg = `-p${password}`;
-
-    log('importing database/sql/database.sql');
-    const result = run(dockerCommand, [
-        'exec',
-        '-i',
-        containerName,
-        'mariadb',
-        '-u',
-        'root',
-        passwordArg
-    ], {
-        input: sql,
-        stdio: ['pipe', 'inherit', 'inherit']
-    });
-
-    if (result.status !== 0) {
-        process.exit(result.status || 1);
-    }
+function publicState() {
+    return {
+        phase: state.phase,
+        pid: state.child ? state.child.pid : null,
+        startedAt: state.startedAt,
+        uptimeMs: state.startedAt && state.child ? Date.now() - state.startedAt : 0,
+        lastExit: state.lastExit,
+        mapUrl: observerUrl(),
+        launcherUrl: launcherUrl(),
+        logs: state.logs.slice(-40)
+    };
 }
 
 function startServer() {
-    log('starting NodeL2');
-    const child = spawn(process.execPath, ['--openssl-legacy-provider', 'src/NodeL2'], {
+    if (state.child) {
+        return publicState();
+    }
+
+    state.phase = 'starting';
+    state.startedAt = Date.now();
+    state.lastExit = null;
+    state.logs = [];
+
+    const child = spawn(process.execPath, [path.join('scripts', 'run-server.js')], {
         cwd: rootDir,
-        stdio: 'inherit',
-        env: process.env
+        env: process.env,
+        stdio: ['ignore', 'pipe', 'pipe']
     });
 
+    state.child = child;
+    appendLog('launcher', `starting server process ${child.pid}`);
+
+    child.stdout.on('data', (chunk) => appendLog('stdout', chunk));
+    child.stderr.on('data', (chunk) => appendLog('stderr', chunk));
+    child.on('error', (err) => {
+        appendLog('launcher', `failed to start server: ${err.message}`);
+        state.phase = 'stopped';
+        state.child = null;
+        state.lastExit = { code: 1, signal: null, at: Date.now(), error: err.message };
+    });
     child.on('exit', (code, signal) => {
-        if (signal) {
-            process.kill(process.pid, signal);
-            return;
+        appendLog('launcher', `server process exited${signal ? ` by ${signal}` : ` with code ${code || 0}`}`);
+        state.child = null;
+        state.phase = 'stopped';
+        state.lastExit = { code: code || 0, signal: signal || null, at: Date.now() };
+    });
+
+    return publicState();
+}
+
+function stopServer() {
+    if (!state.child) {
+        state.phase = 'stopped';
+        return publicState();
+    }
+
+    const pid = state.child.pid;
+    state.phase = 'stopping';
+    appendLog('launcher', `stopping server process ${pid}`);
+
+    if (isWindows) {
+        spawnSync('taskkill.exe', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' });
+    } else {
+        state.child.kill('SIGTERM');
+    }
+
+    return publicState();
+}
+
+function sendJson(response, data, statusCode = 200) {
+    response.writeHead(statusCode, {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store'
+    });
+    response.end(JSON.stringify(data));
+}
+
+function readBody(request) {
+    return new Promise((resolve) => {
+        let body = '';
+        request.on('data', (chunk) => {
+            body += chunk;
+        });
+        request.on('end', () => resolve(body));
+    });
+}
+
+function sendHtml(response) {
+    response.writeHead(200, {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'no-cache'
+    });
+    response.end(`<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>L2Solo Launcher</title>
+    <style>
+        :root {
+            color-scheme: dark;
+            --bg: #151515;
+            --panel: #202020;
+            --panel-2: #181818;
+            --text: #eeeeea;
+            --muted: #aaa59a;
+            --border: #36332d;
+            --accent: #c6a45b;
+            --green: #66c47a;
+            --red: #d96b62;
         }
 
-        process.exit(code || 0);
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            background: var(--bg);
+            color: var(--text);
+            font-family: Arial, Helvetica, sans-serif;
+        }
+
+        main {
+            width: min(560px, calc(100vw - 32px));
+            padding: 24px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: var(--panel);
+            box-shadow: 0 22px 70px rgba(0, 0, 0, 0.32);
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            margin-bottom: 22px;
+        }
+
+        h1 {
+            margin: 0;
+            font-size: 24px;
+            font-weight: 700;
+            letter-spacing: 0;
+        }
+
+        .status {
+            display: inline-flex;
+            align-items: center;
+            gap: 9px;
+            min-width: 112px;
+            justify-content: flex-end;
+            color: var(--muted);
+            font-size: 14px;
+            text-transform: uppercase;
+        }
+
+        .dot {
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background: var(--muted);
+        }
+
+        .running .dot {
+            background: var(--green);
+        }
+
+        .starting .dot,
+        .stopping .dot {
+            background: var(--accent);
+        }
+
+        .stopped .dot {
+            background: var(--red);
+        }
+
+        .controls {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 10px;
+        }
+
+        button {
+            height: 44px;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            background: var(--panel-2);
+            color: var(--text);
+            font-size: 14px;
+            font-weight: 700;
+            cursor: pointer;
+        }
+
+        button.primary {
+            border-color: #8f7438;
+            background: var(--accent);
+            color: #17130b;
+        }
+
+        button:disabled {
+            cursor: default;
+            opacity: 0.48;
+        }
+
+        .meta {
+            display: grid;
+            gap: 8px;
+            margin-top: 20px;
+            padding: 14px;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            background: var(--panel-2);
+            font-size: 14px;
+        }
+
+        .row {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+        }
+
+        .label {
+            color: var(--muted);
+        }
+
+        .value {
+            text-align: right;
+        }
+
+        pre {
+            min-height: 104px;
+            max-height: 220px;
+            margin: 16px 0 0;
+            padding: 12px;
+            overflow: auto;
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            background: #101010;
+            color: #d8d0c0;
+            font: 12px/1.45 Consolas, Monaco, monospace;
+            white-space: pre-wrap;
+        }
+
+        @media (max-width: 560px) {
+            main {
+                padding: 18px;
+            }
+
+            header {
+                align-items: flex-start;
+                flex-direction: column;
+            }
+
+            .controls {
+                grid-template-columns: 1fr;
+            }
+
+            .status {
+                justify-content: flex-start;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <header>
+            <h1>L2Solo Launcher</h1>
+            <div id="status" class="status stopped"><span class="dot"></span><span>Stopped</span></div>
+        </header>
+
+        <section class="controls">
+            <button id="start" class="primary" type="button">Start</button>
+            <button id="stop" type="button">Stop</button>
+            <button id="map" type="button">Open Map</button>
+        </section>
+
+        <section class="meta">
+            <div class="row"><span class="label">Server</span><span id="server" class="value">Stopped</span></div>
+            <div class="row"><span class="label">PID</span><span id="pid" class="value">-</span></div>
+            <div class="row"><span class="label">Uptime</span><span id="uptime" class="value">-</span></div>
+        </section>
+
+        <pre id="log">Launcher ready.</pre>
+    </main>
+
+    <script>
+        const statusEl = document.getElementById('status');
+        const statusText = statusEl.querySelector('span:last-child');
+        const serverEl = document.getElementById('server');
+        const pidEl = document.getElementById('pid');
+        const uptimeEl = document.getElementById('uptime');
+        const logEl = document.getElementById('log');
+        const startButton = document.getElementById('start');
+        const stopButton = document.getElementById('stop');
+        const mapButton = document.getElementById('map');
+        let mapUrl = '';
+
+        function titleCase(value) {
+            return value.charAt(0).toUpperCase() + value.slice(1);
+        }
+
+        function formatUptime(ms) {
+            if (!ms) return '-';
+            const totalSeconds = Math.floor(ms / 1000);
+            const hours = Math.floor(totalSeconds / 3600);
+            const minutes = Math.floor((totalSeconds % 3600) / 60);
+            const seconds = totalSeconds % 60;
+            return [hours, minutes, seconds].map((part) => String(part).padStart(2, '0')).join(':');
+        }
+
+        async function request(path, options) {
+            const response = await fetch(path, options);
+            if (!response.ok) throw new Error(await response.text());
+            return response.json();
+        }
+
+        function render(data) {
+            const phase = data.phase || 'stopped';
+            mapUrl = data.mapUrl;
+            statusEl.className = 'status ' + phase;
+            statusText.textContent = titleCase(phase);
+            serverEl.textContent = titleCase(phase);
+            pidEl.textContent = data.pid || '-';
+            uptimeEl.textContent = formatUptime(data.uptimeMs);
+            startButton.disabled = phase === 'starting' || phase === 'running' || phase === 'stopping';
+            stopButton.disabled = phase === 'stopped' || phase === 'stopping';
+            logEl.textContent = data.logs && data.logs.length
+                ? data.logs.map((entry) => entry.line).join('\\n')
+                : 'Launcher ready.';
+            logEl.scrollTop = logEl.scrollHeight;
+        }
+
+        async function refresh() {
+            try {
+                render(await request('/api/status'));
+            } catch (err) {
+                logEl.textContent = err.message;
+            }
+        }
+
+        startButton.addEventListener('click', async () => {
+            render(await request('/api/start', { method: 'POST' }));
+        });
+
+        stopButton.addEventListener('click', async () => {
+            render(await request('/api/stop', { method: 'POST' }));
+        });
+
+        mapButton.addEventListener('click', () => {
+            if (mapUrl) window.open(mapUrl, '_blank', 'noopener');
+        });
+
+        refresh();
+        setInterval(refresh, 1500);
+    </script>
+</body>
+</html>`);
+}
+
+async function route(request, response) {
+    const url = new URL(request.url, launcherUrl());
+
+    if (request.method === 'GET' && url.pathname === '/') {
+        sendHtml(response);
+        return;
+    }
+
+    if (request.method === 'GET' && url.pathname === '/api/status') {
+        sendJson(response, publicState());
+        return;
+    }
+
+    if (request.method === 'POST' && url.pathname === '/api/start') {
+        await readBody(request);
+        sendJson(response, startServer());
+        return;
+    }
+
+    if (request.method === 'POST' && url.pathname === '/api/stop') {
+        await readBody(request);
+        sendJson(response, stopServer());
+        return;
+    }
+
+    response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    response.end('Not found');
+}
+
+function openBrowser(url) {
+    if (process.env.L2NODE_NO_BROWSER === '1') {
+        return;
+    }
+
+    const command = isWindows ? 'cmd.exe' : (process.platform === 'darwin' ? 'open' : 'xdg-open');
+    const args = isWindows ? ['/c', 'start', '', url] : [url];
+    const child = spawn(command, args, { detached: true, stdio: 'ignore' });
+    child.on('error', (err) => warn(`could not open browser: ${err.message}`));
+    child.unref();
+}
+
+const server = http.createServer((request, response) => {
+    route(request, response).catch((err) => {
+        sendJson(response, { error: err.message }, 500);
     });
+});
+
+server.listen(port, host, () => {
+    log(`ready at ${launcherUrl()}`);
+    openBrowser(launcherUrl());
+});
+
+server.on('error', (err) => {
+    warn(`failed: ${err.message}`);
+    process.exit(1);
+});
+
+function shutdown() {
+    if (state.child) {
+        stopServer();
+    }
+
+    server.close(() => process.exit(0));
 }
 
-function main() {
-    const config = readConfig();
-    ensureDependencies();
-    ensureDockerDatabase(config.Database || {});
-    startServer();
-}
-
-main();
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);


### PR DESCRIPTION
## Summary

- Replace the direct `npm start` server boot with a minimal local browser launcher.
- Keep the existing dependency, database, and server bootstrap path behind the launcher Start button.
- Add Start, Stop, status, uptime, lightweight logs, and an Open Map button for the existing world observer.
- Update README startup docs for the launcher flow.

## Validation

- `node --check scripts/start.js`
- `node --check scripts/run-server.js`
- `node tests/test_pathfinder_astar.js`
- `node tests/test_path_obstacle.js`
- Launcher smoke test: `/api/status`
- Launcher smoke test: `/api/start` followed by `/api/stop`