### PR TITLE
Improve bot town path following

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Useful startup variables:
 - `.bot` or `.companion` - open the companion control panel.
 - `.botstatus` - show a bot overview panel.
 - `.botstatus <name>` - show detailed status for a specific bot.
+- `.botpath` / `.botpath <name>` - inspect bot movement, town-route waypoints, and geodata path diagnostics.
 - `.trade` or `/trade` - open the bot trade window with the targeted SimPlayer, useful as a fallback to the native client trade action.
 - `.leave` - dismiss all companion bots.
 - `.kick <name>` - dismiss one companion bot.
@@ -166,7 +167,7 @@ Main bot modes:
 
 Companion behavior is role-aware. `BotRoles` infers healer, buffer, tank, dagger, archer, mage, or generic DPS from class id. In party mode, tanks can protect the leader and avoid unsafe pulls, healers heal while conserving MP, buffers apply `Might`, `Shield`, `Haste`, and `Wind Walk`, daggers close-assist, and ranged roles keep ranged assist intent.
 
-Bot status is meant to be inspectable. Use `.botparty` to find available nearby SimPlayers, `.botstatus` for state, social memory, role decisions, buff timers, and loot requests, companion panel `Status` links, or watch `BotStatus :: ...`, `BotSocial :: ...`, `BotRole :: ...`, and `BotLoot :: ...` lines in the server logs.
+Bot status is meant to be inspectable. Use `.botparty` to find available nearby SimPlayers, `.botstatus` for state, social memory, role decisions, buff timers, and loot requests, `.botpath` for movement and town-route diagnostics, companion panel `Status` links, or watch `BotStatus :: ...`, `BotSocial :: ...`, `BotRole :: ...`, and `BotLoot :: ...` lines in the server logs.
 
 To reset generated SimPlayer accounts and characters while keeping the rest of the database intact:
 

--- a/src/GameServer/Actor/Generics/MoveTo.js
+++ b/src/GameServer/Actor/Generics/MoveTo.js
@@ -14,17 +14,21 @@ function moveTo(session, actor, coords) {
     // Abort scheduled movement, user redirected the actor
     actor.automation.abortAll(actor);
 
+    const isBot = session && (session.constructor.name === 'BotSession' || (session.accountId && session.accountId.startsWith('bot_')));
+    const requestedTo = { ...coords.to };
+    let townRouteDiagnostics = null;
+
     // Dynamic city exit/entrance routing middleware for bots
-    if (session && (session.constructor.name === 'BotSession' || (session.accountId && session.accountId.startsWith('bot_')))) {
+    if (isBot) {
         const TownPathfinder = invoke('GameServer/Bot/AI/TownPathfinder');
-        const routedTo = TownPathfinder.route(actor, coords.from, coords.to);
+        const routeResult = TownPathfinder.routeWithSession(session, actor, coords.from, coords.to);
+        const routedTo = routeResult.to;
+        townRouteDiagnostics = routeResult.diagnostics;
         
         coords.to.locX = routedTo.locX;
         coords.to.locY = routedTo.locY;
         coords.to.locZ = routedTo.locZ;
     }
-
-    const isBot = session && (session.constructor.name === 'BotSession' || (session.accountId && session.accountId.startsWith('bot_')));
 
     if (!isBot) {
         // Normal player movement
@@ -71,6 +75,15 @@ function moveTo(session, actor, coords) {
             const snappedTo = { ...coords.to };
             snappedTo.locZ = GeodataEngine.getHeight(snappedTo.locX, snappedTo.locY, snappedTo.locZ);
             actor.setLocXYZ(snappedTo);
+            session.lastPathfinding = {
+                requestedTo,
+                routedTo: { ...coords.to },
+                townRoute: townRouteDiagnostics,
+                pathLength: 0,
+                lowLodWarp: true,
+                distanceToPlayer,
+                at: Date.now()
+            };
             return;
         }
 
@@ -82,6 +95,15 @@ function moveTo(session, actor, coords) {
         if (!path || path.length <= 1) {
             path = [{ locX: endX, locY: endY, locZ: endZ }];
         }
+        session.lastPathfinding = {
+            requestedTo,
+            routedTo: { ...coords.to },
+            townRoute: townRouteDiagnostics,
+            pathLength: path.length,
+            lowLodWarp: false,
+            distanceToPlayer,
+            at: Date.now()
+        };
 
         const moveAlongPath = (index) => {
             if (index >= path.length) {

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -1,5 +1,6 @@
 const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
+const TownPathfinder = invoke('GameServer/Bot/AI/TownPathfinder');
 
 function ratio(value, max) {
     if (!max) return 0;
@@ -201,7 +202,12 @@ const BotStatus = {
             movement: {
                 moving: !!session.moveTimer || !!bot.state.fetchTowards(),
                 towards: bot.state.fetchTowards() || false,
-                stuckTicks: session.stuckTicks || 0
+                stuckTicks: session.stuckTicks || 0,
+                followTarget: session.lastFollowMoveTarget || null,
+                followHeldAt: session.lastFollowMoveHeldAt || null,
+                townRoute: session.townRoutePlan || null,
+                pathfinding: session.lastPathfinding || null,
+                pathSummary: TownPathfinder.describeDiagnostics(session.lastPathfinding?.townRoute)
             },
             buffs: BotBuffs.snapshot(bot),
             timers: {
@@ -231,10 +237,11 @@ const BotStatus = {
         const home = status.home && status.home.region ? ` home=${status.home.region}${status.home.visitor ? ':visitor' : ''}` : '';
         const social = status.social ? ` social=${status.social.playerName}:${status.social.relationship}/${status.social.trust}` : '';
         const roleDecision = status.roleDecision ? ` decision=${status.roleDecision.action}/${status.roleDecision.reason}` : '';
+        const path = status.movement?.pathfinding?.townRoute?.changedTarget ? ' path=town' : '';
         const buffs = status.buffs?.needsRefresh ? ' buffs=refresh' : '';
         const blockers = status.blockers.length > 0 ? ` blockers=${status.blockers.join(',')}` : '';
 
-        return `${status.name}: mode=${status.mode} intent=${status.intent} role=${status.role}${home} hp=${hp}% mp=${mp}%${target}${spot}${social}${roleDecision}${buffs}${blockers}`;
+        return `${status.name}: mode=${status.mode} intent=${status.intent} role=${status.role}${home} hp=${hp}% mp=${mp}%${target}${spot}${social}${roleDecision}${path}${buffs}${blockers}`;
     }
 };
 

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -7,6 +7,8 @@ const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
 
 const SUPPORT_BUFF_MP_COST = 20;
 const FOLLOW_RUN_DISTANCE = 250;
+const FOLLOW_RETARGET_DISTANCE = 900;
+const FOLLOW_TARGET_DRIFT = 650;
 const FOLLOW_TELEPORT_DISTANCE = 4500;
 
 function ratio(value, max) {
@@ -20,6 +22,27 @@ function isBusy(bot) {
 
 function point(actor) {
     return new SpeckMath.Point3D(actor.fetchLocX(), actor.fetchLocY(), actor.fetchLocZ());
+}
+
+function loc(actor) {
+    return { locX: actor.fetchLocX(), locY: actor.fetchLocY(), locZ: actor.fetchLocZ() };
+}
+
+function distance2d(a, b) {
+    const dx = a.locX - b.locX;
+    const dy = a.locY - b.locY;
+    return Math.sqrt((dx * dx) + (dy * dy));
+}
+
+function shouldKeepCurrentFollowMove(session, bot, player, leaderDistance) {
+    const isMoving = !!session.moveTimer || bot.state.fetchTowards();
+    if (!isMoving) return false;
+    if ((session.stuckTicks || 0) >= 2) return false;
+    if (leaderDistance > FOLLOW_RETARGET_DISTANCE) return false;
+
+    const target = session.lastFollowMoveTarget;
+    if (!target) return false;
+    return distance2d(target, loc(player)) <= FOLLOW_TARGET_DRIFT;
 }
 
 function standUp(session, bot) {
@@ -536,6 +559,7 @@ module.exports = {
 
         if (!session.currentTargetId && !acted) {
             if (session.botStay && session.stayLocation) {
+                session.lastFollowMoveTarget = null;
                 const stayDist = point(bot).distance(new SpeckMath.Point3D(
                     session.stayLocation.locX,
                     session.stayLocation.locY,
@@ -554,11 +578,22 @@ module.exports = {
                 if (!keepRoleDecision) {
                     recordRoleDecision(session, bot, 'follow_leader', 'keep_range');
                 }
+                if (shouldKeepCurrentFollowMove(session, bot, player, distance)) {
+                    session.lastFollowMoveHeldAt = Date.now();
+                    return;
+                }
+                const followTarget = {
+                    locX: player.fetchLocX() + utils.oneFromSpan(-60, 60),
+                    locY: player.fetchLocY() + utils.oneFromSpan(-60, 60),
+                    locZ: player.fetchLocZ()
+                };
+                session.lastFollowMoveTarget = followTarget;
                 bot.moveTo({
                     from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
-                    to: { locX: player.fetchLocX() + utils.oneFromSpan(-60, 60), locY: player.fetchLocY() + utils.oneFromSpan(-60, 60), locZ: player.fetchLocZ() }
+                    to: followTarget
                 });
             } else {
+                session.lastFollowMoveTarget = null;
                 if (!keepRoleDecision) {
                     recordRoleDecision(session, bot, BotRoles.partyRoleStance(role), 'ready');
                 }

--- a/src/GameServer/Bot/AI/TownPathfinder.js
+++ b/src/GameServer/Bot/AI/TownPathfinder.js
@@ -155,6 +155,19 @@ function distance(a, b) {
     return Math.sqrt((dx * dx) + (dy * dy));
 }
 
+function cloneLoc(loc) {
+    return { locX: loc.locX, locY: loc.locY, locZ: loc.locZ };
+}
+
+function sameLoc(a, b) {
+    return !!a && !!b && a.locX === b.locX && a.locY === b.locY && a.locZ === b.locZ;
+}
+
+function locLabel(loc) {
+    if (!loc) return 'none';
+    return `${loc.locX},${loc.locY},${loc.locZ}`;
+}
+
 function pointInPolygon(loc, polygon) {
     let inside = false;
     for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
@@ -223,10 +236,20 @@ function boundaryNodeToward(town, loc) {
 function chooseNextTownStep(town, from, finalTarget) {
     let bestNode = null;
     let bestScore = Infinity;
+    const currentTargetDistance = distance(from, finalTarget);
+
+    if (currentTargetDistance <= 1500) {
+        return finalTarget;
+    }
+
     for (const node of town.nodes) {
         const fromDistance = distance(from, node);
         const targetDistance = distance(finalTarget, node);
         if (fromDistance <= 350 || targetDistance <= 350) {
+            continue;
+        }
+
+        if (targetDistance >= currentTargetDistance - 100) {
             continue;
         }
 
@@ -241,11 +264,41 @@ function chooseNextTownStep(town, from, finalTarget) {
         return bestNode;
     }
 
-    if (distance(from, town.center) > 700 && distance(finalTarget, town.center) > 700) {
+    if (
+        distance(from, town.center) > 700 &&
+        distance(finalTarget, town.center) > 700 &&
+        distance(town.center, finalTarget) < currentTargetDistance - 100
+    ) {
         return town.center;
     }
 
     return finalTarget;
+}
+
+function createDiagnostics(from, to, routedTo, fromTown, toTown, routePlan, reason) {
+    return {
+        from: cloneLoc(from),
+        to: cloneLoc(to),
+        routedTo: cloneLoc(routedTo),
+        fromTown: fromTown ? fromTown.name : null,
+        toTown: toTown ? toTown.name : null,
+        changedTarget: !sameLoc(routedTo, to),
+        plan: routePlan ? {
+            townName: routePlan.townName,
+            finalTarget: cloneLoc(routePlan.finalTarget),
+            waypoint: cloneLoc(routePlan.waypoint),
+            createdAt: routePlan.createdAt,
+            updatedAt: routePlan.updatedAt,
+            reason: routePlan.reason
+        } : null,
+        reason
+    };
+}
+
+function clearSessionRoute(session) {
+    if (session) {
+        session.townRoutePlan = null;
+    }
 }
 
 const TownPathfinder = {
@@ -257,6 +310,60 @@ const TownPathfinder = {
 
     getTown(loc) {
         return findTown(loc);
+    },
+
+    routeWithSession(session, actor, from, to) {
+        const now = Date.now();
+        const existing = session ? session.townRoutePlan : null;
+        if (existing) {
+            const targetShift = distance(existing.finalTarget, to);
+            const waypointDistance = distance(from, existing.waypoint);
+            const expired = now - existing.createdAt > 30000;
+
+            if (!expired && targetShift <= 900 && waypointDistance > 250) {
+                existing.updatedAt = now;
+                const fromTown = findTown(from);
+                const toTown = findTown(to);
+                return {
+                    to: cloneLoc(existing.waypoint),
+                    diagnostics: createDiagnostics(from, to, existing.waypoint, fromTown, toTown, existing, 'sticky_waypoint')
+                };
+            }
+
+            clearSessionRoute(session);
+        }
+
+        const fromTown = findTown(from);
+        const toTown = findTown(to);
+        const routedTo = this.route(actor, from, to);
+        const usesTownRoute = !sameLoc(routedTo, to);
+        let routePlan = null;
+
+        if (session && usesTownRoute) {
+            routePlan = {
+                townName: (fromTown || toTown)?.name || null,
+                finalTarget: cloneLoc(to),
+                waypoint: cloneLoc(routedTo),
+                createdAt: now,
+                updatedAt: now,
+                reason: 'new_waypoint'
+            };
+            session.townRoutePlan = routePlan;
+        }
+
+        return {
+            to: routedTo,
+            diagnostics: createDiagnostics(from, to, routedTo, fromTown, toTown, routePlan, usesTownRoute ? 'new_waypoint' : 'direct')
+        };
+    },
+
+    describeDiagnostics(diagnostics) {
+        if (!diagnostics) return 'no path diagnostics';
+        const route = `${locLabel(diagnostics.from)} -> ${locLabel(diagnostics.to)}`;
+        const town = `${diagnostics.fromTown || 'field'} -> ${diagnostics.toTown || 'field'}`;
+        const routed = diagnostics.changedTarget ? ` via ${locLabel(diagnostics.routedTo)}` : '';
+        const plan = diagnostics.plan ? ` plan=${diagnostics.plan.townName || 'town'}/${diagnostics.reason}` : ` reason=${diagnostics.reason}`;
+        return `${town}: ${route}${routed}${plan}`;
     },
 
     route(actor, from, to) {
@@ -277,6 +384,9 @@ const TownPathfinder = {
         if (fromTown && !toTown) {
             const exit = boundaryNodeToward(fromTown, to);
             const staging = nearestNode(fromTown, exit);
+            if (distance(from, exit) <= 350) {
+                return to;
+            }
             if (distance(from, staging) > 350 && distance(exit, staging) > 350) {
                 return staging;
             }

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -92,6 +92,9 @@ const BotManager = {
         const roleDecision = status.roleDecision ? `${status.roleDecision.action} / ${status.roleDecision.reason}` : null;
         const huntDecision = botSession.lastDecision ? `${botSession.lastDecision.action} / ${botSession.lastDecision.reason}${botSession.lastDecision.spotName ? ` / ${botSession.lastDecision.spotName}` : ''}` : null;
         const decision = roleDecision || huntDecision || 'none';
+        const pathInfo = status.movement.pathfinding
+            ? `${status.movement.pathSummary} / geodata ${status.movement.pathfinding.pathLength}`
+            : 'none';
         const buffs = status.buffs?.eligible
             ? `WW ${status.buffs.windWalk}s / Shield ${status.buffs.shield}s / Haste ${status.buffs.haste}s / Might ${status.buffs.might}s${status.buffs.needsRefresh ? ' / refresh' : ''}`
             : `Might ${status.buffs?.might ?? 0}s`;
@@ -114,6 +117,7 @@ const BotManager = {
             ['Spot', safe(spot)],
             ['Nearby', safe(`players ${status.nearby.realPlayers}, bots ${status.nearby.friendlyBots}, mobs ${status.nearby.attackableNpcs}`)],
             ['Move', safe(status.movement.moving ? `moving (${status.movement.towards})` : 'idle')],
+            ['Path', safe(pathInfo)],
             ['Blockers', safe(blockers)],
             ['Decision', safe(decision)],
             ['Buffs', safe(buffs)],
@@ -126,6 +130,65 @@ const BotManager = {
         ]);
         const html = Html.page(body, { title: 'Bot Status' });
 
+        playerSession.dataSendToMe(ServerResponse.npcHtml(playerSession.actor.fetchId(), html));
+    },
+
+    renderBotPathPanel(playerSession, botSession = null) {
+        if (!playerSession.actor) return;
+
+        const ServerResponse = invoke('GameServer/Network/Response');
+        const Html = invoke('GameServer/World/Generics/HtmlKit');
+        const safe = (value) => Html.esc(value);
+        const locText = (loc) => loc ? `${loc.locX},${loc.locY},${loc.locZ}` : 'none';
+
+        if (!botSession) {
+            const statuses = this.getAllBotStatuses().slice(0, 14);
+            let body = `${Html.font('Bot Path Diagnostics', Html.COLOR.title)}<br>`;
+            statuses.forEach((status) => {
+                const path = status.movement.pathfinding;
+                const subtitle = path
+                    ? `${status.movement.pathSummary} / geodata ${path.pathLength}`
+                    : 'no movement recorded';
+                body += Html.botCard({
+                    name: status.name,
+                    badge: status.movement.moving ? Html.font('moving', Html.COLOR.ok) : Html.font('idle', Html.COLOR.muted),
+                    subtitle,
+                    actions: [
+                        { label: 'Open', command: `bot-path ${status.name}` },
+                        { label: 'Status', command: `bot-status ${status.name}` }
+                    ]
+                });
+                body += Html.spacer(3);
+            });
+            const html = Html.page(body, { title: 'Bot Paths' });
+            playerSession.dataSendToMe(ServerResponse.npcHtml(playerSession.actor.fetchId(), html));
+            return;
+        }
+
+        const status = this.getBotStatus(botSession);
+        if (!status || !status.available) {
+            const html = Html.page(Html.emptyState('Bot Paths', 'Bot path diagnostics unavailable.'), { title: 'Bot Paths' });
+            playerSession.dataSendToMe(ServerResponse.npcHtml(playerSession.actor.fetchId(), html));
+            return;
+        }
+
+        const path = status.movement.pathfinding;
+        const route = path?.townRoute || null;
+        const body = `${Html.font(status.name, Html.COLOR.title)}<br>` + Html.statusTable([
+            ['Moving', safe(status.movement.moving ? `yes (${status.movement.towards})` : 'no')],
+            ['Stuck', safe(String(status.movement.stuckTicks))],
+            ['Follow Target', safe(locText(status.movement.followTarget))],
+            ['Requested', safe(locText(path?.requestedTo))],
+            ['Routed', safe(locText(path?.routedTo))],
+            ['Town Route', safe(status.movement.pathSummary)],
+            ['Geodata Path', safe(path ? String(path.pathLength) : 'none')],
+            ['LOD Warp', safe(path?.lowLodWarp ? 'yes' : 'no')],
+            ['From/To Town', safe(route ? `${route.fromTown || 'field'} -> ${route.toTown || 'field'}` : 'none')]
+        ]) + '<br>' + Html.actionFooter([
+            { label: 'Refresh', command: `bot-path ${status.name}` },
+            { label: 'Status', command: `bot-status ${status.name}` }
+        ]);
+        const html = Html.page(body, { title: 'Bot Paths' });
         playerSession.dataSendToMe(ServerResponse.npcHtml(playerSession.actor.fetchId(), html));
     },
 

--- a/src/GameServer/Network/Request/Speak.js
+++ b/src/GameServer/Network/Request/Speak.js
@@ -140,6 +140,12 @@ function consume(session, data) {
             BotStatus(session, ['bot-status', parts[1]]);
             return;
         }
+        if (data.text === '.botpath' || data.text.startsWith('.botpath ')) {
+            const BotPath = invoke('GameServer/World/Generics/NpcBypasses/BotPath');
+            const parts = data.text.split(/\s+/);
+            BotPath(session, ['bot-path', parts[1]]);
+            return;
+        }
         if (data.text === '/trade' || data.text === '.trade') {
             const BotManager = invoke('GameServer/Bot/BotManager');
             const BotTradeService = invoke('GameServer/Bot/BotTradeService');

--- a/src/GameServer/World/Generics/NpcBypasses/BotPath.js
+++ b/src/GameServer/World/Generics/NpcBypasses/BotPath.js
@@ -1,0 +1,16 @@
+const BotManager = invoke('GameServer/Bot/BotManager');
+
+function botPath(session, parts) {
+    const name = parts[1];
+    let targetSession = null;
+
+    if (name) {
+        targetSession = BotManager.findSessionByName(name);
+    } else if (session.actor && session.actor.fetchDestId()) {
+        targetSession = BotManager.findSessionById(session.actor.fetchDestId());
+    }
+
+    BotManager.renderBotPathPanel(session, targetSession);
+}
+
+module.exports = botPath;

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -116,6 +116,35 @@ try {
     assert.strictEqual(bot.moves.length, 1, 'companion should run after the leader at 1200 range');
     assert.strictEqual(bot.fetchLocX(), 1200, 'companion should not teleport at 1200 range');
 
+    const movingBot = fakeActor(2000007, { locX: 500, locY: 0 });
+    movingBot.state.setTowards('move');
+    const movingSession = fakeSession('bot_moving_follow', movingBot);
+    movingSession.followPlayerSession = leaderSession;
+    movingSession.partyCompanion = true;
+    movingSession.plan = 'following';
+    movingSession.lastFollowMoveTarget = { locX: 40, locY: 0, locZ: 0 };
+    World.user = { sessions: [leaderSession, movingSession] };
+    World.fetchNpcsInRadius = () => [];
+
+    FollowingState.tick(movingSession, movingBot, {}, { say() {}, executeCombat() {}, executePvPCombat() {} });
+
+    assert.strictEqual(movingBot.moves.length, 0, 'companion should not restart follow movement while the existing waypoint is still useful');
+    assert(movingSession.lastFollowMoveHeldAt, 'companion should record that a follow retarget was held');
+
+    const unknownMoveBot = fakeActor(2000008, { locX: 500, locY: 0 });
+    unknownMoveBot.state.setTowards('move');
+    const unknownMoveSession = fakeSession('bot_unknown_move_follow', unknownMoveBot);
+    unknownMoveSession.followPlayerSession = leaderSession;
+    unknownMoveSession.partyCompanion = true;
+    unknownMoveSession.plan = 'following';
+    World.user = { sessions: [leaderSession, unknownMoveSession] };
+    World.fetchNpcsInRadius = () => [];
+
+    FollowingState.tick(unknownMoveSession, unknownMoveBot, {}, { say() {}, executeCombat() {}, executePvPCombat() {} });
+
+    assert.strictEqual(unknownMoveBot.moves.length, 1, 'companion should retarget when existing movement is not known to be a follow move');
+    assert(unknownMoveSession.lastFollowMoveTarget, 'companion should record the new follow target after retargeting');
+
     const restingBot = fakeActor(2000003, { locX: 0, locY: 0 });
     restingBot.state.setSeated(true);
     const restingSession = fakeSession('bot_resting', restingBot);

--- a/tests/test_town_pathfinder.js
+++ b/tests/test_town_pathfinder.js
@@ -18,10 +18,26 @@ function assertNotSameLoc(actual, expected, message) {
     );
 }
 
+function routeUntilTarget(from, to, maxSteps = 6) {
+    const steps = [];
+    let current = { ...from };
+    for (let i = 0; i < maxSteps; i++) {
+        const next = TownPathfinder.route(null, current, to);
+        steps.push(next);
+        if (next.locX === to.locX && next.locY === to.locY && next.locZ === to.locZ) {
+            return steps;
+        }
+        current = { ...next };
+    }
+    return steps;
+}
+
 const giranCenter = { locX: 83396, locY: 147904, locZ: -3404 };
 const giranField = { locX: 76000, locY: 144000, locZ: -3600 };
 const dionCenter = { locX: 15631, locY: 142885, locZ: -2704 };
 const dionField = { locX: 23000, locY: 145000, locZ: -3100 };
+const talkingIslandCenter = { locX: -84108, locY: 244604, locZ: -3729 };
+const talkingIslandField = { locX: -80000, locY: 250000, locZ: -3500 };
 
 assert.strictEqual(TownPathfinder.getTown(giranCenter).name, 'Giran');
 assert.strictEqual(TownPathfinder.getTown(dionCenter).name, 'Dion');
@@ -41,5 +57,32 @@ assert(distance(dionEntry, dionCenter) < distance(dionField, dionCenter));
 const gludinTown = BotAI.getClosestTown(-82000, 151000);
 assert.strictEqual(gludinTown.name, 'Gludin');
 assert.strictEqual(gludinTown.z, -3044);
+
+const talkingIslandExitSteps = routeUntilTarget(talkingIslandCenter, talkingIslandField);
+assert.deepStrictEqual(
+    talkingIslandExitSteps[talkingIslandExitSteps.length - 1],
+    talkingIslandField,
+    'Talking Island inside->outside route should reach the field target instead of returning to the town center'
+);
+assert(talkingIslandExitSteps.length <= 3, 'Talking Island inside->outside route should not bounce between town waypoints');
+
+const talkingIslandEntrySteps = routeUntilTarget(talkingIslandField, talkingIslandCenter);
+assert.deepStrictEqual(
+    talkingIslandEntrySteps[talkingIslandEntrySteps.length - 1],
+    talkingIslandCenter,
+    'Talking Island outside->inside route should reach the town target instead of bouncing between internal nodes'
+);
+assert(talkingIslandEntrySteps.length <= 3, 'Talking Island outside->inside route should not bounce between town waypoints');
+
+const stickySession = {};
+const shiftedTalkingIslandField = { locX: -79850, locY: 250120, locZ: -3500 };
+const firstSticky = TownPathfinder.routeWithSession(stickySession, null, talkingIslandCenter, talkingIslandField);
+const secondSticky = TownPathfinder.routeWithSession(stickySession, null, talkingIslandCenter, shiftedTalkingIslandField);
+assert.deepStrictEqual(
+    secondSticky.to,
+    firstSticky.to,
+    'sticky town route should keep the current waypoint while the final target only drifts slightly'
+);
+assert.strictEqual(secondSticky.diagnostics.reason, 'sticky_waypoint');
 
 console.log('TownPathfinder regression checks passed');


### PR DESCRIPTION
## Summary
- keep bot town-routing waypoints sticky while follow targets drift slightly
- avoid restarting companion follow movement when the current follow waypoint is still valid
- add `.botpath` diagnostics for town-route and geodata movement visibility

## Validation
- node --check on changed JS files
- node tests\test_town_pathfinder.js
- node tests\test_party_companion_rest_follow.js
- full tests/*.js run
- git diff --check