### PR TITLE
Polish party companion behavior

### DIFF
--- a/src/GameServer/Bot/AI/BotAgentTools.js
+++ b/src/GameServer/Bot/AI/BotAgentTools.js
@@ -94,6 +94,10 @@ function applyMoveToSpot(session, bot, spotId) {
 }
 
 function startShopping(session, bot) {
+    if (session.partyCompanion === true && session.followPlayerSession) {
+        return false;
+    }
+
     const BotAI = invoke('GameServer/Bot/BotAI');
     const closestTown = BotAI.getClosestTown(bot.fetchLocX(), bot.fetchLocY());
     session.preShopLocation = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
@@ -104,6 +108,8 @@ function startShopping(session, bot) {
         from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
         to: { locX: closestTown.x, locY: closestTown.y, locZ: closestTown.z }
     });
+
+    return true;
 }
 
 function isPartyCompanionOf(session, targetSession) {
@@ -240,8 +246,11 @@ function execute(session, decision, visiblePlayers) {
         return { applied: true, reason: 'rest' };
     }
     if (action === 'shop') {
-        startShopping(session, bot);
-        say(session, decision.reply, targetSession);
+        if (startShopping(session, bot)) {
+            say(session, decision.reply, targetSession);
+        } else {
+            say(session, decision.reply || 'I will stay with the party and sell later.', targetSession);
+        }
         return { applied: true, reason: 'shop' };
     }
     if (action === 'move_to_spot') {

--- a/src/GameServer/Bot/AI/BotEquipmentUpgrade.js
+++ b/src/GameServer/Bot/AI/BotEquipmentUpgrade.js
@@ -1,0 +1,251 @@
+const ServerResponse = invoke('GameServer/Network/Response');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
+
+const ARMOR_SLOTS = {
+    earringRight: 1,
+    earringLeft: 2,
+    necklace: 3,
+    ringRight: 4,
+    ringLeft: 5,
+    head: 6,
+    weapon: 7,
+    shield: 8,
+    hands: 9,
+    chest: 10,
+    pants: 11,
+    feet: 12,
+    dual: 14,
+    fullArmor: 15
+};
+
+const RANK_ORDER = ['none', 'd', 'c', 'b', 'a', 's'];
+const UPGRADE_COOLDOWN_MS = 5000;
+
+function isBotSession(session) {
+    return !!session && (
+        session.constructor.name === 'BotSession' ||
+        String(session.accountId || '').startsWith('bot_')
+    );
+}
+
+function gradeForLevel(level) {
+    const value = Number(level || 1);
+    if (value >= 76) return 's';
+    if (value >= 61) return 'a';
+    if (value >= 52) return 'b';
+    if (value >= 40) return 'c';
+    if (value >= 20) return 'd';
+    return 'none';
+}
+
+function rankAllowed(item, actor) {
+    const itemRank = item.fetchRank ? item.fetchRank() : 'none';
+    const itemIndex = RANK_ORDER.indexOf(itemRank);
+    const actorIndex = RANK_ORDER.indexOf(gradeForLevel(actor.fetchLevel()));
+    if (itemIndex < 0 || actorIndex < 0) return false;
+    return itemIndex <= actorIndex;
+}
+
+function armorStyleFor(role) {
+    if (role === 'mage' || role === 'healer' || role === 'buffer') return 'robe';
+    if (role === 'archer' || role === 'dagger') return 'light';
+    return 'heavy';
+}
+
+function weaponKindsFor(role, classId) {
+    if (role === 'archer') return ['Weapon.Bow'];
+    if (role === 'dagger') return ['Weapon.Knife'];
+    if (role === 'mage' || role === 'healer' || role === 'buffer') {
+        return ['Weapon.Sword', 'Weapon.Blunt'];
+    }
+    if ([44, 45, 47, 49, 50, 51, 53, 54, 56].includes(Number(classId))) {
+        return ['Weapon.Blunt'];
+    }
+    return ['Weapon.Sword', 'Weapon.Blunt'];
+}
+
+function armorKindsFor(role, slot) {
+    const style = armorStyleFor(role);
+    if ([ARMOR_SLOTS.chest, ARMOR_SLOTS.pants, ARMOR_SLOTS.fullArmor].includes(Number(slot))) {
+        if (style === 'robe') return ['Armor.Fabric'];
+        if (style === 'light') return ['Armor.Leather'];
+        return ['Armor.Chain'];
+    }
+    if ([ARMOR_SLOTS.head, ARMOR_SLOTS.hands, ARMOR_SLOTS.feet].includes(Number(slot))) {
+        return ['Armor.Wear'];
+    }
+    if ([ARMOR_SLOTS.earringRight, ARMOR_SLOTS.earringLeft, ARMOR_SLOTS.necklace, ARMOR_SLOTS.ringRight, ARMOR_SLOTS.ringLeft].includes(Number(slot))) {
+        return ['Armor.Jewel'];
+    }
+    if (Number(slot) === ARMOR_SLOTS.shield) return ['Armor.Shield'];
+    return [];
+}
+
+function isSuitableItem(actor, item) {
+    if (!item?.isWearable?.() || item.fetchEquipped?.()) return false;
+    if (!rankAllowed(item, actor)) return false;
+    if (item.fetchPrice?.() <= 0) return false;
+
+    const role = BotRoles.inferRole(actor);
+    const kind = item.fetchKind();
+    const slot = Number(item.fetchSlot());
+
+    if (item.isWeapon()) {
+        const kinds = weaponKindsFor(role, actor.fetchClassId());
+        if (!kinds.includes(kind)) return false;
+        if (!['mage', 'healer', 'buffer', 'archer'].includes(role) && slot !== ARMOR_SLOTS.weapon) return false;
+        return true;
+    }
+
+    if (item.isArmor()) {
+        if (slot === ARMOR_SLOTS.shield && ['mage', 'healer', 'buffer', 'archer', 'dagger'].includes(role)) return false;
+        return armorKindsFor(role, slot).includes(kind);
+    }
+
+    return false;
+}
+
+function scoreItem(actor, item) {
+    const role = BotRoles.inferRole(actor);
+    const kind = item.fetchKind();
+    const slot = Number(item.fetchSlot());
+
+    if (item.isWeapon()) {
+        if (role === 'mage' || role === 'healer' || role === 'buffer') {
+            return item.fetchMAtk() * 3 + item.fetchPAtk();
+        }
+        return item.fetchPAtk() * 2 + item.fetchMAtk();
+    }
+
+    if (kind === 'Armor.Jewel') return item.fetchMDef();
+    if (slot === ARMOR_SLOTS.shield) return item.fetchPDef();
+    return item.fetchPDef() + item.fetchBonusMp();
+}
+
+function currentItemForSlot(backpack, slot) {
+    if (!backpack) return null;
+    if (slot === ARMOR_SLOTS.weapon || slot === ARMOR_SLOTS.dual) {
+        return backpack.fetchEquippedWeapon ? backpack.fetchEquippedWeapon() : null;
+    }
+    return backpack.fetchItemRaw(backpack.fetchPaperdollId(slot));
+}
+
+function currentScoreForSlot(actor, slot) {
+    const backpack = actor.backpack;
+    if (!backpack) return 0;
+
+    if (slot === ARMOR_SLOTS.fullArmor) {
+        const full = currentItemForSlot(backpack, ARMOR_SLOTS.fullArmor);
+        if (full) return scoreItem(actor, full);
+        const chest = currentItemForSlot(backpack, ARMOR_SLOTS.chest);
+        const pants = currentItemForSlot(backpack, ARMOR_SLOTS.pants);
+        return (chest ? scoreItem(actor, chest) : 0) + (pants ? scoreItem(actor, pants) : 0);
+    }
+
+    const current = currentItemForSlot(backpack, slot);
+    return current ? scoreItem(actor, current) : 0;
+}
+
+function candidateSlots(item) {
+    const slot = Number(item.fetchSlot());
+    if (slot === ARMOR_SLOTS.earringRight || slot === ARMOR_SLOTS.earringLeft) {
+        return [ARMOR_SLOTS.earringRight, ARMOR_SLOTS.earringLeft];
+    }
+    if (slot === ARMOR_SLOTS.ringRight || slot === ARMOR_SLOTS.ringLeft) {
+        return [ARMOR_SLOTS.ringRight, ARMOR_SLOTS.ringLeft];
+    }
+    return [slot];
+}
+
+function bestUpgradeSlot(actor, item, plannedScores) {
+    const itemScore = scoreItem(actor, item);
+    if (itemScore <= 0) return null;
+
+    return candidateSlots(item).reduce((best, slot) => {
+        const currentScore = plannedScores.get(slot) ?? currentScoreForSlot(actor, slot);
+        if (itemScore <= currentScore) return best;
+        if (!best) return { slot, currentScore };
+        return currentScore < best.currentScore ? { slot, currentScore } : best;
+    }, null)?.slot || null;
+}
+
+function findBestUpgrades(session) {
+    const actor = session?.actor;
+    const items = actor?.backpack?.fetchItems ? actor.backpack.fetchItems() : [];
+    const plannedScores = new Map();
+    const usedIds = new Set();
+
+    return items
+        .filter((item) => isSuitableItem(actor, item))
+        .sort((a, b) => scoreItem(actor, b) - scoreItem(actor, a) || b.fetchPrice() - a.fetchPrice())
+        .reduce((upgrades, item) => {
+            if (usedIds.has(item.fetchId())) return upgrades;
+
+            const slot = bestUpgradeSlot(actor, item, plannedScores);
+            if (!slot) return upgrades;
+
+            const itemScore = scoreItem(actor, item);
+            usedIds.add(item.fetchId());
+            plannedScores.set(slot, itemScore);
+
+            if (slot === ARMOR_SLOTS.fullArmor) {
+                plannedScores.set(ARMOR_SLOTS.chest, itemScore);
+                plannedScores.set(ARMOR_SLOTS.pants, itemScore);
+            }
+
+            upgrades.push({ item, slot, score: itemScore });
+            return upgrades;
+        }, []);
+}
+
+function canApplyNow(session, options = {}) {
+    if (!options.force && !isBotSession(session)) return false;
+    const actor = session?.actor;
+    if (!actor?.backpack || actor.isDead?.()) return false;
+    if (actor.state?.fetchHits?.() || actor.state?.fetchCasts?.() || actor.state?.fetchTowards?.()) return false;
+    if (!options.force && session.lastEquipmentUpgradeCheckAt && Date.now() - session.lastEquipmentUpgradeCheckAt < UPGRADE_COOLDOWN_MS) return false;
+    return true;
+}
+
+function applyBestUpgrades(session, options = {}) {
+    if (!canApplyNow(session, options)) return [];
+
+    const actor = session.actor;
+    session.lastEquipmentUpgradeCheckAt = Date.now();
+    const upgrades = findBestUpgrades(session);
+    if (upgrades.length === 0) return [];
+
+    upgrades.forEach(({ item, slot }) => {
+        if (Number(item.fetchSlot()) !== Number(slot)) {
+            item.setSlot(slot);
+        }
+        if ([ARMOR_SLOTS.earringRight, ARMOR_SLOTS.ringRight].includes(Number(slot)) && actor.backpack.fetchPaperdollId(slot)) {
+            actor.backpack.unequipGear(session, slot);
+            item.setSlot(slot);
+        }
+        actor.backpack.equipGear(session, item);
+    });
+
+    session.lastEquipmentUpgradeAt = Date.now();
+
+    if (session.dataSendToOthers) {
+        session.dataSendToOthers(ServerResponse.charInfo(actor), actor);
+    }
+    if (session.dataSendToMe) {
+        session.dataSendToMe(ServerResponse.itemsList(actor.backpack.fetchItems()));
+    }
+
+    console.info(
+        "BotGear :: %s equipped upgrades: %s",
+        actor.fetchName(),
+        upgrades.map(({ item }) => item.fetchName()).join(', ')
+    );
+
+    return upgrades;
+}
+
+module.exports = {
+    applyBestUpgrades,
+    findBestUpgrades,
+    scoreItem
+};

--- a/src/GameServer/Bot/AI/PartyAwareness.js
+++ b/src/GameServer/Bot/AI/PartyAwareness.js
@@ -1,0 +1,113 @@
+const World = invoke('GameServer/World/World');
+
+function isOnlineActor(actor) {
+    return !!actor && actor.fetchIsOnline && actor.fetchIsOnline() && !actor.state?.fetchDead?.();
+}
+
+function isPartySession(session, leaderSession) {
+    return session === leaderSession || (
+        session &&
+        session.followPlayerSession === leaderSession &&
+        session.partyCompanion === true
+    );
+}
+
+function partySessions(leaderSession) {
+    if (!leaderSession) return [];
+
+    return World.user.sessions.filter((session) => (
+        session &&
+        isPartySession(session, leaderSession) &&
+        isOnlineActor(session.actor)
+    ));
+}
+
+function partyActors(leaderSession) {
+    return partySessions(leaderSession).map((session) => session.actor);
+}
+
+function actorId(actor) {
+    return actor && typeof actor.fetchId === 'function' ? actor.fetchId() : null;
+}
+
+function actorLoc(actor) {
+    return {
+        locX: actor.fetchLocX(),
+        locY: actor.fetchLocY()
+    };
+}
+
+function distance2d(a, b) {
+    const dx = Number(a.locX || 0) - Number(b.locX || 0);
+    const dy = Number(a.locY || 0) - Number(b.locY || 0);
+    return Math.sqrt((dx * dx) + (dy * dy));
+}
+
+function uniqueNpcsAround(actors, radius) {
+    const seen = new Set();
+    const npcs = [];
+
+    actors.forEach((actor) => {
+        World.fetchNpcsInRadius(actor.fetchLocX(), actor.fetchLocY(), radius).forEach((npc) => {
+            const id = actorId(npc);
+            if (seen.has(id)) return;
+            seen.add(id);
+            npcs.push(npc);
+        });
+    });
+
+    return npcs;
+}
+
+function findThreatTargetingParty(leaderSession, options = {}) {
+    const members = partyActors(leaderSession);
+    if (members.length === 0) return null;
+
+    const memberIds = new Set(members.map(actorId).filter((id) => id !== null));
+    const npcRadius = options.npcRadius || 1400;
+    const playerRadius = options.playerRadius || 1800;
+
+    const npcThreat = uniqueNpcsAround(members, npcRadius).find((npc) => (
+        npc.fetchAttackable &&
+        npc.fetchAttackable() &&
+        !npc.isDead() &&
+        memberIds.has(npc.fetchDestId && npc.fetchDestId())
+    ));
+    if (npcThreat) {
+        return {
+            type: 'npc',
+            actor: npcThreat,
+            targetId: npcThreat.fetchDestId()
+        };
+    }
+
+    const playerThreatSession = World.user.sessions.find((session) => {
+        const actor = session?.actor;
+        const id = actorId(actor);
+        if (!isOnlineActor(actor) || memberIds.has(id)) return false;
+        if (!memberIds.has(actor.fetchDestId && actor.fetchDestId())) return false;
+
+        const isAttackable = actor.fetchKarma?.() > 0 || actor.fetchPvpFlag?.() > 0;
+        if (!isAttackable) return false;
+
+        const actorPoint = actorLoc(actor);
+        return members.some((member) => distance2d(actorPoint, actorLoc(member)) <= playerRadius);
+    });
+
+    if (playerThreatSession?.actor) {
+        return {
+            type: 'player',
+            actor: playerThreatSession.actor,
+            targetId: playerThreatSession.actor.fetchDestId()
+        };
+    }
+
+    return null;
+}
+
+module.exports = {
+    findThreatTargetingParty,
+    isPartySession,
+    partyActors,
+    partySessions
+};

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -3,8 +3,11 @@ const World          = invoke('GameServer/World/World');
 const ServerResponse = invoke('GameServer/Network/Response');
 const BotRoles       = invoke('GameServer/Bot/AI/BotRoles');
 const BotBuffs       = invoke('GameServer/Bot/AI/BotBuffs');
+const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
 
 const SUPPORT_BUFF_MP_COST = 20;
+const FOLLOW_RUN_DISTANCE = 250;
+const FOLLOW_TELEPORT_DISTANCE = 4500;
 
 function ratio(value, max) {
     if (!max) return 0;
@@ -17,6 +20,13 @@ function isBusy(bot) {
 
 function point(actor) {
     return new SpeckMath.Point3D(actor.fetchLocX(), actor.fetchLocY(), actor.fetchLocZ());
+}
+
+function standUp(session, bot) {
+    if (!bot.state.fetchSeated()) return false;
+    bot.state.setSeated(false);
+    session.dataSendToOthers(ServerResponse.sitAndStand(bot), bot);
+    return true;
 }
 
 function ensureSkill(bot, selfId, data) {
@@ -152,6 +162,7 @@ module.exports = {
         const player = playerSession.actor;
         const role = BotRoles.inferRole(bot);
         const distance = point(bot).distance(point(player));
+        const partyThreat = PartyAwareness.findThreatTargetingParty(playerSession);
 
         const currentLoc = { x: bot.fetchLocX(), y: bot.fetchLocY() };
         if (!session.lastTickLoc) {
@@ -169,9 +180,22 @@ module.exports = {
             session.stuckTicks = 0;
         }
 
-        if (session.stuckTicks >= 3 || distance > 1000) {
+        if (bot.state.fetchSeated() && (partyThreat || distance > FOLLOW_RUN_DISTANCE)) {
+            session.plan = 'following';
+            session.currentTargetId = partyThreat?.actor?.fetchId?.();
+            standUp(session, bot);
+            recordRoleDecision(
+                session,
+                bot,
+                partyThreat ? assistActionForRole(role) : 'follow_leader',
+                partyThreat ? 'party_under_attack' : 'leader_moved'
+            );
+            return;
+        }
+
+        if (session.stuckTicks >= 3 || distance > FOLLOW_TELEPORT_DISTANCE) {
             session.stuckTicks = 0;
-            recordRoleDecision(session, bot, 'follow_leader', distance > 1000 ? 'catch_up' : 'unstuck');
+            recordRoleDecision(session, bot, 'follow_leader', distance > FOLLOW_TELEPORT_DISTANCE ? 'catch_up' : 'unstuck');
             const TeleportTo = invoke('GameServer/Actor/Generics/TeleportTo');
             if (TeleportTo && typeof TeleportTo === 'function') {
                 const targetLoc = {
@@ -196,7 +220,7 @@ module.exports = {
             mpRatio: ratio(player.fetchMp(), player.fetchMaxMp())
         };
 
-        if (botVitals.hpRatio < 0.30 || botVitals.mpRatio < 0.15) {
+        if (!partyThreat && (botVitals.hpRatio < 0.30 || botVitals.mpRatio < 0.15)) {
             session.plan = 'resting';
             session.currentTargetId = undefined;
             bot.unselect();
@@ -406,9 +430,37 @@ module.exports = {
             }
         }
 
+        if (!acted && partyThreat?.actor) {
+            const target = partyThreat.actor;
+            const targetId = target.fetchId();
+
+            if (session.currentTargetId !== targetId) {
+                session.currentTargetId = targetId;
+                bot.select({ id: targetId });
+                recordRoleDecision(session, bot, assistActionForRole(role), 'party_under_attack', {
+                    targetId,
+                    targetType: partyThreat.type,
+                    protectedId: partyThreat.targetId
+                });
+                if (Math.random() < 0.20) {
+                    BotAI.say(session, "I'm helping the party!");
+                }
+            }
+
+            if (!isBusy(bot)) {
+                if (partyThreat.type === 'player') {
+                    BotAI.executePvPCombat(session, bot, target, Generics);
+                } else {
+                    BotAI.executeCombat(session, bot, target, Generics);
+                }
+            }
+            acted = true;
+        }
+
         if (!acted) {
             const playerTargetId = player.fetchDestId();
             if (playerTargetId && playerTargetId !== bot.fetchId() && playerTargetId !== player.fetchId()) {
+                acted = true;
                 World.fetchUser(playerTargetId).then((user) => {
                     const targetIsTeammate = user.session && (
                         user.session === playerSession ||
@@ -498,7 +550,7 @@ module.exports = {
                         to: { locX: session.stayLocation.locX, locY: session.stayLocation.locY, locZ: session.stayLocation.locZ }
                     });
                 }
-            } else if (distance > 250) {
+            } else if (distance > FOLLOW_RUN_DISTANCE) {
                 if (!keepRoleDecision) {
                     recordRoleDecision(session, bot, 'follow_leader', 'keep_range');
                 }

--- a/src/GameServer/Bot/AI/States/HuntingState.js
+++ b/src/GameServer/Bot/AI/States/HuntingState.js
@@ -11,6 +11,10 @@ function isSoloHunter(session) {
     return session.plan === 'hunting' && session.partyCompanion !== true && !session.followPlayerSession;
 }
 
+function isPartyCompanion(session) {
+    return session.partyCompanion === true && !!session.followPlayerSession;
+}
+
 function isClaimedByOtherSoloBot(session, npc) {
     const BotManager = invoke('GameServer/Bot/BotManager');
     const npcId = npc.fetchId();
@@ -23,6 +27,14 @@ function isClaimedByOtherSoloBot(session, npc) {
 }
 
 function startShopping(session, bot, BotAI, reason) {
+    if (isPartyCompanion(session)) {
+        session.plan = 'following';
+        session.shoppingTarget = undefined;
+        session.shoppingDoneAnnounced = false;
+        BotAI.say(session, "Staying with the party. I can sell loot later.");
+        return false;
+    }
+
     const closestTown = BotAI.getClosestTown(bot.fetchLocX(), bot.fetchLocY());
     session.preShopLocation = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
     session.plan = 'shopping';
@@ -33,6 +45,8 @@ function startShopping(session, bot, BotAI, reason) {
         from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
         to: { locX: closestTown.x, locY: closestTown.y, locZ: closestTown.z }
     });
+
+    return true;
 }
 
 function findPreferredMonster(session, bot, radius, options = {}) {
@@ -184,7 +198,7 @@ module.exports = {
             return;
         }
 
-        if (Math.random() < 0.005) { // ~0.5% chance per tick (~10 minutes)
+        if (isSoloHunter(session) && Math.random() < 0.005) { // ~0.5% chance per tick (~10 minutes)
             const closestTown = BotAI.getClosestTown(bot.fetchLocX(), bot.fetchLocY());
             startShopping(session, bot, BotAI, `My bags are full of loot. Walking back to ${closestTown.name} to sell and restock.`);
             return;

--- a/src/GameServer/Bot/AI/States/RestingState.js
+++ b/src/GameServer/Bot/AI/States/RestingState.js
@@ -1,7 +1,63 @@
 const ServerResponse = invoke('GameServer/Network/Response');
+const SpeckMath      = invoke('GameServer/SpeckMath');
+const BotRoles       = invoke('GameServer/Bot/AI/BotRoles');
+const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
+
+const REST_FOLLOW_WAKE_DISTANCE = 600;
+
+function point(actor) {
+    return new SpeckMath.Point3D(actor.fetchLocX(), actor.fetchLocY(), actor.fetchLocZ());
+}
+
+function standUp(session, bot) {
+    if (!bot.state.fetchSeated()) return false;
+    bot.state.setSeated(false);
+    session.dataSendToOthers(ServerResponse.sitAndStand(bot), bot);
+    return true;
+}
+
+function recordWakeDecision(session, bot, action, reason, extra = {}) {
+    session.roleDecision = {
+        role: BotRoles.inferRole(bot),
+        action,
+        reason,
+        at: Date.now(),
+        ...extra
+    };
+}
 
 module.exports = {
     tick(session, bot, Generics, BotAI) {
+        if (session.followPlayerSession && session.partyCompanion === true) {
+            const playerSession = session.followPlayerSession;
+            const player = playerSession?.actor;
+
+            if (!player || !player.fetchIsOnline()) {
+                session.plan = 'hunting';
+                session.roleDecision = null;
+                BotAI.say(session, "My companion has disconnected. Heading back to hunt.");
+                return;
+            }
+
+            const distance = point(bot).distance(point(player));
+            const threat = PartyAwareness.findThreatTargetingParty(playerSession);
+
+            if (threat || distance > REST_FOLLOW_WAKE_DISTANCE) {
+                session.plan = 'following';
+                session.currentTargetId = threat?.actor?.fetchId?.();
+                session.townGossip = false;
+                standUp(session, bot);
+                recordWakeDecision(
+                    session,
+                    bot,
+                    threat ? 'assist_party' : 'follow_leader',
+                    threat ? 'party_under_attack' : 'leader_moved',
+                    threat ? { targetId: session.currentTargetId, protectedId: threat.targetId } : { distance: Math.round(distance) }
+                );
+                return;
+            }
+        }
+
         if (session.townGossip) {
             // 3% chance per tick to attempt conversation when resting near other bots
             if (Math.random() < 0.03) {

--- a/src/GameServer/Bot/AI/States/ShoppingState.js
+++ b/src/GameServer/Bot/AI/States/ShoppingState.js
@@ -9,6 +9,15 @@ function formatAdena(value) {
 
 module.exports = {
     tick(session, bot, Generics, BotAI) {
+        if (session.partyCompanion === true && session.followPlayerSession) {
+            session.plan = 'following';
+            session.shoppingTarget = undefined;
+            session.shoppingDoneAnnounced = false;
+            session.preShopLocation = undefined;
+            BotAI.say(session, "Shopping can wait. Staying with the party.");
+            return;
+        }
+
         const closestTown = BotAI.getClosestTown(bot.fetchLocX(), bot.fetchLocY());
 
         if (!session.shoppingTarget) {
@@ -122,11 +131,13 @@ module.exports = {
 
         setTimeout(() => {
             BotAI.say(session, "All stocked up! Returning to the hunting spot.");
-            session.plan = 'hunting';
+            session.plan = session.partyCompanion === true && session.followPlayerSession ? 'following' : 'hunting';
             session.shoppingDoneAnnounced = false;
             session.shoppingTarget = undefined;
 
-            if (session.preShopLocation) {
+            if (session.partyCompanion === true && session.followPlayerSession) {
+                session.preShopLocation = undefined;
+            } else if (session.preShopLocation) {
                 Generics.teleportTo(session, bot, session.preShopLocation);
                 session.preShopLocation = undefined;
             } else if (session.initialSpawnCoord) {

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -3,6 +3,7 @@ const GeodataEngine  = invoke('GameServer/Geodata/GeodataEngine');
 const BotStatus      = invoke('GameServer/Bot/AI/BotStatus');
 const BotRoles       = invoke('GameServer/Bot/AI/BotRoles');
 const PopulationService = invoke('GameServer/Bot/Population/PopulationService');
+const BotEquipmentUpgrade = invoke('GameServer/Bot/AI/BotEquipmentUpgrade');
 
 const CHAT_PHRASES = {
     foundTarget: [
@@ -355,6 +356,8 @@ const BotAI = {
         if (!session.plan) {
             session.plan = 'hunting';
         }
+
+        BotEquipmentUpgrade.applyBestUpgrades(session);
 
         // 3. Dynamic State Machine Routing
         const state = States[session.plan];

--- a/src/GameServer/Network/Request/Speak.js
+++ b/src/GameServer/Network/Request/Speak.js
@@ -8,7 +8,8 @@ function logPlayerChat(session, data) {
 
     const name = session.actor.fetchName ? session.actor.fetchName() : session.accountId || 'unknown';
     const text = String(data.text || '').replace(/\s+/g, ' ').slice(0, 180);
-    console.info('PlayerChat :: %s kind=%s text="%s"', name, data.kind, text);
+    const target = data.target ? ` target="${String(data.target).slice(0, 40)}"` : '';
+    console.info('PlayerChat :: %s kind=%s%s text="%s"', name, data.kind, target, text);
 }
 
 function speak(session, buffer) {
@@ -18,14 +19,66 @@ function speak(session, buffer) {
         .readS()  // Text
         .readD(); // Kind
 
+    if (packet.data[1] === 2) {
+        packet.readS(); // Target name for private tell
+    }
+
     consume(session, {
         text: packet.data[0],
         kind: packet.data[1],
+        target: packet.data[2],
     });
+}
+
+function findOnlineUserByName(name) {
+    const lookup = String(name || '').trim().toLowerCase();
+    if (!lookup) return null;
+
+    const World = invoke('GameServer/World/World');
+    return World.user.sessions.find((user) => (
+        user?.actor &&
+        user.actor.fetchIsOnline?.() === true &&
+        !String(user.accountId || '').startsWith('bot_') &&
+        user.actor.fetchName().toLowerCase() === lookup
+    )) || null;
+}
+
+function handlePrivateTell(session, data) {
+    const World = invoke('GameServer/World/World');
+    const target = String(data.target || '').trim();
+    const text = String(data.text || '').trim();
+
+    if (!target || !text) {
+        session.dataSendToMe(ServerResponse.actionFailed());
+        return;
+    }
+
+    const BotManager = invoke('GameServer/Bot/BotManager');
+    const botSession = BotManager.findSessionByName(target);
+    if (botSession) {
+        session.dataSendToMe(ServerResponse.speak(session.actor, data));
+        World.messageBotByName(session, session.actor, target, text, 'client_tell');
+        return;
+    }
+
+    const targetSession = findOnlineUserByName(target);
+    if (!targetSession) {
+        session.dataSendToMe(ServerResponse.actionFailed());
+        return;
+    }
+
+    const packet = ServerResponse.speak(session.actor, data);
+    targetSession.dataSendToMe(packet);
+    session.dataSendToMe(packet);
 }
 
 function consume(session, data) {
     logPlayerChat(session, data);
+
+    if (data.kind === 2) {
+        handlePrivateTell(session, data);
+        return;
+    }
 
     if (data.kind === 0) { // TODO: Remove, temp solution
         if (data.text === '.admin') {

--- a/src/GameServer/Network/Request/TradeDone.js
+++ b/src/GameServer/Network/Request/TradeDone.js
@@ -3,6 +3,7 @@ const ServerResponse = invoke('GameServer/Network/Response');
 const BotTradeService = invoke('GameServer/Bot/BotTradeService');
 const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
 const BotLootEtiquette = invoke('GameServer/Bot/AI/BotLootEtiquette');
+const BotEquipmentUpgrade = invoke('GameServer/Bot/AI/BotEquipmentUpgrade');
 const BotManager = invoke('GameServer/Bot/BotManager');
 
 function describeMovedItems(items) {
@@ -42,6 +43,7 @@ async function tradeDone(session, buffer) {
             session,
             lootRequest ? `Thanks, that's exactly what I needed: ${detail}.` : `Thanks for the trade. I got ${detail}.`
         );
+        BotEquipmentUpgrade.applyBestUpgrades(result.partnerSession, { force: true });
 
         session.dataSendToMe(ServerResponse.itemsList(session.actor.backpack.fetchItems()));
         session.dataSendToMe(ServerResponse.tradeDone(true));

--- a/tests/test_bot_gear.js
+++ b/tests/test_bot_gear.js
@@ -6,6 +6,8 @@ const DataCache = invoke('GameServer/DataCache');
 DataCache.init();
 
 const BotGear = invoke('GameServer/Bot/AI/BotGear');
+const BotEquipmentUpgrade = invoke('GameServer/Bot/AI/BotEquipmentUpgrade');
+const Item = invoke('GameServer/Item/Item');
 
 function bySlot(plan, slot) {
     return plan.items.find((item) => Number(item.slot) === Number(slot));
@@ -30,5 +32,73 @@ assert.strictEqual(itemTemplate(bySlot(lowFighter, 11).selfId).template.kind, 'A
 const noviceDagger = BotGear.planFor({ classId: 7, level: 16 });
 const weapon = itemTemplate(bySlot(noviceDagger, 7).selfId);
 assert.ok(Number(weapon.stats.pAtk || 0) < 1000, 'no-grade bot gear should ignore anomalous weapon stats');
+
+function wearable(id, data) {
+    return new Item(id, {
+        selfId: data.selfId || id,
+        name: data.name || `item_${id}`,
+        kind: data.kind,
+        price: data.price ?? 100,
+        rank: data.rank || 'none',
+        pAtk: data.pAtk || 0,
+        mAtk: data.mAtk || 0,
+        pDef: data.pDef || 0,
+        mDef: data.mDef || 0,
+        maxMp: data.maxMp || 0,
+        equipped: data.equipped || false,
+        slot: data.slot
+    });
+}
+
+function upgradeSession({ classId, level, items, paperdoll }) {
+    const backpack = {
+        fetchItems: () => items,
+        fetchEquippedWeapon: () => items.find((item) => item.isWeapon() && item.fetchEquipped()),
+        fetchPaperdollId: (slot) => paperdoll[slot]?.id,
+        fetchItemRaw: (id) => items.find((item) => item.fetchId() === id)
+    };
+
+    return {
+        accountId: 'bot_upgrade_test',
+        actor: {
+            backpack,
+            fetchLevel: () => level,
+            fetchClassId: () => classId
+        }
+    };
+}
+
+const fighterOldSword = wearable(1001, { kind: 'Weapon.Sword', slot: 7, pAtk: 8, mAtk: 4, equipped: true });
+const fighterNewSword = wearable(1002, { kind: 'Weapon.Sword', slot: 7, pAtk: 12, mAtk: 5 });
+let upgrades = BotEquipmentUpgrade.findBestUpgrades(upgradeSession({
+    classId: 0,
+    level: 10,
+    items: [fighterOldSword, fighterNewSword],
+    paperdoll: { 7: { id: 1001 } }
+}));
+assert.strictEqual(upgrades.length, 1, 'fighter should find one better weapon upgrade');
+assert.strictEqual(upgrades[0].item.fetchId(), 1002);
+
+const mageOldBlunt = wearable(1101, { kind: 'Weapon.Blunt', slot: 7, pAtk: 5, mAtk: 8, equipped: true });
+const mageBow = wearable(1102, { kind: 'Weapon.Bow', slot: 7, pAtk: 80, mAtk: 1 });
+const mageBlunt = wearable(1103, { kind: 'Weapon.Blunt', slot: 7, pAtk: 7, mAtk: 12 });
+upgrades = BotEquipmentUpgrade.findBestUpgrades(upgradeSession({
+    classId: 10,
+    level: 10,
+    items: [mageOldBlunt, mageBow, mageBlunt],
+    paperdoll: { 7: { id: 1101 } }
+}));
+assert.strictEqual(upgrades.length, 1, 'mage should only upgrade to a suitable caster weapon');
+assert.strictEqual(upgrades[0].item.fetchId(), 1103);
+
+const lowOldSword = wearable(1201, { kind: 'Weapon.Sword', slot: 7, pAtk: 8, equipped: true });
+const tooHighGradeSword = wearable(1202, { kind: 'Weapon.Sword', slot: 7, pAtk: 80, rank: 'd' });
+upgrades = BotEquipmentUpgrade.findBestUpgrades(upgradeSession({
+    classId: 0,
+    level: 10,
+    items: [lowOldSword, tooHighGradeSword],
+    paperdoll: { 7: { id: 1201 } }
+}));
+assert.strictEqual(upgrades.length, 0, 'low-level bot should not auto-equip gear above its grade band');
 
 console.log('Bot gear checks passed');

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -1,0 +1,226 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const World = invoke('GameServer/World/World');
+const FollowingState = invoke('GameServer/Bot/AI/States/FollowingState');
+const HuntingState = invoke('GameServer/Bot/AI/States/HuntingState');
+const RestingState = invoke('GameServer/Bot/AI/States/RestingState');
+const ShoppingState = invoke('GameServer/Bot/AI/States/ShoppingState');
+
+class FakeState {
+    constructor() {
+        this.seated = false;
+        this.dead = false;
+        this.towards = false;
+        this.hits = false;
+        this.casts = false;
+        this.animated = false;
+    }
+
+    fetchSeated() { return this.seated; }
+    setSeated(value) { this.seated = value; }
+    fetchDead() { return this.dead; }
+    fetchTowards() { return this.towards; }
+    setTowards(value) { this.towards = value; }
+    fetchHits() { return this.hits; }
+    fetchCasts() { return this.casts; }
+    fetchAnimated() { return this.animated; }
+    fetchPickinUp() { return false; }
+    isBlocked() { return this.hits || this.casts || this.animated || this.seated; }
+}
+
+function fakeActor(id, loc = {}) {
+    const actor = {
+        id,
+        name: `actor_${id}`,
+        locX: loc.locX || 0,
+        locY: loc.locY || 0,
+        locZ: loc.locZ || 0,
+        hp: loc.hp || 100,
+        maxHp: loc.maxHp || 100,
+        mp: loc.mp || 100,
+        maxMp: loc.maxMp || 100,
+        classId: loc.classId || 0,
+        level: loc.level || 26,
+        karma: loc.karma || 0,
+        pvpFlag: loc.pvpFlag || 0,
+        destId: loc.destId,
+        state: new FakeState(),
+        activeBuffs: {
+            windWalk: Date.now() + 600000,
+            shield: Date.now() + 600000,
+            haste: Date.now() + 600000,
+            might: Date.now() + 600000
+        },
+        moves: [],
+        fetchId() { return this.id; },
+        fetchName() { return this.name; },
+        fetchLocX() { return this.locX; },
+        fetchLocY() { return this.locY; },
+        fetchLocZ() { return this.locZ; },
+        fetchHp() { return this.hp; },
+        fetchMaxHp() { return this.maxHp; },
+        fetchMp() { return this.mp; },
+        fetchMaxMp() { return this.maxMp; },
+        fetchClassId() { return this.classId; },
+        fetchLevel() { return this.level; },
+        fetchKarma() { return this.karma; },
+        fetchPvpFlag() { return this.pvpFlag; },
+        fetchDestId() { return this.destId; },
+        fetchIsOnline() { return true; },
+        isDead() { return this.state.fetchDead(); },
+        isBlocked() { return this.state.isBlocked(); },
+        moveTo(data) { this.moves.push(data); },
+        select(data) { this.destId = data.id; },
+        unselect() { this.destId = undefined; },
+        statusUpdateVitals() {},
+        skillset: { fetchSkill: () => null },
+        automation: { abortAll() {}, replenishVitals() {} }
+    };
+    return actor;
+}
+
+function fakeSession(accountId, actor) {
+    return {
+        accountId,
+        actor,
+        sent: 0,
+        dataSendToMe() { this.sent++; },
+        dataSendToOthers() { this.sent++; },
+        dataSendToMeAndOthers() { this.sent++; }
+    };
+}
+
+const originalUsers = World.user;
+const originalFetchUser = World.fetchUser;
+const originalFetchNpc = World.fetchNpc;
+const originalFetchNpcsInRadius = World.fetchNpcsInRadius;
+const originalRandom = Math.random;
+
+try {
+    Math.random = () => 1;
+
+    const leader = fakeActor(2000001, { locX: 0, locY: 0 });
+    const leaderSession = fakeSession('player_test', leader);
+    const bot = fakeActor(2000002, { locX: 1200, locY: 0 });
+    const botSession = fakeSession('bot_test', bot);
+    botSession.followPlayerSession = leaderSession;
+    botSession.partyCompanion = true;
+    botSession.plan = 'following';
+    World.user = { sessions: [leaderSession, botSession] };
+    World.fetchNpcsInRadius = () => [];
+
+    FollowingState.tick(botSession, bot, {}, { say() {}, executeCombat() {}, executePvPCombat() {} });
+
+    assert.strictEqual(bot.moves.length, 1, 'companion should run after the leader at 1200 range');
+    assert.strictEqual(bot.fetchLocX(), 1200, 'companion should not teleport at 1200 range');
+
+    const restingBot = fakeActor(2000003, { locX: 0, locY: 0 });
+    restingBot.state.setSeated(true);
+    const restingSession = fakeSession('bot_resting', restingBot);
+    restingSession.followPlayerSession = leaderSession;
+    restingSession.partyCompanion = true;
+    restingSession.plan = 'resting';
+    World.user = { sessions: [leaderSession, restingSession] };
+    World.fetchNpcsInRadius = () => [{
+        fetchId: () => 1001,
+        fetchAttackable: () => true,
+        isDead: () => false,
+        fetchDestId: () => leader.fetchId(),
+        fetchLocX: () => 50,
+        fetchLocY: () => 0
+    }];
+
+    RestingState.tick(restingSession, restingBot, {}, { say() {} });
+
+    assert.strictEqual(restingSession.plan, 'following', 'resting companion should wake when party is attacked');
+    assert.strictEqual(restingBot.state.fetchSeated(), false, 'resting companion should stand before assisting');
+    assert.strictEqual(restingSession.currentTargetId, 1001, 'resting companion should remember the threat target');
+
+    leader.destId = 1003;
+    const assistingBot = fakeActor(2000006, { locX: 500, locY: 0 });
+    const assistingSession = fakeSession('bot_assisting', assistingBot);
+    assistingSession.followPlayerSession = leaderSession;
+    assistingSession.partyCompanion = true;
+    assistingSession.plan = 'following';
+    World.user = { sessions: [leaderSession, assistingSession] };
+    World.fetchNpcsInRadius = () => [];
+    World.fetchUser = () => ({
+        then: () => ({
+            catch: (handler) => {
+                handler();
+            }
+        })
+    });
+    World.fetchNpc = () => ({
+        then: (handler) => {
+            handler({
+                fetchId: () => 1003,
+                fetchAttackable: () => true,
+                isDead: () => false,
+                fetchLocX: () => 800,
+                fetchLocY: () => 0,
+                fetchLocZ: () => 0,
+                fetchName: () => 'next mob'
+            });
+            return { catch() {} };
+        }
+    });
+
+    FollowingState.tick(assistingSession, assistingBot, {}, {
+        say() {},
+        executeCombat() {},
+        executePvPCombat() {}
+    });
+
+    assert.strictEqual(assistingBot.moves.length, 0, 'companion should not run back to leader while leader has a next target');
+    assert.strictEqual(assistingSession.currentTargetId, 1003, 'companion should switch directly to the leader target');
+
+    Math.random = () => 0;
+    const huntingCompanion = fakeActor(2000004, { locX: 0, locY: 0 });
+    const huntingSession = fakeSession('bot_hunting_companion', huntingCompanion);
+    huntingSession.followPlayerSession = leaderSession;
+    huntingSession.partyCompanion = true;
+    huntingSession.plan = 'hunting';
+    huntingSession.currentSpot = { id: 'test-spot' };
+    World.user = { sessions: [leaderSession, huntingSession] };
+    World.fetchNpcsInRadius = () => [{
+        fetchId: () => 1002,
+        fetchAttackable: () => true,
+        isDead: () => false,
+        fetchDestId: () => undefined,
+        fetchLocX: () => 80,
+        fetchLocY: () => 0,
+        fetchLocZ: () => 0,
+        fetchName: () => 'training mob'
+    }];
+
+    HuntingState.tick(huntingSession, huntingCompanion, {}, {
+        say() {},
+        getRandomPhrase: () => 'target found',
+        executeCombat() {}
+    });
+
+    assert.notStrictEqual(huntingSession.plan, 'shopping', 'party companion should not start random loot shopping');
+
+    const shoppingCompanion = fakeActor(2000005, { locX: 0, locY: 0 });
+    const shoppingSession = fakeSession('bot_shopping_companion', shoppingCompanion);
+    shoppingSession.followPlayerSession = leaderSession;
+    shoppingSession.partyCompanion = true;
+    shoppingSession.plan = 'shopping';
+    shoppingSession.shoppingTarget = { name: 'shop', locX: 1000, locY: 0, locZ: 0 };
+
+    ShoppingState.tick(shoppingSession, shoppingCompanion, {}, { say() {} });
+
+    assert.strictEqual(shoppingSession.plan, 'following', 'shopping companion should return to follow state');
+    assert.strictEqual(shoppingSession.shoppingTarget, undefined, 'shopping target should be cleared for companions');
+} finally {
+    Math.random = originalRandom;
+    World.user = originalUsers;
+    World.fetchUser = originalFetchUser;
+    World.fetchNpc = originalFetchNpc;
+    World.fetchNpcsInRadius = originalFetchNpcsInRadius;
+}
+
+console.log('Party companion rest/follow regression checks passed');

--- a/tests/test_private_tell_routing.js
+++ b/tests/test_private_tell_routing.js
@@ -1,0 +1,81 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const SendPacket = invoke('Packet/Send');
+const SpeakRequest = invoke('GameServer/Network/Request/Speak');
+const World = invoke('GameServer/World/World');
+const BotManager = invoke('GameServer/Bot/BotManager');
+
+function actor(name, id = 2000001) {
+    return {
+        fetchId: () => id,
+        fetchName: () => name,
+        fetchIsOnline: () => true
+    };
+}
+
+function privateTellBuffer(text, target) {
+    return new SendPacket(0x38)
+        .writeS(text)
+        .writeD(2)
+        .writeS(target)
+        .fetchBuffer(false);
+}
+
+const originalMessageBotByName = World.messageBotByName;
+const originalHandlePlayerSpeak = BotManager.handlePlayerSpeak;
+const originalFindSessionByName = BotManager.findSessionByName;
+
+try {
+    const playerSession = {
+        accountId: 'player_test',
+        actor: actor('Slava'),
+        selfPackets: 0,
+        failed: 0,
+        broadcasts: 0,
+        dataSendToMe() { this.selfPackets++; },
+        dataSendToMeAndOthers() { this.broadcasts++; }
+    };
+
+    let routedTell = null;
+    let nearbyHookCalled = false;
+
+    BotManager.findSessionByName = (name) => (
+        String(name).toLowerCase() === 'partybot'
+            ? { accountId: 'bot_partybot', actor: actor('PartyBot', 2000002) }
+            : null
+    );
+    BotManager.handlePlayerSpeak = () => {
+        nearbyHookCalled = true;
+    };
+    World.messageBotByName = (session, requestActor, name, text, source) => {
+        routedTell = {
+            session,
+            actorName: requestActor.fetchName(),
+            name,
+            text,
+            source
+        };
+        return Promise.resolve(true);
+    };
+
+    SpeakRequest(playerSession, privateTellBuffer('follow me', 'PartyBot'));
+
+    assert.deepStrictEqual(routedTell, {
+        session: playerSession,
+        actorName: 'Slava',
+        name: 'PartyBot',
+        text: 'follow me',
+        source: 'client_tell'
+    });
+    assert.strictEqual(nearbyHookCalled, false, 'private tell should not trigger nearby bot chat hook');
+    assert.strictEqual(playerSession.broadcasts, 0, 'private tell should not broadcast to nearby players/bots');
+    assert.strictEqual(playerSession.selfPackets, 1, 'private tell should echo the outgoing line to the sender');
+} finally {
+    World.messageBotByName = originalMessageBotByName;
+    BotManager.handlePlayerSpeak = originalHandlePlayerSpeak;
+    BotManager.findSessionByName = originalFindSessionByName;
+}
+
+console.log('Private tell routing regression checks passed');


### PR DESCRIPTION
## Summary

This PR tightens several live companion-bot behaviors that showed up during in-game testing:

- Party companions wake from regeneration when the leader moves or the party is attacked, and they no longer teleport back too eagerly.
- Companions do not run off to sell loot or restock while they are actively grouped with a player.
- Private tells are routed only to the addressed bot and echo the sender's outgoing line.
- Companion bots keep assisting a newly selected target instead of briefly running back to the leader first.
- Bots can auto-equip suitable inventory upgrades while respecting role, armor style, and grade limits.

## Root Cause

Several systems treated companion state too loosely: resting/following/shop transitions did not consistently check real party-companion ownership, private tell packets were missing their target-name field, and assist target lookup happened asynchronously after the follow-range logic had already been allowed to move the bot back toward the leader.

## Validation

- `node tests/test_party_companion_rest_follow.js`
- `node tests/test_private_tell_routing.js`
- `node tests/test_bot_gear.js`
- `node tests/test_bot_ai_visibility.js`
- `node tests/test_town_pathfinder.js`

Live client validation is still recommended for visual timing, chat echo presentation, and paperdoll updates.
