### PR TITLE
Add bot agent tool foundation

### DIFF
--- a/src/GameServer/Bot/AI/BotAgentTools.js
+++ b/src/GameServer/Bot/AI/BotAgentTools.js
@@ -1,0 +1,298 @@
+const ServerResponse = invoke('GameServer/Network/Response');
+const SpotService = invoke('GameServer/Bot/AI/SpotService');
+const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
+
+const SUPPORT_BUFF_MP_COST = 20;
+const HEAL_MP_COST = 15;
+
+const ACTIONS = [
+    'none',
+    'say',
+    'follow_player',
+    'stay_here',
+    'hunt',
+    'rest',
+    'shop',
+    'move_to_spot',
+    'buff_target',
+    'heal_target'
+];
+
+function clean(text) {
+    return String(text || '').trim().slice(0, 120);
+}
+
+function isRealPlayer(session) {
+    return session &&
+        session.actor &&
+        session.actor.fetchIsOnline() &&
+        session.accountId &&
+        !session.accountId.startsWith('bot_');
+}
+
+function findVisiblePlayerByName(name, visiblePlayers) {
+    if (!name) return null;
+
+    const lookup = String(name).toLowerCase();
+    const visible = visiblePlayers.find((player) => player.name.toLowerCase() === lookup);
+    if (!visible) return null;
+
+    const World = invoke('GameServer/World/World');
+    return World.user.sessions.find((session) =>
+        isRealPlayer(session) &&
+        session.actor.fetchId() === visible.id
+    ) || null;
+}
+
+function responseTargetSession(decision, visiblePlayers) {
+    return findVisiblePlayerByName(decision?.targetPlayerName, visiblePlayers) ||
+        findVisiblePlayerByName(visiblePlayers[0]?.name, visiblePlayers);
+}
+
+function say(session, text, targetSession = null) {
+    const line = clean(text);
+    if (!line) return false;
+
+    const BotAI = invoke('GameServer/Bot/BotAI');
+    if (targetSession) {
+        BotAI.tell(session, targetSession, line);
+    } else {
+        BotAI.say(session, line);
+    }
+    return true;
+}
+
+function sit(session, bot) {
+    if (bot.state.fetchSeated()) return;
+    bot.state.setSeated(true);
+    session.dataSendToOthers(ServerResponse.sitAndStand(bot), bot);
+}
+
+function stand(session, bot) {
+    if (!bot.state.fetchSeated()) return;
+    bot.state.setSeated(false);
+    session.dataSendToOthers(ServerResponse.sitAndStand(bot), bot);
+}
+
+function applyMoveToSpot(session, bot, spotId) {
+    const spot = SpotService.findById(spotId);
+    if (!spot) return false;
+
+    const assignedSpot = SpotService.assignSpot(session, spot);
+    const targetLoc = SpotService.randomPointNear(spot);
+    session.initialSpawnCoord = { ...assignedSpot.center };
+    session.lastSpotMoveAt = Date.now();
+    session.noTargetTicks = 0;
+
+    bot.moveTo({
+        from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
+        to: targetLoc
+    });
+
+    return true;
+}
+
+function startShopping(session, bot) {
+    const BotAI = invoke('GameServer/Bot/BotAI');
+    const closestTown = BotAI.getClosestTown(bot.fetchLocX(), bot.fetchLocY());
+    session.preShopLocation = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
+    session.plan = 'shopping';
+    session.shopTimer = Date.now();
+    session.shoppingTarget = undefined;
+    bot.moveTo({
+        from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
+        to: { locX: closestTown.x, locY: closestTown.y, locZ: closestTown.z }
+    });
+}
+
+function isPartyCompanionOf(session, targetSession) {
+    return session.partyCompanion === true && session.followPlayerSession === targetSession;
+}
+
+function approachPlayer(session, bot, targetSession) {
+    const player = targetSession?.actor;
+    if (!player) return false;
+
+    const dx = player.fetchLocX() - bot.fetchLocX();
+    const dy = player.fetchLocY() - bot.fetchLocY();
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist <= 350) return true;
+
+    bot.moveTo({
+        from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
+        to: {
+            locX: player.fetchLocX() + utils.oneFromSpan(-80, 80),
+            locY: player.fetchLocY() + utils.oneFromSpan(-80, 80),
+            locZ: player.fetchLocZ()
+        }
+    });
+
+    return true;
+}
+
+function distance2d(a, b) {
+    const dx = a.fetchLocX() - b.fetchLocX();
+    const dy = a.fetchLocY() - b.fetchLocY();
+    return Math.sqrt(dx * dx + dy * dy);
+}
+
+function applyBuffTarget(session, bot, decision, targetSession) {
+    const target = targetSession?.actor;
+    const buffType = String(decision.buffType || '').toLowerCase();
+    if (!target || !BotBuffs.SUPPORT_BUFFS[buffType]) return { applied: false, reason: 'invalid_buff_target' };
+    if (!BotRoles.canBuff(bot)) return { applied: false, reason: 'bot_cannot_buff' };
+    if (bot.fetchMp() < SUPPORT_BUFF_MP_COST) return { applied: false, reason: 'low_mp_for_buff' };
+    if (distance2d(bot, target) > 900) return { applied: false, reason: 'target_too_far' };
+
+    const result = BotBuffs.applySupportBuff(targetSession, target, buffType, invoke(path.actor));
+    if (!result) return { applied: false, reason: 'buff_failed' };
+
+    bot.setMp(Math.max(0, bot.fetchMp() - SUPPORT_BUFF_MP_COST));
+    bot.statusUpdateVitals(bot);
+    say(session, decision.reply || `${result.name} on ${target.fetchName()}.`, targetSession);
+    return { applied: true, reason: `buff:${buffType}` };
+}
+
+function applyHealTarget(session, bot, decision, targetSession) {
+    const target = targetSession?.actor;
+    if (!target) return { applied: false, reason: 'invalid_heal_target' };
+    if (!BotRoles.isHealer(bot)) return { applied: false, reason: 'bot_cannot_heal' };
+    if (bot.fetchMp() < HEAL_MP_COST) return { applied: false, reason: 'low_mp_for_heal' };
+    if (distance2d(bot, target) > 900) return { applied: false, reason: 'target_too_far' };
+
+    targetSession.dataSendToMe(
+        ServerResponse.skillStarted(bot, target.fetchId(), {
+            fetchSelfId: () => 1011,
+            fetchCalculatedHitTime: () => 1000,
+            fetchReuseTime: () => 1000
+        })
+    );
+
+    setTimeout(() => {
+        if (target.isDead && target.isDead()) return;
+        target.setHp(target.fetchMaxHp());
+        target.statusUpdateVitals(target);
+        bot.setMp(Math.max(0, bot.fetchMp() - HEAL_MP_COST));
+        bot.statusUpdateVitals(bot);
+        say(session, decision.reply || `Healing you, ${target.fetchName()}.`, targetSession);
+    }, 1000);
+
+    return { applied: true, reason: 'heal_target' };
+}
+
+function execute(session, decision, visiblePlayers) {
+    const bot = session.actor;
+    if (!bot || !decision || Number(decision.confidence || 0) < 0.45) {
+        return { applied: false, reason: 'low_confidence_or_missing_context' };
+    }
+
+    const action = decision.action;
+    const targetSession = responseTargetSession(decision, visiblePlayers);
+
+    if (action === 'none') {
+        return { applied: true, reason: 'none' };
+    }
+    if (action === 'say') {
+        return { applied: say(session, decision.reply, targetSession), reason: 'say' };
+    }
+    if (action === 'follow_player') {
+        if (!targetSession) return { applied: false, reason: 'missing_target_player' };
+        stand(session, bot);
+        if (isPartyCompanionOf(session, targetSession)) {
+            session.plan = 'following';
+            session.botStay = false;
+            say(session, decision.reply || `Following you, ${targetSession.actor.fetchName()}!`, targetSession);
+        } else {
+            approachPlayer(session, bot, targetSession);
+            say(session, decision.reply || `Coming closer. Invite me if you want party follow.`, targetSession);
+        }
+        return { applied: true, reason: 'follow_player' };
+    }
+    if (action === 'stay_here') {
+        session.botStay = true;
+        session.stayLocation = {
+            locX: bot.fetchLocX(),
+            locY: bot.fetchLocY(),
+            locZ: bot.fetchLocZ()
+        };
+        if (session.followPlayerSession && session.partyCompanion === true) {
+            session.plan = 'following';
+        }
+        say(session, decision.reply || 'Holding this position.', targetSession);
+        return { applied: true, reason: 'stay_here' };
+    }
+    if (action === 'hunt') {
+        stand(session, bot);
+        session.plan = 'hunting';
+        session.followPlayerSession = null;
+        session.partyCompanion = false;
+        session.botStay = false;
+        say(session, decision.reply, targetSession);
+        return { applied: true, reason: 'hunt' };
+    }
+    if (action === 'rest') {
+        session.plan = 'resting';
+        session.currentTargetId = undefined;
+        bot.unselect();
+        sit(session, bot);
+        say(session, decision.reply, targetSession);
+        return { applied: true, reason: 'rest' };
+    }
+    if (action === 'shop') {
+        startShopping(session, bot);
+        say(session, decision.reply, targetSession);
+        return { applied: true, reason: 'shop' };
+    }
+    if (action === 'move_to_spot') {
+        const applied = applyMoveToSpot(session, bot, decision.spotId);
+        if (applied) say(session, decision.reply, targetSession);
+        return { applied, reason: applied ? 'move_to_spot' : 'invalid_spot' };
+    }
+    if (action === 'buff_target') {
+        return applyBuffTarget(session, bot, decision, targetSession);
+    }
+    if (action === 'heal_target') {
+        return applyHealTarget(session, bot, decision, targetSession);
+    }
+
+    return { applied: false, reason: `unknown_action:${action}` };
+}
+
+function remember(session, decision, result, model) {
+    if (!result?.applied) return;
+    session.lastBrainDecision = {
+        action: decision.action,
+        reason: decision.reason || result.reason,
+        appliedReason: result.reason,
+        at: Date.now(),
+        model,
+        usage: decision.usage ? {
+            promptTokens: decision.usage.prompt_tokens,
+            completionTokens: decision.usage.completion_tokens,
+            cost: decision.usage.cost
+        } : null
+    };
+}
+
+function toolDescriptions() {
+    return [
+        { action: 'none', description: 'Do nothing when no useful response is needed.' },
+        { action: 'say', description: 'Send a short in-character reply to the target visible player.' },
+        { action: 'follow_player', description: 'Approach a visible player. Real party follow still requires an invite.' },
+        { action: 'stay_here', description: 'Hold the current position.' },
+        { action: 'hunt', description: 'Return to independent hunting.' },
+        { action: 'rest', description: 'Sit and recover.' },
+        { action: 'shop', description: 'Go to town for normal restock behavior.' },
+        { action: 'move_to_spot', description: 'Move to one of the provided candidate spot ids.' },
+        { action: 'buff_target', description: 'Apply a supported buff to a visible player if class, MP, and range allow it.' },
+        { action: 'heal_target', description: 'Heal a visible player if class, MP, and range allow it.' }
+    ];
+}
+
+module.exports = {
+    ACTIONS,
+    execute,
+    remember,
+    toolDescriptions
+};

--- a/src/GameServer/Bot/AI/BotBrain.js
+++ b/src/GameServer/Bot/AI/BotBrain.js
@@ -1,5 +1,6 @@
-const ServerResponse = invoke('GameServer/Network/Response');
 const SpotService    = invoke('GameServer/Bot/AI/SpotService');
+const BotBrainContext = invoke('GameServer/Bot/AI/BotBrainContext');
+const BotAgentTools = invoke('GameServer/Bot/AI/BotAgentTools');
 
 const ALLOWED_PLANS = ['hunting', 'following', 'resting', 'shopping', 'pk_hunting', 'merchant'];
 const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
@@ -94,43 +95,6 @@ function visibleRealPlayers(session, bot, cfg = config()) {
     return visible;
 }
 
-function compactStatus(status) {
-    if (!status || !status.available) return status;
-    return {
-        name: status.name,
-        level: status.level,
-        classId: status.classId,
-        mode: status.mode,
-        intent: status.intent,
-        role: status.role,
-        vitals: {
-            hpPct: Math.round(status.vitals.hpPct * 100),
-            mpPct: Math.round(status.vitals.mpPct * 100)
-        },
-        target: status.target ? {
-            type: status.target.type,
-            name: status.target.name || null,
-            level: status.target.level || null,
-            dead: status.target.dead,
-            distance: status.target.distance ? Math.round(status.target.distance) : null
-        } : null,
-        party: status.party ? {
-            leader: status.party.leader?.name || null,
-            stance: status.party.stance,
-            role: status.party.role
-        } : null,
-        nearby: status.nearby,
-        blockers: status.blockers,
-        spot: status.spot ? {
-            id: status.spot.id,
-            name: status.spot.name,
-            minLevel: status.spot.minLevel,
-            maxLevel: status.spot.maxLevel,
-            density: status.spot.density
-        } : null
-    };
-}
-
 function candidateSpots(status) {
     if (!status || !status.available || status.mode !== 'hunting') return [];
 
@@ -158,7 +122,7 @@ function schema() {
         properties: {
             action: {
                 type: 'string',
-                enum: ['none', 'say', 'follow_player', 'stay_here', 'hunt', 'rest', 'shop', 'move_to_spot']
+                enum: BotAgentTools.ACTIONS
             },
             reply: {
                 type: 'string',
@@ -172,6 +136,11 @@ function schema() {
                 type: 'string',
                 description: 'Candidate spot id for move_to_spot, or empty string.'
             },
+            buffType: {
+                type: 'string',
+                enum: ['', 'might', 'shield', 'haste', 'windwalk'],
+                description: 'Buff type for buff_target, or empty string.'
+            },
             reason: {
                 type: 'string',
                 description: 'Short private reason for logs/status.'
@@ -182,7 +151,7 @@ function schema() {
                 maximum: 1
             }
         },
-        required: ['action', 'reply', 'targetPlayerName', 'spotId', 'reason', 'confidence'],
+        required: ['action', 'reply', 'targetPlayerName', 'spotId', 'buffType', 'reason', 'confidence'],
         additionalProperties: false
     };
 }
@@ -195,6 +164,8 @@ function systemPrompt() {
         'React only when a real visible player writes to this bot or nearby bots.',
         'For player_chat, react only if the message is addressed to this bot, nearby bots, or clearly asks for help.',
         'follow_player only means approach a visible player unless the bot is already an invited party companion.',
+        'For buff_target and heal_target, choose a visible player and let the server validate class, MP, range, and safety.',
+        'Do not offer trading, selling, price negotiation, or private stores; those tools are intentionally unavailable for now.',
         'Never invent unavailable actions, players, items, or spells.'
     ].join(' ');
 }
@@ -203,10 +174,11 @@ function userPayload(event, session, status, visiblePlayers, text) {
     return {
         event,
         playerMessage: text || '',
-        bot: compactStatus(status),
+        bot: BotBrainContext.compactStatus(session, status, text),
         visiblePlayers,
         candidateSpots: candidateSpots(status),
-        allowedActions: ['none', 'say', 'follow_player', 'stay_here', 'hunt', 'rest', 'shop', 'move_to_spot'],
+        allowedActions: BotAgentTools.ACTIONS,
+        tools: BotAgentTools.toolDescriptions(),
         constraints: {
             keepReplyShort: true,
             avoidSpam: true,
@@ -290,183 +262,10 @@ async function requestDecision(payload, cfg) {
     }
 }
 
-function findVisiblePlayerByName(name, visiblePlayers) {
-    if (!name) return null;
-
-    const lookup = String(name).toLowerCase();
-    const visible = visiblePlayers.find((player) => player.name.toLowerCase() === lookup);
-    if (!visible) return null;
-
-    const World = invoke('GameServer/World/World');
-    return World.user.sessions.find((session) =>
-        isRealPlayer(session) &&
-        session.actor.fetchId() === visible.id
-    ) || null;
-}
-
-function responseTargetSession(decision, visiblePlayers) {
-    return findVisiblePlayerByName(decision?.targetPlayerName, visiblePlayers) ||
-        findVisiblePlayerByName(visiblePlayers[0]?.name, visiblePlayers);
-}
-
-function say(session, text, targetSession = null) {
-    const clean = String(text || '').trim().slice(0, 120);
-    if (!clean) return;
-    const BotAI = invoke('GameServer/Bot/BotAI');
-    if (targetSession) {
-        BotAI.tell(session, targetSession, clean);
-    } else {
-        BotAI.say(session, clean);
-    }
-}
-
-function sit(session, bot) {
-    if (bot.state.fetchSeated()) return;
-    bot.state.setSeated(true);
-    session.dataSendToOthers(ServerResponse.sitAndStand(bot), bot);
-}
-
-function stand(session, bot) {
-    if (!bot.state.fetchSeated()) return;
-    bot.state.setSeated(false);
-    session.dataSendToOthers(ServerResponse.sitAndStand(bot), bot);
-}
-
-function applyMoveToSpot(session, bot, spotId) {
-    const spot = SpotService.findById(spotId);
-    if (!spot) return false;
-
-    const assignedSpot = SpotService.assignSpot(session, spot);
-    const targetLoc = SpotService.randomPointNear(spot);
-    session.initialSpawnCoord = { ...assignedSpot.center };
-    session.lastSpotMoveAt = Date.now();
-    session.noTargetTicks = 0;
-
-    bot.moveTo({
-        from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
-        to: targetLoc
-    });
-
-    return true;
-}
-
-function startShopping(session, bot) {
-    const BotAI = invoke('GameServer/Bot/BotAI');
-    const closestTown = BotAI.getClosestTown(bot.fetchLocX(), bot.fetchLocY());
-    session.preShopLocation = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
-    session.plan = 'shopping';
-    session.shopTimer = Date.now();
-    session.shoppingTarget = undefined;
-    bot.moveTo({
-        from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
-        to: { locX: closestTown.x, locY: closestTown.y, locZ: closestTown.z }
-    });
-}
-
-function isPartyCompanionOf(session, targetSession) {
-    return session.partyCompanion === true && session.followPlayerSession === targetSession;
-}
-
-function approachPlayer(session, bot, targetSession) {
-    const player = targetSession?.actor;
-    if (!player) return false;
-
-    const dx = player.fetchLocX() - bot.fetchLocX();
-    const dy = player.fetchLocY() - bot.fetchLocY();
-    const dist = Math.sqrt(dx * dx + dy * dy);
-    if (dist <= 350) return true;
-
-    bot.moveTo({
-        from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
-        to: {
-            locX: player.fetchLocX() + utils.oneFromSpan(-80, 80),
-            locY: player.fetchLocY() + utils.oneFromSpan(-80, 80),
-            locZ: player.fetchLocZ()
-        }
-    });
-
-    return true;
-}
-
 function applyDecision(session, decision, visiblePlayers) {
-    const bot = session.actor;
-    if (!bot || !decision || decision.confidence < 0.45) return false;
-
-    const action = decision.action;
-    const targetSession = responseTargetSession(decision, visiblePlayers);
-    let applied = false;
-
-    if (action === 'none') {
-        applied = true;
-    } else if (action === 'say') {
-        say(session, decision.reply, targetSession);
-        applied = true;
-    } else if (action === 'follow_player') {
-        if (targetSession) {
-            stand(session, bot);
-            if (isPartyCompanionOf(session, targetSession)) {
-                session.plan = 'following';
-                session.botStay = false;
-                say(session, decision.reply || `Following you, ${targetSession.actor.fetchName()}!`, targetSession);
-            } else {
-                approachPlayer(session, bot, targetSession);
-                say(session, decision.reply || `Coming closer. Invite me if you want party follow.`, targetSession);
-            }
-            applied = true;
-        }
-    } else if (action === 'stay_here') {
-        session.botStay = true;
-        session.stayLocation = {
-            locX: bot.fetchLocX(),
-            locY: bot.fetchLocY(),
-            locZ: bot.fetchLocZ()
-        };
-        if (session.followPlayerSession && session.partyCompanion === true) {
-            session.plan = 'following';
-        }
-        say(session, decision.reply || 'Holding this position.', targetSession);
-        applied = true;
-    } else if (action === 'hunt') {
-        stand(session, bot);
-        session.plan = 'hunting';
-        session.followPlayerSession = null;
-        session.partyCompanion = false;
-        session.botStay = false;
-        say(session, decision.reply, targetSession);
-        applied = true;
-    } else if (action === 'rest') {
-        session.plan = 'resting';
-        session.currentTargetId = undefined;
-        bot.unselect();
-        sit(session, bot);
-        say(session, decision.reply, targetSession);
-        applied = true;
-    } else if (action === 'shop') {
-        startShopping(session, bot);
-        say(session, decision.reply, targetSession);
-        applied = true;
-    } else if (action === 'move_to_spot') {
-        if (applyMoveToSpot(session, bot, decision.spotId)) {
-            say(session, decision.reply, targetSession);
-            applied = true;
-        }
-    }
-
-    if (applied) {
-        session.lastBrainDecision = {
-            action: decision.action,
-            reason: decision.reason,
-            at: Date.now(),
-            model: config().model,
-            usage: decision.usage ? {
-                promptTokens: decision.usage.prompt_tokens,
-                completionTokens: decision.usage.completion_tokens,
-                cost: decision.usage.cost
-            } : null
-        };
-    }
-
-    return applied;
+    const result = BotAgentTools.execute(session, decision, visiblePlayers);
+    BotAgentTools.remember(session, decision, result, config().model);
+    return result.applied;
 }
 
 const BotBrain = {

--- a/src/GameServer/Bot/AI/BotBrainContext.js
+++ b/src/GameServer/Bot/AI/BotBrainContext.js
@@ -1,0 +1,258 @@
+const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
+const ShotStock = invoke('GameServer/Inventory/ShotStock');
+
+const SLOT_NAMES = {
+    1: 'right_ear',
+    2: 'left_ear',
+    3: 'neck',
+    4: 'right_finger',
+    5: 'left_finger',
+    6: 'head',
+    7: 'weapon',
+    8: 'shield',
+    9: 'hands',
+    10: 'chest',
+    11: 'pants',
+    12: 'feet',
+    14: 'dual',
+    15: 'armor'
+};
+
+function pct(value) {
+    return Math.round((Number(value) || 0) * 100);
+}
+
+function safeNumber(read, fallback = 0) {
+    try {
+        const value = read();
+        return Number.isFinite(Number(value)) ? Number(value) : fallback;
+    } catch (_) {
+        return fallback;
+    }
+}
+
+function compactTarget(target) {
+    if (!target) return null;
+    return {
+        type: target.type,
+        name: target.name || null,
+        level: target.level || null,
+        dead: target.dead,
+        distance: target.distance ? Math.round(target.distance) : null
+    };
+}
+
+function compactParty(party) {
+    if (!party) return null;
+    return {
+        leader: party.leader?.name || null,
+        stance: party.stance,
+        role: party.role
+    };
+}
+
+function compactSpot(spot) {
+    if (!spot) return null;
+    return {
+        id: spot.id,
+        name: spot.name,
+        minLevel: spot.minLevel,
+        maxLevel: spot.maxLevel,
+        density: spot.density
+    };
+}
+
+function buffSnapshot(actor, status) {
+    const snapshot = status?.buffs || BotBuffs.snapshot(actor);
+    const active = Object.entries(BotBuffs.ALL_BUFFS)
+        .map(([type, buff]) => ({
+            type,
+            key: buff.key,
+            name: buff.name,
+            remainingSec: Number(snapshot[buff.key] || 0)
+        }))
+        .filter((buff) => buff.remainingSec > 0);
+
+    return {
+        eligible: !!snapshot.eligible,
+        needsRefresh: !!snapshot.needsRefresh,
+        needsSupportRefresh: !!snapshot.needsSupportRefresh,
+        active,
+        missingNewbie: actor ? BotBuffs.missingNewbieBuffs(actor, BotBuffs.REFRESH_THRESHOLD_MS) : []
+    };
+}
+
+function itemSummary(item, detailed = false) {
+    if (!item) return null;
+
+    const summary = {
+        objectId: item.fetchId(),
+        selfId: item.fetchSelfId(),
+        name: item.fetchName(),
+        kind: item.fetchKind(),
+        amount: item.fetchAmount(),
+        equipped: !!(item.fetchEquipped && item.fetchEquipped()),
+        slot: item.fetchSlot ? SLOT_NAMES[item.fetchSlot()] || item.fetchSlot() : 0,
+        stackable: !!(item.fetchStackable && item.fetchStackable()),
+        consumable: !!(item.fetchConsumable && item.fetchConsumable())
+    };
+
+    if (item.fetchRank) {
+        summary.rank = item.fetchRank();
+    }
+
+    if (detailed || summary.equipped) {
+        if (item.isWeapon && item.isWeapon()) {
+            summary.stats = {
+                pAtk: item.fetchPAtk(),
+                pAtkRnd: item.fetchPAtkRnd(),
+                mAtk: item.fetchMAtk(),
+                atkSpd: item.fetchAtkSpd(),
+                critical: item.fetchCritical(),
+                accuracy: item.fetchAccur(),
+                soulshotCost: item.fetchSoulshot(),
+                spiritshotCost: item.fetchSpiritshot()
+            };
+        } else if (item.isArmor && item.isArmor()) {
+            summary.stats = {
+                pDef: item.fetchPDef(),
+                mDef: item.fetchMDef(),
+                evasion: item.fetchEvasion(),
+                bonusMp: item.fetchBonusMp()
+            };
+        }
+    }
+
+    return summary;
+}
+
+function equipmentSnapshot(actor) {
+    const backpack = actor?.backpack;
+    if (!backpack) return null;
+
+    const equipped = backpack.fetchItems()
+        .filter((item) => item.fetchEquipped && item.fetchEquipped())
+        .map((item) => itemSummary(item, true));
+
+    return {
+        weapon: itemSummary(backpack.fetchEquippedWeapon?.(), true),
+        equipped,
+        totals: {
+            pAtk: safeNumber(() => backpack.fetchTotalWeaponPAtk?.(), safeNumber(() => actor.fetchPAtk?.())),
+            mAtk: safeNumber(() => backpack.fetchTotalWeaponMAtk?.(), safeNumber(() => actor.fetchMAtk?.())),
+            pDef: safeNumber(() => backpack.fetchTotalArmorPDef?.(actor.isSpellcaster?.()), safeNumber(() => actor.fetchPDef?.())),
+            mDef: safeNumber(() => backpack.fetchTotalArmorMDef?.(), safeNumber(() => actor.fetchMDef?.())),
+            load: safeNumber(() => backpack.fetchTotalLoad?.())
+        }
+    };
+}
+
+function inventorySnapshot(actor, text = '') {
+    const backpack = actor?.backpack;
+    if (!backpack) return null;
+
+    const items = backpack.fetchItems();
+    const lower = String(text || '').toLowerCase();
+    const wantsItems = /\b(item|items|inventory|gear|weapon|armor|adena|shot|trade|loot|give|sell|buy)\b/.test(lower) ||
+        /(инвент|вещ|шмот|оруж|брон|аден|сос|трейд|лут|дай|прод)/.test(lower);
+    const shotPlan = ShotStock.planForActor(actor);
+    const shotItem = backpack.fetchItemFromSelfId(shotPlan.selfId);
+
+    const notable = items
+        .filter((item) =>
+            (item.fetchEquipped && item.fetchEquipped()) ||
+            (item.fetchConsumable && item.fetchConsumable()) ||
+            item.fetchSelfId() === shotPlan.selfId ||
+            item.fetchSelfId() === 57
+        )
+        .slice(0, wantsItems ? 24 : 12)
+        .map((item) => itemSummary(item, wantsItems));
+
+    return {
+        adena: safeNumber(() => backpack.fetchTotalAdena()),
+        totalItems: items.length,
+        totalLoad: safeNumber(() => backpack.fetchTotalLoad()),
+        shots: {
+            kind: shotPlan.kind,
+            rank: shotPlan.rank,
+            selfId: shotPlan.selfId,
+            name: shotPlan.name,
+            amount: Number(shotItem?.fetchAmount?.() || 0),
+            loaded: shotPlan.kind === 'spiritshot' ? !!actor.spiritshotLoaded : !!actor.soulshotLoaded
+        },
+        notable,
+        truncated: notable.length < items.length
+    };
+}
+
+function skillSummary(skill) {
+    if (!skill) return null;
+    return {
+        selfId: skill.fetchSelfId(),
+        name: skill.model?.name || '',
+        level: skill.fetchLevel(),
+        passive: !!skill.fetchPassive(),
+        mpCost: skill.fetchConsumedMp() || 0,
+        hpCost: skill.fetchConsumedHp() || 0,
+        range: skill.fetchDistance() || 0,
+        hitTime: skill.fetchHitTime() || 0,
+        reuseMs: skill.fetchReuseTime() || 0,
+        power: skill.fetchPower() || 0
+    };
+}
+
+function skillsSnapshot(actor, text = '') {
+    const skills = actor?.skillset?.fetchSkills ? actor.skillset.fetchSkills() : [];
+    const lower = String(text || '').toLowerCase();
+    const wantsSkills = /\b(skill|skills|heal|buff|haste|shield|might|wind walk|windwalk|spoil|sweep)\b/.test(lower) ||
+        /(скилл|хил|баф|хаст|щит|майт|винд|спойл|свип)/.test(lower);
+    const active = skills
+        .filter((skill) => !skill.fetchPassive())
+        .slice(0, wantsSkills ? 24 : 12)
+        .map(skillSummary);
+
+    return {
+        active,
+        passiveCount: skills.filter((skill) => skill.fetchPassive()).length,
+        support: {
+            canHeal: BotRoles.isHealer(actor),
+            canBuff: BotRoles.canBuff(actor),
+            availableBuffs: Object.keys(BotBuffs.SUPPORT_BUFFS)
+        },
+        truncated: active.length < skills.filter((skill) => !skill.fetchPassive()).length
+    };
+}
+
+function compactStatus(session, status, text = '') {
+    if (!status || !status.available) return status;
+
+    const actor = session?.actor;
+    return {
+        name: status.name,
+        level: status.level,
+        classId: status.classId,
+        mode: status.mode,
+        intent: status.intent,
+        role: status.role,
+        vitals: {
+            hpPct: pct(status.vitals.hpPct),
+            mpPct: pct(status.vitals.mpPct)
+        },
+        target: compactTarget(status.target),
+        party: compactParty(status.party),
+        nearby: status.nearby,
+        blockers: status.blockers,
+        spot: compactSpot(status.spot),
+        buffs: buffSnapshot(actor, status),
+        equipment: equipmentSnapshot(actor),
+        inventory: inventorySnapshot(actor, text),
+        skills: skillsSnapshot(actor, text),
+        roleDecision: status.roleDecision || null,
+        social: status.social || null
+    };
+}
+
+module.exports = {
+    compactStatus
+};


### PR DESCRIPTION
## Summary
- Add an LLM-safe bot brain context with compact buffs, equipment, inventory, and skill snapshots.
- Move bot brain action execution into a bounded tool executor with server-side validation.
- Add initial chat-driven support actions for buffing and healing while explicitly keeping trading out of scope.

## Validation
- `git diff --check`
- `node -c` on the touched bot AI modules
- `node tests/test_town_pathfinder.js`
- `node tests/test_path_obstacle.js`
- `node tests/test_pathfinder_astar.js`
- `node tests/test_bot_gear.js`
- `node tests/test_bot_ai_visibility.js`