### PR TITLE
Add town routing hints for bot movement

### DIFF
--- a/src/GameServer/Bot/AI/TownPathfinder.js
+++ b/src/GameServer/Bot/AI/TownPathfinder.js
@@ -1,151 +1,300 @@
-const GATES = {
-    NORTH: {
-        gate: { locX: -84081, locY: 243227, locZ: -3723 },
-        approach: { locX: -84081, locY: 242827, locZ: -3723 }
+// Town polygons and walk nodes are distilled from public L2J/L2jOrion town
+// zone, mapregion, and bot random-walk data. Keep this file small and explicit:
+// it is a routing hint layer, not a replacement for geodata.
+const TOWNS = [
+    {
+        name: "Talking Island",
+        center: { locX: -84108, locY: 244604, locZ: -3729 },
+        polygon: [
+            [-83739, 245733], [-84049, 246087], [-84289, 246258], [-84556, 246243],
+            [-84984, 245820], [-85336, 245426], [-85684, 245099], [-85969, 244770],
+            [-86400, 244292], [-86664, 243997], [-86940, 243631], [-87517, 243034],
+            [-87650, 242799], [-87613, 242572], [-87348, 242246], [-86956, 241942],
+            [-86656, 241684], [-86343, 241365], [-85829, 240966], [-85544, 240765],
+            [-85193, 240440], [-84865, 240185], [-84594, 239866], [-84284, 239666],
+            [-84002, 239734], [-83822, 239922], [-83640, 240190], [-83295, 240492],
+            [-82990, 240878], [-82635, 241208], [-82234, 241698], [-82027, 241985],
+            [-81684, 242328], [-81421, 242741], [-81113, 243073], [-81011, 243228],
+            [-81029, 243496], [-81340, 243797], [-81691, 244028], [-82292, 244585],
+            [-82787, 244999], [-83726, 245721]
+        ],
+        nodes: [
+            { locX: -84108, locY: 244604, locZ: -3729 },
+            { locX: -83990, locY: 243336, locZ: -3700 },
+            { locX: -84512, locY: 242679, locZ: -3700 },
+            { locX: -84623, locY: 243193, locZ: -3700 },
+            { locX: -83761, locY: 243620, locZ: -3700 },
+            { locX: -84903, locY: 243489, locZ: -3700 }
+        ]
     },
-    WEST: {
-        gate: { locX: -85400, locY: 244579, locZ: -3730 },
-        approach: { locX: -85800, locY: 244579, locZ: -3730 }
+    {
+        name: "Gludin",
+        center: { locX: -80752, locY: 149776, locZ: -3044 },
+        polygon: [
+            [-84867, 149371], [-82581, 149364], [-82499, 149139], [-81593, 149177],
+            [-81551, 149410], [-79270, 149392], [-79275, 150365], [-79055, 150368],
+            [-78820, 150429], [-78644, 150595], [-78558, 150837], [-78567, 152410],
+            [-78796, 152420], [-78803, 154319], [-77131, 155437], [-78190, 156459],
+            [-79978, 156104], [-84876, 156106]
+        ],
+        nodes: [
+            { locX: -80752, locY: 149776, locZ: -3044 },
+            { locX: -83520, locY: 150560, locZ: -3000 },
+            { locX: -82464, locY: 150848, locZ: -3000 },
+            { locX: -81787, locY: 150780, locZ: -3000 },
+            { locX: -82035, locY: 152647, locZ: -3000 },
+            { locX: -80053, locY: 154348, locZ: -3000 }
+        ]
     },
-    EAST: {
-        gate: { locX: -83150, locY: 244579, locZ: -3730 },
-        approach: { locX: -82750, locY: 244579, locZ: -3730 }
+    {
+        name: "Gludio",
+        center: { locX: -12736, locY: 122816, locZ: -3114 },
+        polygon: [
+            [-14960, 121148], [-14875, 121120], [-14717, 121106], [-14394, 121109],
+            [-14242, 121104], [-12659, 121098], [-12025, 121767], [-12024, 123944],
+            [-12277, 124668], [-12648, 125573], [-12879, 126199], [-13855, 126470],
+            [-14484, 126463], [-15236, 126178], [-16126, 125356], [-16531, 124493],
+            [-16537, 123850], [-16492, 123330], [-16194, 123160], [-16057, 123101],
+            [-15327, 122741], [-14958, 121150]
+        ],
+        nodes: [
+            { locX: -12736, locY: 122816, locZ: -3114 },
+            { locX: -14288, locY: 122752, locZ: -3000 },
+            { locX: -14592, locY: 123232, locZ: -3000 },
+            { locX: -13904, locY: 123456, locZ: -3000 },
+            { locX: -15314, locY: 124131, locZ: -3000 },
+            { locX: -14279, locY: 124446, locZ: -3000 }
+        ]
     },
-    SOUTH: {
-        gate: { locX: -84318, locY: 245800, locZ: -3730 },
-        approach: { locX: -84318, locY: 246200, locZ: -3730 }
+    {
+        name: "Dion",
+        center: { locX: 15631, locY: 142885, locZ: -2704 },
+        polygon: [
+            [15264, 141764], [15434, 143574], [15760, 144707], [15846, 145302],
+            [16134, 146850], [16715, 147153], [17844, 147640], [18139, 147138],
+            [18541, 146758], [18782, 146598], [19069, 146521], [19430, 146485],
+            [20363, 146421], [20722, 146319], [21415, 146319], [21402, 145011],
+            [21381, 143675], [20696, 142841], [20380, 142492], [19060, 142463],
+            [18821, 142512], [17885, 143046], [17447, 143348], [17019, 144028],
+            [16780, 142908], [17344, 142847], [17327, 142650], [17483, 142634],
+            [17396, 141776], [17238, 141792], [17218, 141574]
+        ],
+        nodes: [
+            { locX: 15631, locY: 142885, locZ: -2704 },
+            { locX: 18769, locY: 145629, locZ: -3108 },
+            { locX: 18482, locY: 145795, locZ: -3088 },
+            { locX: 17763, locY: 146746, locZ: -3114 },
+            { locX: 17168, locY: 145258, locZ: -3048 },
+            { locX: 17639, locY: 145415, locZ: -3068 },
+            { locX: 19099, locY: 143987, locZ: -3071 }
+        ]
+    },
+    {
+        name: "Giran",
+        center: { locX: 83396, locY: 147904, locZ: -3404 },
+        polygon: [
+            [77170, 147420], [79200, 147420], [79200, 144780], [80310, 144780],
+            [80310, 143630], [83120, 143630], [83120, 143505], [83700, 143505],
+            [83700, 141500], [84070, 141500], [84070, 143505], [85040, 143505],
+            [85040, 145760], [86115, 145760], [86115, 146910], [88425, 146910],
+            [88425, 147175], [90430, 147175], [90430, 147540], [88425, 147540],
+            [88425, 150050], [86495, 150050], [86495, 150250], [85995, 150250],
+            [85995, 152250], [86780, 152250], [86780, 153600], [84850, 153600],
+            [84850, 152250], [85625, 152250], [85265, 150250], [85085, 150250],
+            [85085, 149875], [83680, 149875], [83680, 149920], [83500, 149920],
+            [83500, 151270], [82705, 151270], [82705, 152820], [79195, 152820],
+            [79195, 149805], [77170, 149805]
+        ],
+        nodes: [
+            { locX: 83396, locY: 147904, locZ: -3404 },
+            { locX: 82248, locY: 148600, locZ: -3464 },
+            { locX: 82072, locY: 147560, locZ: -3464 },
+            { locX: 82792, locY: 147832, locZ: -3464 },
+            { locX: 83320, locY: 147976, locZ: -3400 },
+            { locX: 84584, locY: 148536, locZ: -3400 },
+            { locX: 83384, locY: 149256, locZ: -3400 },
+            { locX: 87016, locY: 148632, locZ: -3400 },
+            { locX: 85816, locY: 148872, locZ: -3400 },
+            { locX: 85832, locY: 153208, locZ: -3496 },
+            { locX: 81384, locY: 150040, locZ: -3528 },
+            { locX: 79656, locY: 150728, locZ: -3512 },
+            { locX: 79272, locY: 149544, locZ: -3528 },
+            { locX: 80744, locY: 146424, locZ: -3528 }
+        ]
+    },
+    {
+        name: "Oren",
+        center: { locX: 82960, locY: 53177, locZ: -1497 },
+        polygon: [
+            [84014, 52245], [84138, 54683], [84143, 55029], [84001, 57029],
+            [81773, 57023], [81795, 56237], [81239, 56236], [81282, 56892],
+            [81187, 56904], [81105, 57179], [79195, 57167], [78986, 57076],
+            [78844, 55218], [78843, 54882], [79148, 54560], [79660, 54556],
+            [79662, 53994], [79002, 53990], [78963, 53359], [78959, 53070],
+            [79027, 52125], [79628, 52070], [80547, 52068], [80835, 52116],
+            [80733, 53068], [81306, 53070], [81369, 52310], [82605, 52244],
+            [84010, 52250]
+        ],
+        nodes: [
+            { locX: 82960, locY: 53177, locZ: -1497 },
+            { locX: 80304, locY: 56241, locZ: -1500 },
+            { locX: 80594, locY: 55837, locZ: -1500 },
+            { locX: 79933, locY: 55752, locZ: -1500 },
+            { locX: 80334, locY: 54400, locZ: -1500 },
+            { locX: 82445, locY: 56012, locZ: -1480 },
+            { locX: 82880, locY: 55390, locZ: -1480 },
+            { locX: 82638, locY: 53885, locZ: -1440 },
+            { locX: 80054, locY: 53209, locZ: -1500 }
+        ]
     }
-};
+];
+
+function distance(a, b) {
+    const dx = a.locX - b.locX;
+    const dy = a.locY - b.locY;
+    return Math.sqrt((dx * dx) + (dy * dy));
+}
+
+function pointInPolygon(loc, polygon) {
+    let inside = false;
+    for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+        const xi = polygon[i][0];
+        const yi = polygon[i][1];
+        const xj = polygon[j][0];
+        const yj = polygon[j][1];
+        const intersects = ((yi > loc.locY) !== (yj > loc.locY)) &&
+            (loc.locX < ((xj - xi) * (loc.locY - yi)) / ((yj - yi) || 1) + xi);
+        if (intersects) {
+            inside = !inside;
+        }
+    }
+    return inside;
+}
+
+function closestTownByCenter(loc) {
+    let best = null;
+    let bestDistance = Infinity;
+    for (const town of TOWNS) {
+        const dist = distance(loc, town.center);
+        if (dist < bestDistance) {
+            best = town;
+            bestDistance = dist;
+        }
+    }
+    return bestDistance <= 1500 ? best : null;
+}
+
+function findTown(loc) {
+    return TOWNS.find((town) => pointInPolygon(loc, town.polygon)) || closestTownByCenter(loc);
+}
+
+function nearestNode(town, loc) {
+    let best = town.center;
+    let bestDistance = Infinity;
+    for (const node of town.nodes) {
+        const dist = distance(node, loc);
+        if (dist < bestDistance) {
+            best = node;
+            bestDistance = dist;
+        }
+    }
+    return best;
+}
+
+function boundaryNodeToward(town, loc) {
+    const dx = loc.locX - town.center.locX;
+    const dy = loc.locY - town.center.locY;
+    const len = Math.sqrt((dx * dx) + (dy * dy)) || 1;
+    const nx = dx / len;
+    const ny = dy / len;
+
+    let best = town.center;
+    let bestProjection = -Infinity;
+    for (const point of town.polygon) {
+        const projection = ((point[0] - town.center.locX) * nx) + ((point[1] - town.center.locY) * ny);
+        if (projection > bestProjection) {
+            bestProjection = projection;
+            best = { locX: point[0], locY: point[1], locZ: town.center.locZ };
+        }
+    }
+    return best;
+}
+
+function chooseNextTownStep(town, from, finalTarget) {
+    let bestNode = null;
+    let bestScore = Infinity;
+    for (const node of town.nodes) {
+        const fromDistance = distance(from, node);
+        const targetDistance = distance(finalTarget, node);
+        if (fromDistance <= 350 || targetDistance <= 350) {
+            continue;
+        }
+
+        const score = fromDistance + targetDistance;
+        if (score < bestScore) {
+            bestNode = node;
+            bestScore = score;
+        }
+    }
+
+    if (bestNode) {
+        return bestNode;
+    }
+
+    if (distance(from, town.center) > 700 && distance(finalTarget, town.center) > 700) {
+        return town.center;
+    }
+
+    return finalTarget;
+}
 
 const TownPathfinder = {
+    towns: TOWNS,
+
     isInsideTown(loc) {
-        return loc.locX >= -85400 && loc.locX <= -83150 &&
-               loc.locY >= 243227 && loc.locY <= 245800;
+        return !!findTown(loc);
     },
 
-    getGateByPosition(loc) {
-        const dx = loc.locX - (-84318);
-        const dy = loc.locY - 244579;
-        const angle = Math.atan2(dy, dx);
-
-        if (angle >= -3 * Math.PI / 4 && angle < -Math.PI / 4) {
-            return GATES.NORTH;
-        }
-        if (angle >= Math.PI / 4 && angle < 3 * Math.PI / 4) {
-            return GATES.SOUTH;
-        }
-        if (angle >= -Math.PI / 4 && angle < Math.PI / 4) {
-            return GATES.EAST;
-        }
-        return GATES.WEST;
-    },
-
-    lineCircleIntersect(p1, p2, circle) {
-        const dx = p2.locX - p1.locX;
-        const dy = p2.locY - p1.locY;
-        const lenSq = dx * dx + dy * dy;
-        if (lenSq === 0) return false;
-
-        const t = ((circle.x - p1.locX) * dx + (circle.y - p1.locY) * dy) / lenSq;
-        if (t < 0 || t > 1) {
-            const dist1Sq = (p1.locX - circle.x) ** 2 + (p1.locY - circle.y) ** 2;
-            const dist2Sq = (p2.locX - circle.x) ** 2 + (p2.locY - circle.y) ** 2;
-            return dist1Sq < circle.r * circle.r || dist2Sq < circle.r * circle.r;
-        }
-
-        const cx = p1.locX + t * dx;
-        const cy = p1.locY + t * dy;
-        const distSq = (cx - circle.x) ** 2 + (cy - circle.y) ** 2;
-        return distSq < circle.r * circle.r;
-    },
-
-    getObstacleAvoidedTarget(from, to) {
-        const OBSTACLES = [
-            { name: "Center Obelisk", x: -84318, y: 244579, r: 250 },
-            { name: "North-West Building", x: -84800, y: 244000, r: 350 },
-            { name: "North-East Temple", x: -83800, y: 243800, r: 400 },
-            { name: "South-West Building", x: -84900, y: 245100, r: 350 },
-            { name: "South-East Building", x: -83700, y: 245100, r: 350 }
-        ];
-
-        const intersects = OBSTACLES.some(obs => this.lineCircleIntersect(from, to, obs));
-        if (intersects) {
-            const center = { locX: -84318, locY: 244579, locZ: -3730 };
-            const dxCenter = from.locX - center.locX;
-            const dyCenter = from.locY - center.locY;
-            const distToCenter = Math.sqrt(dxCenter * dxCenter + dyCenter * dyCenter);
-            if (distToCenter > 300) {
-                // Head to plaza center first to get clear line-of-sight
-                return center;
-            }
-        }
-        return to;
+    getTown(loc) {
+        return findTown(loc);
     },
 
     route(actor, from, to) {
-        const fromInTown = this.isInsideTown(from);
-        const toInTown = this.isInsideTown(to);
+        const fromTown = findTown(from);
+        const toTown = findTown(to);
 
-        let routedTo = to;
+        if (!fromTown && !toTown) {
+            return to;
+        }
 
-        // Case 1: Running from inside town to outside town (going to hunt)
-        if (fromInTown && !toInTown) {
-            const exitGate = this.getGateByPosition(to);
-            const dx = from.locX - exitGate.gate.locX;
-            const dy = from.locY - exitGate.gate.locY;
-            if (Math.sqrt(dx*dx + dy*dy) < 400) {
-                routedTo = to; // Already at the exit gate, run directly to target
-            } else {
-                routedTo = exitGate.gate; // Head to the exit gate first
+        if (fromTown && toTown && fromTown.name === toTown.name) {
+            if (distance(from, to) <= 700) {
+                return to;
             }
+            return chooseNextTownStep(fromTown, from, to);
         }
 
-        // Case 2: Running from outside town to inside town (returning to town)
-        else if (!fromInTown && toInTown) {
-            const exitGate = this.getGateByPosition(from);
-            
-            const dxApproach = from.locX - exitGate.approach.locX;
-            const dyApproach = from.locY - exitGate.approach.locY;
-            const distApproach = Math.sqrt(dxApproach * dxApproach + dyApproach * dyApproach);
-
-            const dxGate = from.locX - exitGate.gate.locX;
-            const dyGate = from.locY - exitGate.gate.locY;
-            const distGate = Math.sqrt(dxGate * dxGate + dyGate * dyGate);
-
-            if (distGate < 250) {
-                routedTo = to; // Already at the gate, run directly inside
-            } else if (distApproach < 250) {
-                routedTo = exitGate.gate; // Lined up with approach, run to gate
-            } else {
-                routedTo = exitGate.approach; // Run to approach point first to align outside wall
+        if (fromTown && !toTown) {
+            const exit = boundaryNodeToward(fromTown, to);
+            const staging = nearestNode(fromTown, exit);
+            if (distance(from, staging) > 350 && distance(exit, staging) > 350) {
+                return staging;
             }
-        }
-
-        // Case 3: Both inside town (running from shop to plaza, etc.)
-        else if (fromInTown && toInTown) {
-            const dx = to.locX - from.locX;
-            const dy = to.locY - from.locY;
-            if (Math.sqrt(dx*dx + dy*dy) < 800) {
-                routedTo = to; // Close enough, walk directly
-            } else {
-                // Otherwise, route via central plaza first to avoid clipping fences/corners
-                const center = { locX: -84318, locY: 244579, locZ: -3730 };
-                const dxCenter = from.locX - center.locX;
-                const dyCenter = from.locY - center.locY;
-                if (Math.sqrt(dxCenter*dxCenter + dyCenter*dyCenter) < 400) {
-                    routedTo = to;
-                } else {
-                    routedTo = center;
-                }
+            if (distance(from, exit) > 350) {
+                return exit;
             }
+            return to;
         }
 
-        // Apply obstacle avoidance inside town
-        if (fromInTown) {
-            return this.getObstacleAvoidedTarget(from, routedTo);
+        if (!fromTown && toTown) {
+            const entry = boundaryNodeToward(toTown, from);
+            if (distance(from, entry) > 350) {
+                return entry;
+            }
+            return chooseNextTownStep(toTown, from, to);
         }
 
-        return routedTo;
+        return to;
     }
 };
 

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -157,10 +157,11 @@ const BotAI = {
             { name: "Dark Elven Village", x: 12111, y: 16686, z: -4582 },
             { name: "Dwarven Village", x: 115632, y: -177996, z: -905 },
             { name: "Orc Village", x: -45032, y: -113598, z: -192 },
-            { name: "Gludio", x: -12672, y: 122776, z: -3730 },
-            { name: "Dion", x: 15664, y: 142979, z: -3730 },
-            { name: "Giran", x: 83400, y: 147943, z: -3730 },
-            { name: "Oren", x: 82960, y: 53177, z: -3730 }
+            { name: "Gludin", x: -80752, y: 149776, z: -3044 },
+            { name: "Gludio", x: -12736, y: 122816, z: -3114 },
+            { name: "Dion", x: 15631, y: 142885, z: -2704 },
+            { name: "Giran", x: 83396, y: 147904, z: -3404 },
+            { name: "Oren", x: 82960, y: 53177, z: -1497 }
         ];
         let closest = towns[0];
         let minDist = Infinity;

--- a/src/Global.js
+++ b/src/Global.js
@@ -84,6 +84,7 @@ global.utils = {
     isInPeaceZone(locX, locY) {
         const PEACE_ZONES = [
             { x: -84318, y: 244579, r: 8000 }, // TI
+            { x: -80752, y: 149776, r: 6000 }, // Gludin
             { x: -12672, y: 122776, r: 6000 }, // Gludio
             { x: 15664,  y: 142979, r: 6000 }, // Dion
             { x: 83400,  y: 147943, r: 8000 }, // Giran

--- a/tests/test_town_pathfinder.js
+++ b/tests/test_town_pathfinder.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const TownPathfinder = invoke('GameServer/Bot/AI/TownPathfinder');
+const BotAI = invoke('GameServer/Bot/BotAI');
+
+function distance(a, b) {
+    const dx = a.locX - b.locX;
+    const dy = a.locY - b.locY;
+    return Math.sqrt((dx * dx) + (dy * dy));
+}
+
+function assertNotSameLoc(actual, expected, message) {
+    assert(
+        actual.locX !== expected.locX || actual.locY !== expected.locY || actual.locZ !== expected.locZ,
+        message
+    );
+}
+
+const giranCenter = { locX: 83396, locY: 147904, locZ: -3404 };
+const giranField = { locX: 76000, locY: 144000, locZ: -3600 };
+const dionCenter = { locX: 15631, locY: 142885, locZ: -2704 };
+const dionField = { locX: 23000, locY: 145000, locZ: -3100 };
+
+assert.strictEqual(TownPathfinder.getTown(giranCenter).name, 'Giran');
+assert.strictEqual(TownPathfinder.getTown(dionCenter).name, 'Dion');
+
+const giranEntry = TownPathfinder.route(null, giranField, giranCenter);
+assertNotSameLoc(giranEntry, giranCenter, 'Giran outside->inside should route through an entry/staging point');
+assert.strictEqual(TownPathfinder.getTown(giranEntry).name, 'Giran');
+
+const giranExit = TownPathfinder.route(null, giranCenter, giranField);
+assertNotSameLoc(giranExit, giranField, 'Giran inside->outside should route through an exit/staging point');
+assert.strictEqual(TownPathfinder.getTown(giranExit).name, 'Giran');
+
+const dionEntry = TownPathfinder.route(null, dionField, dionCenter);
+assertNotSameLoc(dionEntry, dionCenter, 'Dion outside->inside should route through an entry/staging point');
+assert(distance(dionEntry, dionCenter) < distance(dionField, dionCenter));
+
+const gludinTown = BotAI.getClosestTown(-82000, 151000);
+assert.strictEqual(gludinTown.name, 'Gludin');
+assert.strictEqual(gludinTown.z, -3044);
+
+console.log('TownPathfinder regression checks passed');


### PR DESCRIPTION
## Summary
- Replace the Talking Island-only town routing shim with data-driven town polygons and walk nodes for the main early towns.
- Update bot closest-town coordinates with Gludin and accurate town Z values.
- Add a focused regression test for town routing decisions.

## Why
Bots could choose bad straight-line movement inside or around cities because the town pathing layer only understood Talking Island and some town centers used placeholder heights. This gives bot movement safer city entry, exit, and internal staging points without hand-mapping every road.

## Validation
- node --check src\GameServer\Bot\AI\TownPathfinder.js
- node --check src\GameServer\Bot\BotAI.js
- node --check src\Global.js
- node --check tests\test_town_pathfinder.js
- node tests\test_town_pathfinder.js
- node tests\test_path_obstacle.js
- git diff --cached --check