### PR TITLE
Add shot stocking for players and bots

### DIFF
--- a/src/GameServer/Actor/Attack.js
+++ b/src/GameServer/Actor/Attack.js
@@ -136,6 +136,23 @@ class Attack {
             return;
         }
 
+        if (!actor.spiritshotLoaded && actor.backpack && typeof actor.backpack.consumeSpiritshot === 'function') {
+            actor.backpack.consumeSpiritshot(session, (success) => {
+                if (success) {
+                    actor.spiritshotLoaded = true;
+
+                    session.dataSendToMeAndOthers(
+                        ServerResponse.skillStarted(actor, actor.fetchId(), {
+                            fetchSelfId: () => 2047,
+                            fetchCalculatedHitTime: () => 0,
+                            fetchReuseTime: () => 0
+                        }),
+                        actor
+                    );
+                }
+            });
+        }
+
         skill.setCalculatedHitTime(Formulas.calcRemoteAtkTime(skill.fetchHitTime(), actor.fetchCollectiveCastSpd()));
         session.dataSendToMeAndOthers(ServerResponse.skillStarted(actor, creature.fetchId(), skill), actor);
         session.dataSendToMe(ServerResponse.skillDurationBar(skill.fetchCalculatedHitTime()));
@@ -150,7 +167,12 @@ class Attack {
             actor.statusUpdateVitals(actor);
 
             const mAtk = actor.fetchCollectiveMAtk();
-            this.hit(session, actor, creature, Formulas.calcRemoteHit(mAtk, skill.fetchPower(), creature.fetchCollectiveMDef()));
+            let damage = Formulas.calcRemoteHit(mAtk, skill.fetchPower(), creature.fetchCollectiveMDef());
+            if (actor.spiritshotLoaded) {
+                damage = Math.round(damage * 2.0);
+                actor.spiritshotLoaded = false;
+            }
+            this.hit(session, actor, creature, damage);
             actor.state.setCasts(false);
 
             // Start replenish

--- a/src/GameServer/Actor/Backpack.js
+++ b/src/GameServer/Actor/Backpack.js
@@ -6,6 +6,7 @@ const DataCache      = invoke('GameServer/DataCache');
 const ConsoleText    = invoke('GameServer/ConsoleText');
 const World          = invoke('GameServer/World/World');
 const Database       = invoke('Database');
+const ShotStock      = invoke('GameServer/Inventory/ShotStock');
 
 class Backpack extends BackpackModel {
     constructor(data) {
@@ -62,7 +63,32 @@ class Backpack extends BackpackModel {
             return callback(false);
         }
 
-        const found = this.items.find(item => [1835, 1463, 1464, 1465, 1466, 1467].includes(item.fetchSelfId()));
+        const plan = ShotStock.planForActor(session.actor);
+        if (plan.kind !== 'soulshot') {
+            return callback(false);
+        }
+
+        const found = this.items.find(item => item.fetchSelfId() === plan.selfId);
+        if (found) {
+            this.deleteItem(session, found.fetchId(), 1, () => {
+                callback(true);
+            });
+        } else {
+            callback(false);
+        }
+    }
+
+    consumeSpiritshot(session, callback = () => {}) {
+        if (session.actor.isDead()) {
+            return callback(false);
+        }
+
+        const plan = ShotStock.planForActor(session.actor);
+        if (plan.kind !== 'spiritshot') {
+            return callback(false);
+        }
+
+        const found = this.items.find(item => item.fetchSelfId() === plan.selfId);
         if (found) {
             this.deleteItem(session, found.fetchId(), 1, () => {
                 callback(true);
@@ -92,7 +118,7 @@ class Backpack extends BackpackModel {
                 this.equipGear(session, item);
             }
             else {
-                if ([1835, 1463, 1464, 1465, 1466, 1467].includes(item.fetchSelfId())) {
+                if (ShotStock.SOULSHOT_IDS.includes(item.fetchSelfId())) {
                     if (session.actor.soulshotLoaded) {
                         return; // Already loaded
                     }
@@ -106,6 +132,26 @@ class Backpack extends BackpackModel {
                                 fetchCalculatedHitTime: () => 0,
                                 fetchReuseTime: () => 0
                             }), 
+                            session.actor
+                        );
+                    });
+                    return;
+                }
+                else
+                if (ShotStock.SPIRITSHOT_IDS.includes(item.fetchSelfId())) {
+                    if (session.actor.spiritshotLoaded) {
+                        return; // Already loaded
+                    }
+                    this.deleteItem(session, id, 1, () => {
+                        session.actor.spiritshotLoaded = true;
+
+                        // Play activation effect (Skill 2047)
+                        session.dataSendToMeAndOthers(
+                            ServerResponse.skillStarted(session.actor, session.actor.fetchId(), {
+                                fetchSelfId: () => 2047,
+                                fetchCalculatedHitTime: () => 0,
+                                fetchReuseTime: () => 0
+                            }),
                             session.actor
                         );
                     });

--- a/src/GameServer/Bot/AI/States/HuntingState.js
+++ b/src/GameServer/Bot/AI/States/HuntingState.js
@@ -5,6 +5,7 @@ const GeodataEngine  = invoke('GameServer/Geodata/GeodataEngine');
 const SpotService    = invoke('GameServer/Bot/AI/SpotService');
 const DecisionService = invoke('GameServer/Bot/AI/BotDecisionService');
 const BotBuffs       = invoke('GameServer/Bot/AI/BotBuffs');
+const ShotStock      = invoke('GameServer/Inventory/ShotStock');
 
 function isSoloHunter(session) {
     return session.plan === 'hunting' && session.partyCompanion !== true && !session.followPlayerSession;
@@ -18,6 +19,19 @@ function isClaimedByOtherSoloBot(session, npc) {
         if (otherSession === session || !otherSession.actor || !isSoloHunter(otherSession)) return false;
         if (otherSession.currentTargetId !== npcId) return false;
         return !otherSession.actor.state.fetchDead();
+    });
+}
+
+function startShopping(session, bot, BotAI, reason) {
+    const closestTown = BotAI.getClosestTown(bot.fetchLocX(), bot.fetchLocY());
+    session.preShopLocation = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
+    session.plan = 'shopping';
+    session.shopTimer = Date.now();
+    session.shoppingTarget = undefined;
+    BotAI.say(session, reason || `Walking back to ${closestTown.name} to sell and restock.`);
+    bot.moveTo({
+        from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
+        to: { locX: closestTown.x, locY: closestTown.y, locZ: closestTown.z }
     });
 }
 
@@ -65,6 +79,12 @@ module.exports = {
                 BotAI.say(session, "My newbie blessings have expired! Heading to the Newbie Guide to get buffed.");
                 return;
             }
+        }
+
+        if (isSoloHunter(session) && ShotStock.needsActorRestock(bot, 0)) {
+            const plan = ShotStock.planForActor(bot);
+            startShopping(session, bot, BotAI, `Out of ${ShotStock.describe(plan)}. Heading to town to restock.`);
+            return;
         }
 
         // 2. PK Spotting & Fleeing Check
@@ -166,15 +186,7 @@ module.exports = {
 
         if (Math.random() < 0.005) { // ~0.5% chance per tick (~10 minutes)
             const closestTown = BotAI.getClosestTown(bot.fetchLocX(), bot.fetchLocY());
-            session.preShopLocation = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
-            session.plan = 'shopping';
-            session.shopTimer = Date.now();
-            session.shoppingTarget = undefined;
-            BotAI.say(session, `My bags are full of loot. Walking back to ${closestTown.name} to sell and restock.`);
-            bot.moveTo({
-                from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
-                to: { locX: closestTown.x, locY: closestTown.y, locZ: closestTown.z }
-            });
+            startShopping(session, bot, BotAI, `My bags are full of loot. Walking back to ${closestTown.name} to sell and restock.`);
             return;
         }
 

--- a/src/GameServer/Bot/AI/States/ShoppingState.js
+++ b/src/GameServer/Bot/AI/States/ShoppingState.js
@@ -1,6 +1,7 @@
 const SpeckMath      = invoke('GameServer/SpeckMath');
 const ServerResponse = invoke('GameServer/Network/Response');
 const TradeService   = invoke('GameServer/Bot/TradeService');
+const ShotStock      = invoke('GameServer/Inventory/ShotStock');
 
 function formatAdena(value) {
     return String(value).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
@@ -93,42 +94,30 @@ module.exports = {
     },
 
     scheduleRestock(session, bot, Generics, BotAI) {
-        const Database = invoke('Database');
-
         setTimeout(() => {
-            const backpack = bot.backpack;
-            const adena = backpack.fetchTotalAdena();
+            const plan = ShotStock.planForActor(bot);
+            const current = ShotStock.shotAmount(bot, plan);
+            const amount = Math.max(0, ShotStock.DEFAULT_TARGET_AMOUNT - current);
+            const expectedCost = amount * Number(plan.price || 0);
 
-            if (adena >= 7000) {
-                backpack.stackableExists(57).then((adenaItem) => {
-                    const total = adenaItem.fetchAmount() - 7000;
-                    Database.updateItemAmount(bot.fetchId(), adenaItem.fetchId(), total).then(() => {
-                        adenaItem.setAmount(total);
-                    });
-                });
+            ShotStock.purchaseActorRestock(bot, {
+                plan,
+                targetAmount: ShotStock.DEFAULT_TARGET_AMOUNT
+            }).then((result) => {
+                if (!result.ok) {
+                    BotAI.say(session, `Not enough Adena to buy ${ShotStock.describe(plan)} (Have ${result.adena || 0}/${result.cost || expectedCost} Adena). Skipping restocking.`);
+                    return;
+                }
 
-                backpack.stackableExists(1835).then((shotItem) => {
-                    const total = shotItem.fetchAmount() + 1000;
-                    Database.updateItemAmount(bot.fetchId(), shotItem.fetchId(), total).then(() => {
-                        shotItem.setAmount(total);
-                    });
-                }).catch(() => {
-                    Database.setItem(bot.fetchId(), {
-                        selfId: 1835,
-                        name: "Soulshot: No Grade",
-                        amount: 1000,
-                        equipped: false,
-                        slot: 0
-                    }).then((packet) => {
-                        backpack.insertItem(Number(packet.insertId), 1835, { amount: 1000 });
-                    });
-                });
-
-                BotAI.say(session, "Bought 1000x Soulshot: No Grade (-7000 Adena)!");
+                if (result.delta > 0) {
+                    BotAI.say(session, `Bought ${result.delta}x ${ShotStock.describe(plan)} (-${formatAdena(result.cost)} Adena)!`);
+                } else {
+                    BotAI.say(session, `Still stocked on ${ShotStock.describe(plan)}.`);
+                }
                 session.dataSendToOthers(ServerResponse.skillStarted(bot, bot.fetchId(), { fetchSelfId: () => 2001, fetchCalculatedHitTime: () => 500, fetchReuseTime: () => 500 }), bot);
-            } else {
-                BotAI.say(session, `Not enough Adena to buy Soulshots (Have ${adena}/7000 Adena). Skipping restocking.`);
-            }
+            }).catch((err) => {
+                utils.infoWarn('Shopping', 'shot restock failed for %s: %s', bot.fetchName(), err.message);
+            });
         }, 4000);
 
         setTimeout(() => {

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -13,6 +13,7 @@ const BotAvailability = invoke('GameServer/Bot/AI/BotAvailability');
 const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
 const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
 const BotGear = invoke('GameServer/Bot/AI/BotGear');
+const ShotStock = invoke('GameServer/Inventory/ShotStock');
 const PopulationService = invoke('GameServer/Bot/Population/PopulationService');
 
 const BOTS_TO_SPAWN = BotPopulation.buildStarterBots();
@@ -250,10 +251,14 @@ const BotManager = {
             if (!firstCharacter) return;
 
             const firstStoreCfg = merchantConfigFor(botData, firstCharacter.name);
-            const gearReady = firstStoreCfg
-                ? Promise.resolve(characters)
-                : BotGear.ensureCharacterGear(firstCharacter, botData)
-                    .then(() => Shared.fetchCharacters(username));
+            const gearReady = (firstStoreCfg
+                ? Promise.resolve()
+                : BotGear.ensureCharacterGear(firstCharacter, botData))
+                .then(() => ShotStock.ensureCharacterStock(firstCharacter.id, {
+                    classId: firstCharacter.classId,
+                    targetAmount: ShotStock.DEFAULT_TARGET_AMOUNT
+                }))
+                .then(() => Shared.fetchCharacters(username));
 
             gearReady.then((readyCharacters) => {
                 const character = readyCharacters[0];

--- a/src/GameServer/Bot/Population/GeneratedColdSeeder.js
+++ b/src/GameServer/Bot/Population/GeneratedColdSeeder.js
@@ -4,6 +4,7 @@ const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
 const Config = invoke('GameServer/Bot/Population/PopulationConfig');
 const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
 const SpotProfiles = invoke('GameServer/Bot/Population/SpotProfiles');
+const ShotStock = invoke('GameServer/Inventory/ShotStock');
 
 const CLASS_POOL = [
     { race: 0, classId: 0, sex: 0, role: 'dps' },
@@ -150,7 +151,11 @@ function ensureAdena(characterId, amount) {
 function ensureBaseLoadout(characterId, classId, adena) {
     return awardBaseGear(characterId, classId)
         .then(() => awardBaseSkills(characterId, classId))
-        .then(() => ensureAdena(characterId, adena));
+        .then(() => ensureAdena(characterId, adena))
+        .then(() => ShotStock.ensureCharacterStock(characterId, {
+            classId,
+            targetAmount: ShotStock.DEFAULT_TARGET_AMOUNT
+        }));
 }
 
 function ensureAccount(username) {
@@ -213,6 +218,7 @@ function stateFor(character, index, seedMeta = {}) {
     }, index);
     const vitals = seedMeta.vitals || vitalsFor(classInfo(base.classId), level);
     const now = Date.now();
+    const shotPlan = ShotStock.planFor({ classId: base.classId, rank: 'none' });
 
     return {
         characterId: Number(character.id),
@@ -248,6 +254,11 @@ function stateFor(character, index, seedMeta = {}) {
                 selfId: 57,
                 name: 'Adena',
                 amount: Number(character.adena || Math.round(level * 85))
+            },
+            [shotPlan.selfId]: {
+                selfId: shotPlan.selfId,
+                name: shotPlan.name,
+                amount: ShotStock.DEFAULT_TARGET_AMOUNT
             }
         }
     };

--- a/src/GameServer/Inventory/ShotStock.js
+++ b/src/GameServer/Inventory/ShotStock.js
@@ -1,0 +1,243 @@
+const Database = invoke('Database');
+const DataCache = invoke('GameServer/DataCache');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
+
+const DEFAULT_TARGET_AMOUNT = 1000;
+const WEAPON_SLOTS = new Set([7, 14]);
+
+const SOULSHOT_BY_RANK = {
+    none: 1835,
+    d: 1463,
+    c: 1464,
+    b: 1465,
+    a: 1466,
+    s: 1467
+};
+
+const SPIRITSHOT_BY_RANK = {
+    none: 2509,
+    d: 2510,
+    c: 2511,
+    b: 2512,
+    a: 2513,
+    s: 2514
+};
+
+const SOULSHOT_IDS = Object.values(SOULSHOT_BY_RANK);
+const SPIRITSHOT_IDS = Object.values(SPIRITSHOT_BY_RANK);
+const SHOT_IDS = [...SOULSHOT_IDS, ...SPIRITSHOT_IDS];
+
+function normalizeRank(rank) {
+    const value = String(rank || 'none').toLowerCase();
+    return SOULSHOT_BY_RANK[value] ? value : 'none';
+}
+
+function templateFor(selfId) {
+    return (DataCache.items || []).find((item) => Number(item.selfId) === Number(selfId)) || null;
+}
+
+function itemName(selfId) {
+    return templateFor(selfId)?.template?.name || `Item ${selfId}`;
+}
+
+function itemPrice(selfId) {
+    return Number(templateFor(selfId)?.template?.price || 0);
+}
+
+function itemRank(selfId) {
+    return normalizeRank(templateFor(selfId)?.etc?.rank);
+}
+
+function classWantsSpiritshots(classId) {
+    const role = BotRoles.inferRole(Number(classId || 0));
+    return role === 'mage' || role === 'healer' || role === 'buffer';
+}
+
+function actorClassId(actor) {
+    return typeof actor?.fetchClassId === 'function' ? actor.fetchClassId() : actor?.classId;
+}
+
+function weaponRankFromActor(actor) {
+    const weapon = actor?.backpack?.fetchEquippedWeapon ? actor.backpack.fetchEquippedWeapon() : null;
+    if (weapon && typeof weapon.fetchRank === 'function') {
+        return normalizeRank(weapon.fetchRank());
+    }
+    if (weapon && typeof weapon.fetchSelfId === 'function') {
+        return itemRank(weapon.fetchSelfId());
+    }
+    return 'none';
+}
+
+function weaponRankFromRows(rows = []) {
+    const equippedWeapon = rows.find((row) => {
+        if (Number(row.equipped) !== 1 && row.equipped !== true) return false;
+        return WEAPON_SLOTS.has(Number(row.slot || 0));
+    });
+    return equippedWeapon ? itemRank(equippedWeapon.selfId) : 'none';
+}
+
+function planFor({ classId, rank = 'none' } = {}) {
+    const normalizedRank = normalizeRank(rank);
+    const kind = classWantsSpiritshots(classId) ? 'spiritshot' : 'soulshot';
+    const selfId = kind === 'spiritshot'
+        ? SPIRITSHOT_BY_RANK[normalizedRank]
+        : SOULSHOT_BY_RANK[normalizedRank];
+
+    return {
+        kind,
+        rank: normalizedRank,
+        selfId,
+        name: itemName(selfId),
+        price: itemPrice(selfId)
+    };
+}
+
+function planForActor(actor) {
+    return planFor({
+        classId: actorClassId(actor),
+        rank: weaponRankFromActor(actor)
+    });
+}
+
+function planForRows(rows, classId) {
+    return planFor({
+        classId,
+        rank: weaponRankFromRows(rows || [])
+    });
+}
+
+function shotAmount(actor, plan = planForActor(actor)) {
+    const item = actor?.backpack?.fetchItemFromSelfId
+        ? actor.backpack.fetchItemFromSelfId(plan.selfId)
+        : null;
+    return Number(item?.fetchAmount ? item.fetchAmount() : 0);
+}
+
+function existingRow(rows, selfId) {
+    return (rows || []).find((row) => Number(row.selfId) === Number(selfId));
+}
+
+function ensureActorStock(actor, options = {}) {
+    if (!actor?.backpack || typeof actor.fetchId !== 'function') {
+        return Promise.resolve({ changed: false, reason: 'missing_actor' });
+    }
+
+    const targetAmount = Number(options.targetAmount || DEFAULT_TARGET_AMOUNT);
+    const plan = options.plan || planForActor(actor);
+    const current = actor.backpack.fetchItemFromSelfId(plan.selfId);
+    const currentAmount = Number(current?.fetchAmount ? current.fetchAmount() : 0);
+
+    if (current && currentAmount >= targetAmount) {
+        return Promise.resolve({ changed: false, plan, amount: currentAmount, delta: 0 });
+    }
+
+    if (current) {
+        const delta = targetAmount - currentAmount;
+        return Database.updateItemAmount(actor.fetchId(), current.fetchId(), targetAmount).then(() => {
+            current.setAmount(targetAmount);
+            return { changed: true, plan, amount: targetAmount, delta };
+        });
+    }
+
+    return Database.setItem(actor.fetchId(), {
+        selfId: plan.selfId,
+        name: plan.name,
+        amount: targetAmount,
+        equipped: false,
+        slot: 0
+    }).then((packet) => {
+        actor.backpack.insertItem(Number(packet.insertId), plan.selfId, { amount: targetAmount });
+        return { changed: true, plan, amount: targetAmount, delta: targetAmount };
+    });
+}
+
+function ensureCharacterStock(characterId, options = {}) {
+    const id = Number(characterId?.id || characterId || 0);
+    if (!id) return Promise.resolve({ changed: false, reason: 'missing_character' });
+
+    const targetAmount = Number(options.targetAmount || DEFAULT_TARGET_AMOUNT);
+    return Database.fetchItems(id).then((rows) => {
+        const plan = options.plan || planForRows(rows || [], options.classId ?? characterId?.classId);
+        const current = existingRow(rows, plan.selfId);
+        const currentAmount = Number(current?.amount || 0);
+
+        if (current && currentAmount >= targetAmount) {
+            return { changed: false, plan, amount: currentAmount, delta: 0 };
+        }
+
+        if (current) {
+            const delta = targetAmount - currentAmount;
+            return Database.updateItemAmount(id, current.id, targetAmount).then(() => ({
+                changed: true,
+                plan,
+                amount: targetAmount,
+                delta
+            }));
+        }
+
+        return Database.setItem(id, {
+            selfId: plan.selfId,
+            name: plan.name,
+            amount: targetAmount,
+            equipped: false,
+            slot: 0
+        }).then(() => ({
+            changed: true,
+            plan,
+            amount: targetAmount,
+            delta: targetAmount
+        }));
+    });
+}
+
+function purchaseActorRestock(actor, options = {}) {
+    if (!actor?.backpack || typeof actor.fetchId !== 'function') {
+        return Promise.resolve({ ok: false, reason: 'missing_actor' });
+    }
+
+    const targetAmount = Number(options.targetAmount || DEFAULT_TARGET_AMOUNT);
+    const plan = options.plan || planForActor(actor);
+    const currentAmount = shotAmount(actor, plan);
+    const delta = Math.max(0, targetAmount - currentAmount);
+    if (delta <= 0) return Promise.resolve({ ok: true, changed: false, plan, amount: currentAmount, cost: 0 });
+
+    const cost = delta * Number(plan.price || 0);
+    const adenaItem = actor.backpack.fetchItemFromSelfId(57);
+    const adena = Number(adenaItem?.fetchAmount ? adenaItem.fetchAmount() : 0);
+    if (!adenaItem || adena < cost) {
+        return Promise.resolve({ ok: false, reason: 'not_enough_adena', plan, cost, adena });
+    }
+
+    const nextAdena = adena - cost;
+    return Database.updateItemAmount(actor.fetchId(), adenaItem.fetchId(), nextAdena)
+        .then(() => {
+            adenaItem.setAmount(nextAdena);
+            return ensureActorStock(actor, { targetAmount, plan });
+        })
+        .then((result) => ({ ok: true, ...result, cost, adena: nextAdena }));
+}
+
+function needsActorRestock(actor, threshold = 0) {
+    return shotAmount(actor) <= Number(threshold || 0);
+}
+
+function describe(plan) {
+    if (!plan) return 'shots';
+    return plan.name || itemName(plan.selfId);
+}
+
+module.exports = {
+    DEFAULT_TARGET_AMOUNT,
+    SOULSHOT_IDS,
+    SPIRITSHOT_IDS,
+    SHOT_IDS,
+    planFor,
+    planForActor,
+    planForRows,
+    shotAmount,
+    ensureActorStock,
+    ensureCharacterStock,
+    purchaseActorRestock,
+    needsActorRestock,
+    describe
+};

--- a/src/GameServer/Network/Request/CreateNewChar.js
+++ b/src/GameServer/Network/Request/CreateNewChar.js
@@ -3,6 +3,7 @@ const Shared         = invoke('GameServer/Network/Shared');
 const DataCache      = invoke('GameServer/DataCache');
 const ReceivePacket  = invoke('Packet/Receive');
 const Database       = invoke('Database');
+const ShotStock      = invoke('GameServer/Inventory/ShotStock');
 
 function createNewChar(session, buffer) {
     const packet = new ReceivePacket(buffer);
@@ -57,6 +58,7 @@ function consume(session, data) {
                     const charId = Number(packet.insertId);
                     awardBaseSkills   (charId, data.classId);
                     awardBaseGear     (charId, data.classId);
+                    awardBaseShots    (charId, data.classId);
                     awardBaseShortcuts(charId, data.classId);
         
                     Shared.fetchCharacters(session.accountId).then((characters) => {
@@ -94,6 +96,11 @@ function awardBaseGear(id, classId) {
         item.slot = DataCache.items.find(ob => ob.selfId === item.selfId)?.etc?.slot ?? 0;
         Database.setItem(id, item);
     });
+}
+
+function awardBaseShots(id, classId) {
+    ShotStock.ensureCharacterStock(id, { classId, targetAmount: ShotStock.DEFAULT_TARGET_AMOUNT })
+        .catch((err) => utils.infoWarn('Character', 'failed to award starter shots: %s', err.message));
 }
 
 function awardBaseShortcuts(id, classId) {

--- a/src/GameServer/Network/Request/EnterWorld.js
+++ b/src/GameServer/Network/Request/EnterWorld.js
@@ -1,20 +1,30 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const Database       = invoke('Database');
+const ShotStock      = invoke('GameServer/Inventory/ShotStock');
 
 function enterWorld(session, buffer) {
-    session.dataSendToMe(ServerResponse.itemsList(session.actor.backpack.fetchItems()));
-    Database.fetchShortcuts(session.actor.fetchId()).then((shortcuts) => {
-        session.dataSendToMe(
-            ServerResponse.shortcutInit(shortcuts)
-        );
-    });
-    
-    session.actor.enterWorld();
-    session.dataSendToMe(ServerResponse.sunrise()); // TODO: Server timer
-    session.dataSendToMe(ServerResponse.userInfo(session.actor));
-    session.dataSendToMe(ServerResponse.abnormalStatusUpdate.fromActor(session.actor));
-    session.dataSendToOthers(ServerResponse.charInfo(session.actor), session.actor);
-    session.dataSendToOthers(ServerResponse.relationChanged(session.actor), session.actor);
+    const continueEnter = () => {
+        session.dataSendToMe(ServerResponse.itemsList(session.actor.backpack.fetchItems()));
+        Database.fetchShortcuts(session.actor.fetchId()).then((shortcuts) => {
+            session.dataSendToMe(
+                ServerResponse.shortcutInit(shortcuts)
+            );
+        });
+
+        session.actor.enterWorld();
+        session.dataSendToMe(ServerResponse.sunrise()); // TODO: Server timer
+        session.dataSendToMe(ServerResponse.userInfo(session.actor));
+        session.dataSendToMe(ServerResponse.abnormalStatusUpdate.fromActor(session.actor));
+        session.dataSendToOthers(ServerResponse.charInfo(session.actor), session.actor);
+        session.dataSendToOthers(ServerResponse.relationChanged(session.actor), session.actor);
+    };
+
+    ShotStock.ensureActorStock(session.actor, { targetAmount: ShotStock.DEFAULT_TARGET_AMOUNT })
+        .then(continueEnter)
+        .catch((err) => {
+            utils.infoWarn('Character', 'starter shot stock failed for %s: %s', session.actor.fetchName(), err.message);
+            continueEnter();
+        });
 }
 
 module.exports = enterWorld;


### PR DESCRIPTION
## Summary
- Add shared shot stock handling that chooses soulshots or spiritshots by class and weapon grade.
- Give players and bots a 1000-shot baseline on character creation, login, spawn, and cold population seeding.
- Make solo hunting bots go to town to restock when shots run out, and restock the correct grade during shopping.
- Add spiritshot loading and magic-hit consumption alongside existing soulshot combat behavior.

## Validation
- `git diff --check`
- `node --check` on the touched server files
- Datapack smoke checks for fighter and mage shot selection/restock behavior