### PR TITLE
Improve party companion state handling

### DIFF
--- a/src/GameServer/Bot/AI/BotAgentTools.js
+++ b/src/GameServer/Bot/AI/BotAgentTools.js
@@ -155,7 +155,10 @@ function applyBuffTarget(session, bot, decision, targetSession) {
     if (bot.fetchMp() < SUPPORT_BUFF_MP_COST) return { applied: false, reason: 'low_mp_for_buff' };
     if (distance2d(bot, target) > 900) return { applied: false, reason: 'target_too_far' };
 
-    const result = BotBuffs.applySupportBuff(targetSession, target, buffType, invoke(path.actor));
+    const result = BotBuffs.applySupportBuff(targetSession, target, buffType, invoke(path.actor), {
+        casterSession: session,
+        caster: bot
+    });
     if (!result) return { applied: false, reason: 'buff_failed' };
 
     bot.setMp(Math.max(0, bot.fetchMp() - SUPPORT_BUFF_MP_COST));

--- a/src/GameServer/Bot/AI/BotBrainContext.js
+++ b/src/GameServer/Bot/AI/BotBrainContext.js
@@ -48,7 +48,30 @@ function compactParty(party) {
     return {
         leader: party.leader?.name || null,
         stance: party.stance,
-        role: party.role
+        role: party.role,
+        members: (party.members || []).map((member) => ({
+            name: member.name,
+            role: member.role,
+            leader: !!member.leader,
+            self: !!member.self,
+            hpPct: pct(member.hpPct),
+            mpPct: pct(member.mpPct),
+            distance: member.distance ? Math.round(member.distance) : null,
+            dead: !!member.dead,
+            stance: member.stance || null
+        })),
+        threat: party.threat ? {
+            type: party.threat.type,
+            source: party.threat.source || null,
+            targetId: party.threat.targetId || null,
+            actor: compactTarget({
+                type: party.threat.type,
+                name: party.threat.actor?.name || null,
+                level: party.threat.actor?.level || null,
+                dead: party.threat.actor?.dead,
+                distance: party.threat.actor?.distance
+            })
+        } : null
     };
 }
 

--- a/src/GameServer/Bot/AI/BotBuffs.js
+++ b/src/GameServer/Bot/AI/BotBuffs.js
@@ -1,13 +1,14 @@
 const ServerResponse = invoke('GameServer/Network/Response');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
 
 const BUFF_DURATION_MS = 20 * 60 * 1000;
 const REFRESH_THRESHOLD_MS = 2 * 60 * 1000;
 
 const ALL_BUFFS = {
-    windwalk: { key: 'windWalk', id: 1204, name: 'Wind Walk' },
-    shield: { key: 'shield', id: 1040, name: 'Shield' },
-    haste: { key: 'haste', id: 1086, name: 'Haste' },
-    might: { key: 'might', id: 1068, name: 'Might' }
+    windwalk: { key: 'windWalk', id: 1204, level: 2, name: 'Wind Walk' },
+    shield: { key: 'shield', id: 1040, level: 2, name: 'Shield' },
+    haste: { key: 'haste', id: 1086, level: 2, name: 'Haste' },
+    might: { key: 'might', id: 1068, level: 2, name: 'Might' }
 };
 
 const NEWBIE_BUFF_TYPES = ['windwalk', 'shield', 'haste'];
@@ -31,6 +32,8 @@ function isNewbieEligible(actor) {
 }
 
 function remainingMs(actor, key) {
+    const effectRemaining = EffectStore.remainingMs(actor, key);
+    if (effectRemaining > 0) return effectRemaining;
     if (!actor?.activeBuffs?.[key]) return 0;
     return Math.max(0, actor.activeBuffs[key] - now());
 }
@@ -54,6 +57,12 @@ function refreshActorPackets(session, actor, Generics) {
 
     session.dataSendToMe(ServerResponse.userInfo(actor));
     session.dataSendToMe(ServerResponse.abnormalStatusUpdate.fromActor(actor));
+    try {
+        const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
+        PartyCompanionService.updateActorEffects(session);
+    } catch (err) {
+        utils.infoWarn('BotParty', 'party effect refresh failed: %s', err.message);
+    }
 
     if (session.accountId && String(session.accountId).startsWith('bot_')) {
         session.dataSendToOthers(ServerResponse.charInfo(actor), actor);
@@ -70,12 +79,30 @@ function nextSupportBuff(actor, thresholdMs = REFRESH_THRESHOLD_MS) {
     return SUPPORT_BUFF_TYPES.find((type) => needsBuff(actor, type, thresholdMs)) || null;
 }
 
-function applyBuff(session, actor, buffType, Generics) {
+function broadcastSkillCast(casterSession, caster, target, buff) {
+    if (!casterSession?.dataSendToMeAndOthers || !caster || !target || caster === target) return;
+    casterSession.dataSendToMeAndOthers(ServerResponse.skillStarted(caster, target.fetchId(), {
+        fetchSelfId: () => buff.id,
+        fetchCalculatedHitTime: () => 800,
+        fetchReuseTime: () => 1000
+    }), caster);
+}
+
+function applyBuff(session, actor, buffType, Generics, source = {}) {
     const buff = ALL_BUFFS[buffType];
     if (!buff || !actor) return null;
 
     const store = ensureStore(actor);
     store[buff.key] = now() + BUFF_DURATION_MS;
+    EffectStore.apply(actor, {
+        key: buff.key,
+        id: buff.id,
+        level: buff.level,
+        name: buff.name,
+        type: 'buff',
+        durationMs: BUFF_DURATION_MS
+    });
+    broadcastSkillCast(source.casterSession, source.caster, actor, buff);
     refreshActorPackets(session, actor, Generics);
 
     return {
@@ -85,14 +112,14 @@ function applyBuff(session, actor, buffType, Generics) {
     };
 }
 
-function applyNewbieBuff(session, actor, buffType, Generics) {
+function applyNewbieBuff(session, actor, buffType, Generics, source) {
     if (!NEWBIE_BUFFS[buffType]) return null;
-    return applyBuff(session, actor, buffType, Generics);
+    return applyBuff(session, actor, buffType, Generics, source);
 }
 
-function applySupportBuff(session, actor, buffType, Generics) {
+function applySupportBuff(session, actor, buffType, Generics, source) {
     if (!SUPPORT_BUFFS[buffType]) return null;
-    return applyBuff(session, actor, buffType, Generics);
+    return applyBuff(session, actor, buffType, Generics, source);
 }
 
 function applyFullNewbieBlessing(session, actor, Generics) {
@@ -102,6 +129,14 @@ function applyFullNewbieBlessing(session, actor, Generics) {
     const expiresAt = now() + BUFF_DURATION_MS;
     NEWBIE_BUFF_TYPES.map((type) => ALL_BUFFS[type]).forEach((buff) => {
         store[buff.key] = expiresAt;
+        EffectStore.apply(actor, {
+            key: buff.key,
+            id: buff.id,
+            level: buff.level,
+            name: buff.name,
+            type: 'buff',
+            expiresAt
+        });
     });
 
     actor.setHp(actor.fetchMaxHp());

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -2,6 +2,7 @@ const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
 const TownPathfinder = invoke('GameServer/Bot/AI/TownPathfinder');
 const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
+const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
 
 function ratio(value, max) {
     if (!max) return 0;
@@ -203,9 +204,11 @@ const BotStatus = {
         const role = BotRoles.inferRole(bot);
         const target = findTarget(session, bot);
         const leaderSession = session.followPlayerSession && session.partyCompanion === true ? session.followPlayerSession : null;
+        const partySettings = leaderSession ? PartyCompanionService.getSettings(leaderSession) : null;
         const party = leaderSession ? {
             leader: actorSummary(leaderSession.actor, bot),
             role,
+            settings: partySettings,
             stance: session.botStay ? 'stay' : 'follow',
             roleStance: BotRoles.partyRoleStance(role),
             autoTaunt: session.autoTaunt !== false,

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -1,6 +1,7 @@
 const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
 const TownPathfinder = invoke('GameServer/Bot/AI/TownPathfinder');
+const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
 
 function ratio(value, max) {
     if (!max) return 0;
@@ -34,6 +35,36 @@ function actorSummary(actor, fromActor) {
         distance: fromActor ? distance2d(loc, actorLocation(fromActor)) : null,
         dead: actor.state ? actor.state.fetchDead() : actor.isDead(),
         karma: typeof actor.fetchKarma === 'function' ? actor.fetchKarma() : 0
+    };
+}
+
+function partyMemberSummary(memberSession, leaderSession, bot) {
+    const actor = memberSession?.actor;
+    if (!actor) return null;
+
+    const summary = actorSummary(actor, bot);
+    if (!summary) return null;
+
+    return {
+        ...summary,
+        role: BotRoles.inferRole(actor),
+        leader: memberSession === leaderSession,
+        self: actor === bot,
+        hpPct: ratio(actor.fetchHp(), actor.fetchMaxHp()),
+        mpPct: ratio(actor.fetchMp(), actor.fetchMaxMp()),
+        stance: memberSession.botStay ? 'stay' : 'follow'
+    };
+}
+
+function partyThreatSummary(leaderSession, bot) {
+    const threat = PartyAwareness.findThreatTargetingParty(leaderSession);
+    if (!threat?.actor) return null;
+
+    return {
+        type: threat.type,
+        source: threat.source || null,
+        targetId: threat.targetId || null,
+        actor: actorSummary(threat.actor, bot)
     };
 }
 
@@ -171,13 +202,18 @@ const BotStatus = {
 
         const role = BotRoles.inferRole(bot);
         const target = findTarget(session, bot);
-        const party = session.followPlayerSession && session.partyCompanion === true ? {
-            leader: actorSummary(session.followPlayerSession.actor, bot),
+        const leaderSession = session.followPlayerSession && session.partyCompanion === true ? session.followPlayerSession : null;
+        const party = leaderSession ? {
+            leader: actorSummary(leaderSession.actor, bot),
             role,
             stance: session.botStay ? 'stay' : 'follow',
             roleStance: BotRoles.partyRoleStance(role),
             autoTaunt: session.autoTaunt !== false,
-            decision: session.roleDecision || null
+            decision: session.roleDecision || null,
+            members: PartyAwareness.partySessions(leaderSession)
+                .map((memberSession) => partyMemberSummary(memberSession, leaderSession, bot))
+                .filter(Boolean),
+            threat: partyThreatSummary(leaderSession, bot)
         } : null;
 
         const status = {

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -3,6 +3,7 @@ const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
 const TownPathfinder = invoke('GameServer/Bot/AI/TownPathfinder');
 const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
 const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
 
 function ratio(value, max) {
     if (!max) return 0;
@@ -249,6 +250,11 @@ const BotStatus = {
                 pathSummary: TownPathfinder.describeDiagnostics(session.lastPathfinding?.townRoute)
             },
             buffs: BotBuffs.snapshot(bot),
+            debuffs: EffectStore.activeDebuffs(bot).map((effect) => ({
+                key: effect.key,
+                name: effect.name,
+                remainingSec: Math.round(EffectStore.remainingMs(bot, effect.key) / 1000)
+            })),
             timers: {
                 deathStartedAt: session.deathTimerStart || null,
                 fleeStartedAt: session.fleeStart || null,

--- a/src/GameServer/Bot/AI/PartyCompanionService.js
+++ b/src/GameServer/Bot/AI/PartyCompanionService.js
@@ -1,0 +1,164 @@
+const ServerResponse = invoke('GameServer/Network/Response');
+
+function botSessions() {
+    const BotManager = invoke('GameServer/Bot/BotManager');
+    return BotManager.sessions || [];
+}
+
+function isActiveCompanion(session, leaderSession) {
+    return !!(
+        session &&
+        session.actor &&
+        session.followPlayerSession === leaderSession &&
+        session.partyCompanion === true
+    );
+}
+
+function membersForLeader(leaderSession) {
+    if (!leaderSession) return [];
+    return botSessions().filter((session) => isActiveCompanion(session, leaderSession));
+}
+
+function sendPartyWindow(leaderSession, distribution = 0) {
+    const leader = leaderSession?.actor;
+    if (!leader || !leaderSession.dataSendToMe) return;
+
+    const members = membersForLeader(leaderSession)
+        .map((session) => session.actor)
+        .filter(Boolean);
+
+    leaderSession.dataSendToMe(ServerResponse.partySmallWindowDeleteAll());
+    if (members.length > 0) {
+        leaderSession.dataSendToMe(ServerResponse.partySmallWindowAll(leader.fetchId(), distribution, members));
+    }
+}
+
+function renderPanel(leaderSession) {
+    if (!leaderSession?.actor) return;
+    try {
+        const CompanionControl = invoke('GameServer/World/Generics/NpcBypasses/CompanionControl');
+        if (CompanionControl?.render) {
+            CompanionControl.render(leaderSession);
+        }
+    } catch (err) {
+        utils.infoWarn('BotParty', 'companion panel refresh failed: %s', err.message);
+    }
+}
+
+function detachState(companionSession, plan = 'hunting') {
+    companionSession.plan = plan;
+    companionSession.followPlayerSession = null;
+    companionSession.partyCompanion = false;
+    companionSession.botStay = false;
+    companionSession.stayLocation = null;
+    companionSession.currentTargetId = undefined;
+    companionSession.roleDecision = null;
+    companionSession.actor?.unselect?.();
+}
+
+const PartyCompanionService = {
+    membersForLeader,
+
+    activeActorsForLeader(leaderSession) {
+        return membersForLeader(leaderSession).map((session) => session.actor).filter(Boolean);
+    },
+
+    rebuildWindow(leaderSession, distribution = 0) {
+        sendPartyWindow(leaderSession, distribution);
+    },
+
+    refreshPanel(leaderSession) {
+        renderPanel(leaderSession);
+    },
+
+    attach(leaderSession, companionSession, options = {}) {
+        const leader = leaderSession?.actor;
+        const bot = companionSession?.actor;
+        if (!leader || !bot) return false;
+
+        const previousLeader = companionSession.followPlayerSession;
+        const wasResting = companionSession.plan === 'resting';
+        const distribution = options.distribution || 1;
+
+        if (options.sendJoin !== false) {
+            leaderSession.dataSendToMe(ServerResponse.joinParty(distribution));
+        }
+
+        companionSession.plan = wasResting ? 'resting' : 'following';
+        companionSession.followPlayerSession = leaderSession;
+        companionSession.partyCompanion = true;
+        companionSession.botStay = false;
+        companionSession.stayLocation = null;
+        companionSession.currentTargetId = undefined;
+        companionSession.actor?.unselect?.();
+
+        if (previousLeader && previousLeader !== leaderSession) {
+            sendPartyWindow(previousLeader, 0);
+            renderPanel(previousLeader);
+        }
+
+        sendPartyWindow(leaderSession, 0);
+        renderPanel(leaderSession);
+        return true;
+    },
+
+    detach(leaderSession, companionSession, options = {}) {
+        if (!isActiveCompanion(companionSession, leaderSession)) return false;
+
+        const BotManager = invoke('GameServer/Bot/BotManager');
+        const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
+        const event = options.event || null;
+        const source = options.source || 'party';
+
+        if (event) {
+            BotSocialMemory.recordEvent(leaderSession, companionSession, event, source);
+        }
+
+        detachState(companionSession, options.plan || 'hunting');
+
+        if (options.message) {
+            BotManager.botSay(companionSession, options.message);
+        }
+
+        sendPartyWindow(leaderSession, 0);
+        renderPanel(leaderSession);
+        return true;
+    },
+
+    detachAll(leaderSession, options = {}) {
+        const members = membersForLeader(leaderSession);
+        members.forEach((memberSession) => {
+            this.detach(leaderSession, memberSession, {
+                ...options,
+                refresh: false
+            });
+        });
+        sendPartyWindow(leaderSession, 0);
+        renderPanel(leaderSession);
+        return members.length;
+    },
+
+    clearCompanion(companionSession, options = {}) {
+        const leaderSession = companionSession?.followPlayerSession || null;
+        if (!companionSession?.partyCompanion) return false;
+        detachState(companionSession, options.plan || 'hunting');
+        if (leaderSession) {
+            sendPartyWindow(leaderSession, 0);
+            renderPanel(leaderSession);
+        }
+        return true;
+    },
+
+    updateMember(companionSession) {
+        if (!companionSession?.followPlayerSession || companionSession.partyCompanion !== true || !companionSession.actor) {
+            return false;
+        }
+
+        const leaderSession = companionSession.followPlayerSession;
+        if (!leaderSession.actor?.fetchIsOnline?.()) return false;
+        leaderSession.dataSendToMe(ServerResponse.partySmallWindowUpdate(companionSession.actor));
+        return true;
+    }
+};
+
+module.exports = PartyCompanionService;

--- a/src/GameServer/Bot/AI/PartyCompanionService.js
+++ b/src/GameServer/Bot/AI/PartyCompanionService.js
@@ -129,13 +129,20 @@ function sendPartyWindow(leaderSession, distribution = 0) {
     const leader = leaderSession?.actor;
     if (!leader || !leaderSession.dataSendToMe) return;
 
-    const members = membersForLeader(leaderSession)
+    const memberSessions = membersForLeader(leaderSession);
+    const members = memberSessions
         .map((session) => session.actor)
         .filter(Boolean);
 
     leaderSession.dataSendToMe(ServerResponse.partySmallWindowDeleteAll());
     if (members.length > 0) {
         leaderSession.dataSendToMe(ServerResponse.partySmallWindowAll(leader.fetchId(), distribution, members));
+        leaderSession.dataSendToMe(ServerResponse.partySpelled.fromActor(leader));
+        memberSessions.forEach((memberSession) => {
+            if (memberSession.actor) {
+                leaderSession.dataSendToMe(ServerResponse.partySpelled.fromActor(memberSession.actor));
+            }
+        });
     }
 }
 
@@ -195,6 +202,23 @@ const PartyCompanionService = {
 
     refreshPanel(leaderSession) {
         renderPanel(leaderSession);
+    },
+
+    updateActorEffects(session) {
+        const actor = session?.actor;
+        if (!actor) return false;
+
+        if (session.partyCompanion === true && session.followPlayerSession?.dataSendToMe) {
+            session.followPlayerSession.dataSendToMe(ServerResponse.partySpelled.fromActor(actor));
+            return true;
+        }
+
+        if (membersForLeader(session).length > 0 && session.dataSendToMe) {
+            session.dataSendToMe(ServerResponse.partySpelled.fromActor(actor));
+            return true;
+        }
+
+        return false;
     },
 
     resolveLootSession(looterSession, selfId, target) {
@@ -318,6 +342,7 @@ const PartyCompanionService = {
         const leaderSession = companionSession.followPlayerSession;
         if (!leaderSession.actor?.fetchIsOnline?.()) return false;
         leaderSession.dataSendToMe(ServerResponse.partySmallWindowUpdate(companionSession.actor));
+        leaderSession.dataSendToMe(ServerResponse.partySpelled.fromActor(companionSession.actor));
         return true;
     }
 };

--- a/src/GameServer/Bot/AI/PartyCompanionService.js
+++ b/src/GameServer/Bot/AI/PartyCompanionService.js
@@ -1,6 +1,12 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 
 const DEFAULT_PARTY_DISTRIBUTION = 1;
+const DEFAULT_PARTY_SETTINGS = {
+    distribution: DEFAULT_PARTY_DISTRIBUTION,
+    movementMode: 'follow',
+    combatMode: 'assist',
+    pullMode: 'auto'
+};
 
 function hasOwn(object, key) {
     return Object.prototype.hasOwnProperty.call(object || {}, key);
@@ -13,14 +19,30 @@ function normalizeDistribution(distribution) {
 }
 
 function settingsForLeader(leaderSession) {
-    if (!leaderSession) return { distribution: DEFAULT_PARTY_DISTRIBUTION };
+    if (!leaderSession) return { ...DEFAULT_PARTY_SETTINGS };
     if (!leaderSession.partyCompanionSettings) {
-        leaderSession.partyCompanionSettings = { distribution: DEFAULT_PARTY_DISTRIBUTION };
+        leaderSession.partyCompanionSettings = { ...DEFAULT_PARTY_SETTINGS };
     }
-    if (!hasOwn(leaderSession.partyCompanionSettings, 'distribution')) {
-        leaderSession.partyCompanionSettings.distribution = DEFAULT_PARTY_DISTRIBUTION;
-    }
+    Object.keys(DEFAULT_PARTY_SETTINGS).forEach((key) => {
+        if (!hasOwn(leaderSession.partyCompanionSettings, key)) {
+            leaderSession.partyCompanionSettings[key] = DEFAULT_PARTY_SETTINGS[key];
+        }
+    });
     return leaderSession.partyCompanionSettings;
+}
+
+function getSettings(leaderSession) {
+    return { ...settingsForLeader(leaderSession) };
+}
+
+function updateSettings(leaderSession, patch = {}) {
+    const settings = settingsForLeader(leaderSession);
+    Object.keys(patch).forEach((key) => {
+        if (patch[key] !== undefined && patch[key] !== null) {
+            settings[key] = patch[key];
+        }
+    });
+    return getSettings(leaderSession);
 }
 
 function distributionForLeader(leaderSession) {
@@ -107,6 +129,10 @@ const PartyCompanionService = {
 
     distributionForLeader,
 
+    getSettings,
+
+    updateSettings,
+
     rebuildWindow(leaderSession, distribution) {
         const effectiveDistribution = arguments.length > 1
             ? setDistribution(leaderSession, distribution)
@@ -140,6 +166,7 @@ const PartyCompanionService = {
         companionSession.stayLocation = null;
         companionSession.currentTargetId = undefined;
         companionSession.actor?.unselect?.();
+        companionSession.autoTaunt = settingsForLeader(leaderSession).pullMode !== 'off';
 
         if (previousLeader && previousLeader !== leaderSession) {
             refreshLeaderView(previousLeader);

--- a/src/GameServer/Bot/AI/PartyCompanionService.js
+++ b/src/GameServer/Bot/AI/PartyCompanionService.js
@@ -1,5 +1,38 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 
+const DEFAULT_PARTY_DISTRIBUTION = 1;
+
+function hasOwn(object, key) {
+    return Object.prototype.hasOwnProperty.call(object || {}, key);
+}
+
+function normalizeDistribution(distribution) {
+    if (distribution === undefined || distribution === null) return DEFAULT_PARTY_DISTRIBUTION;
+    const value = Number(distribution);
+    return Number.isFinite(value) ? value : DEFAULT_PARTY_DISTRIBUTION;
+}
+
+function settingsForLeader(leaderSession) {
+    if (!leaderSession) return { distribution: DEFAULT_PARTY_DISTRIBUTION };
+    if (!leaderSession.partyCompanionSettings) {
+        leaderSession.partyCompanionSettings = { distribution: DEFAULT_PARTY_DISTRIBUTION };
+    }
+    if (!hasOwn(leaderSession.partyCompanionSettings, 'distribution')) {
+        leaderSession.partyCompanionSettings.distribution = DEFAULT_PARTY_DISTRIBUTION;
+    }
+    return leaderSession.partyCompanionSettings;
+}
+
+function distributionForLeader(leaderSession) {
+    return normalizeDistribution(settingsForLeader(leaderSession).distribution);
+}
+
+function setDistribution(leaderSession, distribution) {
+    const settings = settingsForLeader(leaderSession);
+    settings.distribution = normalizeDistribution(distribution);
+    return settings.distribution;
+}
+
 function botSessions() {
     const BotManager = invoke('GameServer/Bot/BotManager');
     return BotManager.sessions || [];
@@ -47,7 +80,7 @@ function renderPanel(leaderSession) {
 
 function refreshLeaderView(leaderSession, options = {}) {
     if (options.rebuildWindow !== false) {
-        sendPartyWindow(leaderSession, 0);
+        sendPartyWindow(leaderSession, distributionForLeader(leaderSession));
     }
     if (options.refreshPanel !== false) {
         renderPanel(leaderSession);
@@ -72,8 +105,13 @@ const PartyCompanionService = {
         return membersForLeader(leaderSession).map((session) => session.actor).filter(Boolean);
     },
 
-    rebuildWindow(leaderSession, distribution = 0) {
-        sendPartyWindow(leaderSession, distribution);
+    distributionForLeader,
+
+    rebuildWindow(leaderSession, distribution) {
+        const effectiveDistribution = arguments.length > 1
+            ? setDistribution(leaderSession, distribution)
+            : distributionForLeader(leaderSession);
+        sendPartyWindow(leaderSession, effectiveDistribution);
     },
 
     refreshPanel(leaderSession) {
@@ -87,7 +125,9 @@ const PartyCompanionService = {
 
         const previousLeader = companionSession.followPlayerSession;
         const wasResting = companionSession.plan === 'resting';
-        const distribution = options.distribution || 1;
+        const distribution = hasOwn(options, 'distribution')
+            ? setDistribution(leaderSession, options.distribution)
+            : distributionForLeader(leaderSession);
 
         if (options.sendJoin !== false) {
             leaderSession.dataSendToMe(ServerResponse.joinParty(distribution));

--- a/src/GameServer/Bot/AI/PartyCompanionService.js
+++ b/src/GameServer/Bot/AI/PartyCompanionService.js
@@ -45,6 +45,15 @@ function renderPanel(leaderSession) {
     }
 }
 
+function refreshLeaderView(leaderSession, options = {}) {
+    if (options.rebuildWindow !== false) {
+        sendPartyWindow(leaderSession, 0);
+    }
+    if (options.refreshPanel !== false) {
+        renderPanel(leaderSession);
+    }
+}
+
 function detachState(companionSession, plan = 'hunting') {
     companionSession.plan = plan;
     companionSession.followPlayerSession = null;
@@ -93,12 +102,10 @@ const PartyCompanionService = {
         companionSession.actor?.unselect?.();
 
         if (previousLeader && previousLeader !== leaderSession) {
-            sendPartyWindow(previousLeader, 0);
-            renderPanel(previousLeader);
+            refreshLeaderView(previousLeader);
         }
 
-        sendPartyWindow(leaderSession, 0);
-        renderPanel(leaderSession);
+        refreshLeaderView(leaderSession);
         return true;
     },
 
@@ -120,8 +127,7 @@ const PartyCompanionService = {
             BotManager.botSay(companionSession, options.message);
         }
 
-        sendPartyWindow(leaderSession, 0);
-        renderPanel(leaderSession);
+        refreshLeaderView(leaderSession, options);
         return true;
     },
 
@@ -130,11 +136,11 @@ const PartyCompanionService = {
         members.forEach((memberSession) => {
             this.detach(leaderSession, memberSession, {
                 ...options,
-                refresh: false
+                rebuildWindow: false,
+                refreshPanel: false
             });
         });
-        sendPartyWindow(leaderSession, 0);
-        renderPanel(leaderSession);
+        refreshLeaderView(leaderSession, options);
         return members.length;
     },
 
@@ -143,8 +149,7 @@ const PartyCompanionService = {
         if (!companionSession?.partyCompanion) return false;
         detachState(companionSession, options.plan || 'hunting');
         if (leaderSession) {
-            sendPartyWindow(leaderSession, 0);
-            renderPanel(leaderSession);
+            refreshLeaderView(leaderSession, options);
         }
         return true;
     },

--- a/src/GameServer/Bot/AI/PartyCompanionService.js
+++ b/src/GameServer/Bot/AI/PartyCompanionService.js
@@ -9,6 +9,16 @@ const DEFAULT_PARTY_SETTINGS = {
     itemLastLootIndex: -1
 };
 const PARTY_LOOT_RADIUS = 2500;
+const FORMATION_OFFSETS = [
+    { locX: -90, locY: -70 },
+    { locX: -90, locY: 70 },
+    { locX: -170, locY: -120 },
+    { locX: -170, locY: 120 },
+    { locX: -250, locY: 0 },
+    { locX: -250, locY: -170 },
+    { locX: -250, locY: 170 },
+    { locX: -330, locY: 0 }
+];
 
 function hasOwn(object, key) {
     return Object.prototype.hasOwnProperty.call(object || {}, key);
@@ -125,6 +135,29 @@ function nextTurnMember(leaderSession, members) {
     return members[nextIndex];
 }
 
+function formationSlotFor(companionSession) {
+    const leaderSession = companionSession?.followPlayerSession;
+    const members = membersForLeader(leaderSession);
+    const index = Math.max(0, members.indexOf(companionSession));
+    return {
+        index,
+        offset: FORMATION_OFFSETS[index % FORMATION_OFFSETS.length]
+    };
+}
+
+function formationTargetFor(companionSession) {
+    const leader = companionSession?.followPlayerSession?.actor;
+    if (!leader) return null;
+
+    const slot = formationSlotFor(companionSession);
+    return {
+        locX: leader.fetchLocX() + slot.offset.locX,
+        locY: leader.fetchLocY() + slot.offset.locY,
+        locZ: leader.fetchLocZ(),
+        slot: slot.index
+    };
+}
+
 function sendPartyWindow(leaderSession, distribution = 0) {
     const leader = leaderSession?.actor;
     if (!leader || !leaderSession.dataSendToMe) return;
@@ -184,6 +217,10 @@ const PartyCompanionService = {
     activeActorsForLeader(leaderSession) {
         return membersForLeader(leaderSession).map((session) => session.actor).filter(Boolean);
     },
+
+    formationSlotFor,
+
+    formationTargetFor,
 
     lootMembersForLeader,
 

--- a/src/GameServer/Bot/AI/PartyCompanionService.js
+++ b/src/GameServer/Bot/AI/PartyCompanionService.js
@@ -5,8 +5,10 @@ const DEFAULT_PARTY_SETTINGS = {
     distribution: DEFAULT_PARTY_DISTRIBUTION,
     movementMode: 'follow',
     combatMode: 'assist',
-    pullMode: 'auto'
+    pullMode: 'auto',
+    itemLastLootIndex: -1
 };
+const PARTY_LOOT_RADIUS = 2500;
 
 function hasOwn(object, key) {
     return Object.prototype.hasOwnProperty.call(object || {}, key);
@@ -69,9 +71,58 @@ function isActiveCompanion(session, leaderSession) {
     );
 }
 
+function distance2d(a, b) {
+    const dx = a.fetchLocX() - b.fetchLocX();
+    const dy = a.fetchLocY() - b.fetchLocY();
+    return Math.sqrt((dx * dx) + (dy * dy));
+}
+
+function isAliveOnline(session) {
+    const actor = session?.actor;
+    return actor && actor.fetchIsOnline?.() === true && !actor.isDead?.();
+}
+
+function partyLeaderSession(session) {
+    if (session?.partyCompanion === true && session.followPlayerSession) {
+        return session.followPlayerSession;
+    }
+    return session;
+}
+
 function membersForLeader(leaderSession) {
     if (!leaderSession) return [];
     return botSessions().filter((session) => isActiveCompanion(session, leaderSession));
+}
+
+function lootMembersForLeader(leaderSession, target) {
+    const members = [leaderSession, ...membersForLeader(leaderSession)]
+        .filter(isAliveOnline);
+
+    if (!target?.fetchLocX || !target?.fetchLocY) {
+        return members;
+    }
+
+    return members.filter((memberSession) => (
+        memberSession.actor?.fetchLocX &&
+        distance2d(memberSession.actor, target) <= PARTY_LOOT_RADIUS
+    ));
+}
+
+function randomMember(members) {
+    if (members.length === 0) return null;
+    const index = Math.min(members.length - 1, Math.floor(Math.random() * members.length));
+    return members[index];
+}
+
+function nextTurnMember(leaderSession, members) {
+    if (members.length === 0) return null;
+
+    const settings = settingsForLeader(leaderSession);
+    const rawLastIndex = Number(settings.itemLastLootIndex);
+    const lastIndex = Number.isFinite(rawLastIndex) ? rawLastIndex : -1;
+    const nextIndex = (lastIndex + 1) % members.length;
+    settings.itemLastLootIndex = nextIndex;
+    return members[nextIndex];
 }
 
 function sendPartyWindow(leaderSession, distribution = 0) {
@@ -127,6 +178,8 @@ const PartyCompanionService = {
         return membersForLeader(leaderSession).map((session) => session.actor).filter(Boolean);
     },
 
+    lootMembersForLeader,
+
     distributionForLeader,
 
     getSettings,
@@ -142,6 +195,42 @@ const PartyCompanionService = {
 
     refreshPanel(leaderSession) {
         renderPanel(leaderSession);
+    },
+
+    resolveLootSession(looterSession, selfId, target) {
+        const leaderSession = partyLeaderSession(looterSession);
+        const members = lootMembersForLeader(leaderSession, target);
+        if (!leaderSession || members.length <= 1) return looterSession;
+
+        const distribution = distributionForLeader(leaderSession);
+        if (distribution === 1 || distribution === 2) {
+            return randomMember(members) || looterSession;
+        }
+        if (distribution === 3 || distribution === 4) {
+            return nextTurnMember(leaderSession, members) || looterSession;
+        }
+        return members.includes(looterSession) ? looterSession : (leaderSession || looterSession);
+    },
+
+    adenaAllocations(looterSession, amount, target) {
+        const total = Math.max(0, Math.floor(Number(amount) || 0));
+        if (total <= 0) return [];
+
+        const leaderSession = partyLeaderSession(looterSession);
+        const members = lootMembersForLeader(leaderSession, target);
+        if (!leaderSession || members.length <= 1) {
+            return [{ session: looterSession, amount: total }];
+        }
+
+        const share = Math.floor(total / members.length);
+        let remainder = total - (share * members.length);
+        return members
+            .map((memberSession) => {
+                const extra = remainder > 0 ? 1 : 0;
+                remainder -= extra;
+                return { session: memberSession, amount: share + extra };
+            })
+            .filter((entry) => entry.amount > 0);
     },
 
     attach(leaderSession, companionSession, options = {}) {

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -222,6 +222,14 @@ function assistReasonForRole(role) {
     return 'leader_target';
 }
 
+function followTargetFor(session, player) {
+    return PartyCompanionService.formationTargetFor(session) || {
+        locX: player.fetchLocX(),
+        locY: player.fetchLocY(),
+        locZ: player.fetchLocZ()
+    };
+}
+
 function supportBuffPhrase(buffType, playerName) {
     if (buffType === 'might') return "Might on " + playerName + ". Hit harder!";
     if (buffType === 'shield') return "Shield on " + playerName + ". Stay sturdy.";
@@ -308,9 +316,7 @@ module.exports = {
             const TeleportTo = invoke('GameServer/Actor/Generics/TeleportTo');
             if (TeleportTo && typeof TeleportTo === 'function') {
                 const targetLoc = {
-                    locX: player.fetchLocX() + utils.oneFromSpan(-60, 60),
-                    locY: player.fetchLocY() + utils.oneFromSpan(-60, 60),
-                    locZ: player.fetchLocZ()
+                    ...followTargetFor(session, player)
                 };
                 TeleportTo(session, bot, targetLoc);
                 if (Math.random() < 0.20) {
@@ -340,11 +346,7 @@ module.exports = {
                 standUp(session, bot);
                 recordRoleDecision(session, bot, 'rest_with_leader', 'move_near_sitting_leader');
                 if (!shouldKeepCurrentFollowMove(session, bot, player, distance)) {
-                    const followTarget = {
-                        locX: player.fetchLocX() + utils.oneFromSpan(-60, 60),
-                        locY: player.fetchLocY() + utils.oneFromSpan(-60, 60),
-                        locZ: player.fetchLocZ()
-                    };
+                    const followTarget = followTargetFor(session, player);
                     session.lastFollowMoveTarget = followTarget;
                     bot.moveTo({
                         from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
@@ -720,11 +722,7 @@ module.exports = {
                     session.lastFollowMoveHeldAt = Date.now();
                     return;
                 }
-                const followTarget = {
-                    locX: player.fetchLocX() + utils.oneFromSpan(-60, 60),
-                    locY: player.fetchLocY() + utils.oneFromSpan(-60, 60),
-                    locZ: player.fetchLocZ()
-                };
+                const followTarget = followTargetFor(session, player);
                 session.lastFollowMoveTarget = followTarget;
                 bot.moveTo({
                     from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -4,6 +4,7 @@ const ServerResponse = invoke('GameServer/Network/Response');
 const BotRoles       = invoke('GameServer/Bot/AI/BotRoles');
 const BotBuffs       = invoke('GameServer/Bot/AI/BotBuffs');
 const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
+const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
 
 const SUPPORT_BUFF_MP_COST = 20;
 const FOLLOW_RUN_DISTANCE = 250;
@@ -248,8 +249,15 @@ module.exports = {
         const player = playerSession.actor;
         const role = BotRoles.inferRole(bot);
         const distance = point(bot).distance(point(player));
-        const partyThreat = PartyAwareness.findThreatTargetingParty(playerSession);
-        const leaderTargetId = PartyAwareness.leaderCombatTargetId(playerSession);
+        const partySettings = PartyCompanionService.getSettings(playerSession);
+        const combatMode = partySettings.combatMode || 'assist';
+        const rawPartyThreat = PartyAwareness.findThreatTargetingParty(playerSession);
+        const partyThreat = combatMode === 'passive' && rawPartyThreat?.targetId !== bot.fetchId()
+            ? null
+            : rawPartyThreat;
+        const leaderTargetId = combatMode === 'assist'
+            ? PartyAwareness.leaderCombatTargetId(playerSession)
+            : undefined;
 
         const currentLoc = { x: bot.fetchLocX(), y: bot.fetchLocY() };
         if (!session.lastTickLoc) {

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -5,6 +5,7 @@ const BotRoles       = invoke('GameServer/Bot/AI/BotRoles');
 const BotBuffs       = invoke('GameServer/Bot/AI/BotBuffs');
 const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
 const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
+const EffectStore    = invoke('GameServer/Effects/EffectStore');
 
 const SUPPORT_BUFF_MP_COST = 20;
 const FOLLOW_RUN_DISTANCE = 250;
@@ -258,6 +259,14 @@ module.exports = {
         const leaderTargetId = combatMode === 'assist'
             ? PartyAwareness.leaderCombatTargetId(playerSession)
             : undefined;
+        const impairments = EffectStore.impairments(bot);
+
+        if (impairments.disabled) {
+            session.currentTargetId = undefined;
+            bot.unselect();
+            recordRoleDecision(session, bot, 'disabled', 'debuff_control');
+            return;
+        }
 
         const currentLoc = { x: bot.fetchLocX(), y: bot.fetchLocY() };
         if (!session.lastTickLoc) {
@@ -285,6 +294,11 @@ module.exports = {
                 partyThreat || leaderTargetId ? assistActionForRole(role) : 'follow_leader',
                 partyThreat ? 'party_under_attack' : (leaderTargetId ? assistReasonForRole(role) : 'leader_moved')
             );
+            return;
+        }
+
+        if (impairments.rooted && !partyThreat && !leaderTargetId && distance > FOLLOW_RUN_DISTANCE) {
+            recordRoleDecision(session, bot, 'hold_position', 'rooted');
             return;
         }
 
@@ -407,6 +421,9 @@ module.exports = {
                     activeMobs
                 });
                 keepRoleDecision = true;
+            } else if (impairments.silenced) {
+                recordRoleDecision(session, bot, 'save_mp', 'silenced');
+                keepRoleDecision = true;
             } else if (bot.fetchMp() < SUPPORT_BUFF_MP_COST || botVitals.mpRatio < 0.35) {
                 recordRoleDecision(session, bot, 'save_mp', 'low_mp_for_buff', {
                     buff: supportBuffTarget.buff,
@@ -414,7 +431,10 @@ module.exports = {
                 });
                 keepRoleDecision = true;
             } else {
-                const result = BotBuffs.applySupportBuff(supportBuffTarget.session, supportBuffTarget.actor, supportBuffTarget.buff, Generics);
+                const result = BotBuffs.applySupportBuff(supportBuffTarget.session, supportBuffTarget.actor, supportBuffTarget.buff, Generics, {
+                    casterSession: session,
+                    caster: bot
+                });
                 if (result) {
                     acted = true;
                     bot.setMp(Math.max(0, bot.fetchMp() - SUPPORT_BUFF_MP_COST));
@@ -470,7 +490,7 @@ module.exports = {
 
         if (role === 'healer') {
             const skill = healSkill(bot);
-            const canCast = bot.fetchMp() >= skill.fetchConsumedMp() && !isBusy(bot);
+            const canCast = bot.fetchMp() >= skill.fetchConsumedMp() && !isBusy(bot) && !impairments.silenced;
             const woundedPartyMember = weakestPartyMember(playerSession, bot);
 
             if (woundedPartyMember?.hpRatio < 0.45 && canCast) {
@@ -497,6 +517,9 @@ module.exports = {
                 if (Math.random() < 0.15) {
                     BotAI.say(session, "Healing myself!");
                 }
+            } else if (impairments.silenced) {
+                recordRoleDecision(session, bot, 'save_mp', 'silenced');
+                keepRoleDecision = true;
             } else if (botVitals.mpRatio < 0.25) {
                 recordRoleDecision(session, bot, 'save_mp', 'low_mp');
                 keepRoleDecision = true;
@@ -686,6 +709,10 @@ module.exports = {
                     });
                 }
             } else if (distance > FOLLOW_RUN_DISTANCE) {
+                if (impairments.rooted) {
+                    recordRoleDecision(session, bot, 'hold_position', 'rooted');
+                    return;
+                }
                 if (!keepRoleDecision) {
                     recordRoleDecision(session, bot, 'follow_leader', 'keep_range');
                 }

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -128,24 +128,80 @@ function castSkillOn(session, bot, Generics, target, skillId, ctrl) {
     Generics.skillExec(session, bot, { id: target.fetchId(), selfId: skillId, ctrl });
 }
 
-function leaderAggroCount(player) {
-    return World.fetchNpcsInRadius(player.fetchLocX(), player.fetchLocY(), 900)
-        .filter((npc) => npc.fetchAttackable() && !npc.isDead() && npc.fetchDestId() === player.fetchId())
+function partyActorIds(leaderSession) {
+    return new Set(PartyAwareness.partyActors(leaderSession)
+        .map((actor) => actor.fetchId())
+        .filter((id) => id !== null && id !== undefined));
+}
+
+function partyAggroCount(leaderSession) {
+    const ids = partyActorIds(leaderSession);
+    if (ids.size === 0) return 0;
+
+    const seen = new Set();
+    return PartyAwareness.partyActors(leaderSession).flatMap((actor) => (
+        World.fetchNpcsInRadius(actor.fetchLocX(), actor.fetchLocY(), 900)
+    ))
+        .filter((npc) => {
+            const id = npc.fetchId?.() || npc;
+            if (seen.has(id)) return false;
+            seen.add(id);
+            return true;
+        })
+        .filter((npc) => npc.fetchAttackable() && !npc.isDead() && ids.has(npc.fetchDestId()))
         .length;
 }
 
-function unsafeSupportMoment(session, bot, player, activeMobs) {
+function unsafeSupportMoment(session, bot, target, activeMobs) {
     return !!session.currentTargetId ||
-        !!player.fetchDestId() ||
+        !!target.fetchDestId() ||
         activeMobs > 0 ||
         isBusy(bot);
 }
 
-function pullBlockReason(session, botVitals, leaderVitals, activeMobs) {
+function partyMembersInSupportRange(leaderSession, bot, maxDistance = 900) {
+    return PartyAwareness.partySessions(leaderSession)
+        .filter((memberSession) => memberSession.actor && !memberSession.actor.isDead?.())
+        .map((memberSession) => ({
+            session: memberSession,
+            actor: memberSession.actor,
+            hpRatio: ratio(memberSession.actor.fetchHp(), memberSession.actor.fetchMaxHp()),
+            mpRatio: ratio(memberSession.actor.fetchMp(), memberSession.actor.fetchMaxMp()),
+            distance: point(bot).distance(point(memberSession.actor))
+        }))
+        .filter((entry) => entry.distance <= maxDistance);
+}
+
+function weakestPartyMember(leaderSession, bot, maxDistance = 900) {
+    return partyMembersInSupportRange(leaderSession, bot, maxDistance)
+        .filter((entry) => entry.actor !== bot)
+        .sort((a, b) => a.hpRatio - b.hpRatio)[0] || null;
+}
+
+function weakestPartyVitals(leaderSession, bot) {
+    return partyMembersInSupportRange(leaderSession, bot)
+        .reduce((lowest, entry) => !lowest || entry.hpRatio < lowest.hpRatio ? entry : lowest, null);
+}
+
+function nextSupportBuffTarget(leaderSession, bot) {
+    return partyMembersInSupportRange(leaderSession, bot)
+        .sort((a, b) => {
+            const aRank = a.session === leaderSession ? 0 : (a.actor === bot ? 2 : 1);
+            const bRank = b.session === leaderSession ? 0 : (b.actor === bot ? 2 : 1);
+            return aRank - bRank;
+        })
+        .map((entry) => ({
+            ...entry,
+            buff: BotBuffs.nextSupportBuff(entry.actor)
+        }))
+        .find((entry) => entry.buff) || null;
+}
+
+function pullBlockReason(session, botVitals, partyVitals, activeMobs) {
     if (session.autoTaunt === false) return 'manual_pull_off';
     if (session.botStay) return 'stay_order';
     if (session.currentTargetId) return 'already_assisting';
-    if (leaderVitals.hpRatio < 0.65) return 'leader_low_hp';
+    if (partyVitals?.hpRatio < 0.65) return 'party_low_hp';
     if (botVitals.hpRatio < 0.55) return 'tank_low_hp';
     if (botVitals.mpRatio < 0.25) return 'save_mp';
     if (activeMobs >= 2) return 'active_mobs';
@@ -250,6 +306,7 @@ module.exports = {
             hpRatio: ratio(player.fetchHp(), player.fetchMaxHp()),
             mpRatio: ratio(player.fetchMp(), player.fetchMaxMp())
         };
+        const partyVitals = weakestPartyVitals(playerSession, bot) || leaderVitals;
         const leaderSeated = player.state?.fetchSeated?.() === true;
         const botRecovering = botVitals.hpRatio < 0.95 || botVitals.mpRatio < 0.95;
 
@@ -302,7 +359,7 @@ module.exports = {
 
         const buffsNeedRefresh = BotBuffs.needsNewbieRefresh(bot);
         if (buffsNeedRefresh) {
-            const unsafeToRefresh = unsafeSupportMoment(session, bot, player, leaderAggroCount(player));
+            const unsafeToRefresh = unsafeSupportMoment(session, bot, player, partyAggroCount(playerSession));
 
             if (unsafeToRefresh || session.partyCompanion === true) {
                 recordRoleDecision(session, bot, 'refresh_buffs', 'wait_for_safe_moment', {
@@ -332,34 +389,34 @@ module.exports = {
             }
         }
 
-        const nextSupportBuff = BotBuffs.nextSupportBuff(player);
-        if (!acted && BotRoles.canBuff(bot) && nextSupportBuff) {
-            const activeMobs = leaderAggroCount(player);
-            if (unsafeSupportMoment(session, bot, player, activeMobs)) {
+        const supportBuffTarget = nextSupportBuffTarget(playerSession, bot);
+        if (!acted && BotRoles.canBuff(bot) && supportBuffTarget) {
+            const activeMobs = partyAggroCount(playerSession);
+            if (unsafeSupportMoment(session, bot, supportBuffTarget.actor, activeMobs)) {
                 recordRoleDecision(session, bot, 'buff_party', 'wait_for_safe_moment', {
-                    buff: nextSupportBuff,
-                    targetId: player.fetchId(),
+                    buff: supportBuffTarget.buff,
+                    targetId: supportBuffTarget.actor.fetchId(),
                     activeMobs
                 });
                 keepRoleDecision = true;
             } else if (bot.fetchMp() < SUPPORT_BUFF_MP_COST || botVitals.mpRatio < 0.35) {
                 recordRoleDecision(session, bot, 'save_mp', 'low_mp_for_buff', {
-                    buff: nextSupportBuff,
-                    targetId: player.fetchId()
+                    buff: supportBuffTarget.buff,
+                    targetId: supportBuffTarget.actor.fetchId()
                 });
                 keepRoleDecision = true;
             } else {
-                const result = BotBuffs.applySupportBuff(playerSession, player, nextSupportBuff, Generics);
+                const result = BotBuffs.applySupportBuff(supportBuffTarget.session, supportBuffTarget.actor, supportBuffTarget.buff, Generics);
                 if (result) {
                     acted = true;
                     bot.setMp(Math.max(0, bot.fetchMp() - SUPPORT_BUFF_MP_COST));
                     bot.statusUpdateVitals(bot);
-                    recordRoleDecision(session, bot, 'buff_party', nextSupportBuff, {
-                        buff: nextSupportBuff,
-                        targetId: player.fetchId()
+                    recordRoleDecision(session, bot, 'buff_party', supportBuffTarget.buff, {
+                        buff: supportBuffTarget.buff,
+                        targetId: supportBuffTarget.actor.fetchId()
                     });
                     if (Math.random() < 0.30) {
-                        BotAI.say(session, supportBuffPhrase(nextSupportBuff, player.fetchName()));
+                        BotAI.say(session, supportBuffPhrase(supportBuffTarget.buff, supportBuffTarget.actor.fetchName()));
                     }
                 }
             }
@@ -406,23 +463,24 @@ module.exports = {
         if (role === 'healer') {
             const skill = healSkill(bot);
             const canCast = bot.fetchMp() >= skill.fetchConsumedMp() && !isBusy(bot);
+            const woundedPartyMember = weakestPartyMember(playerSession, bot);
 
-            if (leaderVitals.hpRatio < 0.45 && canCast) {
+            if (woundedPartyMember?.hpRatio < 0.45 && canCast) {
                 acted = true;
-                recordRoleDecision(session, bot, 'heal_leader', 'emergency_heal', { targetId: player.fetchId() });
-                castSkillOn(session, bot, Generics, player, 1011, false);
+                recordRoleDecision(session, bot, 'heal_party', 'emergency_heal', { targetId: woundedPartyMember.actor.fetchId() });
+                castSkillOn(session, bot, Generics, woundedPartyMember.actor, 1011, false);
                 if (Math.random() < 0.15) {
-                    BotAI.say(session, "Emergency heal on " + player.fetchName() + "!");
+                    BotAI.say(session, "Emergency heal on " + woundedPartyMember.actor.fetchName() + "!");
                 }
-            } else if (leaderVitals.hpRatio < 0.70 && botVitals.mpRatio >= 0.35 && canCast) {
+            } else if (woundedPartyMember?.hpRatio < 0.70 && botVitals.mpRatio >= 0.35 && canCast) {
                 acted = true;
-                recordRoleDecision(session, bot, 'heal_leader', 'top_off', { targetId: player.fetchId() });
-                castSkillOn(session, bot, Generics, player, 1011, false);
+                recordRoleDecision(session, bot, 'heal_party', 'top_off', { targetId: woundedPartyMember.actor.fetchId() });
+                castSkillOn(session, bot, Generics, woundedPartyMember.actor, 1011, false);
                 if (Math.random() < 0.15) {
-                    BotAI.say(session, "Healing you, " + player.fetchName() + "!");
+                    BotAI.say(session, "Healing " + woundedPartyMember.actor.fetchName() + "!");
                 }
-            } else if (leaderVitals.hpRatio < 0.70 && botVitals.mpRatio < 0.35) {
-                recordRoleDecision(session, bot, 'save_mp', leaderVitals.hpRatio < 0.45 ? 'low_mp_emergency' : 'leader_not_critical');
+            } else if (woundedPartyMember?.hpRatio < 0.70 && botVitals.mpRatio < 0.35) {
+                recordRoleDecision(session, bot, 'save_mp', woundedPartyMember.hpRatio < 0.45 ? 'low_mp_emergency' : 'party_not_critical');
                 keepRoleDecision = true;
             } else if (botVitals.hpRatio < 0.55 && botVitals.mpRatio >= 0.25 && canCast) {
                 acted = true;
@@ -439,7 +497,9 @@ module.exports = {
 
         if (!acted && role === 'tank') {
             const nearbyNpcs = World.fetchNpcsInRadius(bot.fetchLocX(), bot.fetchLocY(), 800);
-            const monsterToAggro = nearbyNpcs.find((npc) => npc.fetchAttackable() && !npc.isDead() && npc.fetchDestId() === player.fetchId());
+            const monsterToAggro = partyThreat?.type === 'npc'
+                ? partyThreat.actor
+                : nearbyNpcs.find((npc) => npc.fetchAttackable() && !npc.isDead() && partyActorIds(playerSession).has(npc.fetchDestId()));
 
             if (monsterToAggro) {
                 const skill = aggressionSkill(bot);
@@ -458,8 +518,8 @@ module.exports = {
         }
 
         if (!acted && role === 'tank') {
-            const activeMobs = leaderAggroCount(player);
-            const blockReason = pullBlockReason(session, botVitals, leaderVitals, activeMobs);
+            const activeMobs = partyAggroCount(playerSession);
+            const blockReason = pullBlockReason(session, botVitals, partyVitals, activeMobs);
 
             if (blockReason) {
                 recordRoleDecision(session, bot, 'avoid_overpull', blockReason, { activeMobs });

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -4,6 +4,7 @@ const BotStatus      = invoke('GameServer/Bot/AI/BotStatus');
 const BotRoles       = invoke('GameServer/Bot/AI/BotRoles');
 const PopulationService = invoke('GameServer/Bot/Population/PopulationService');
 const BotEquipmentUpgrade = invoke('GameServer/Bot/AI/BotEquipmentUpgrade');
+const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
 
 const CHAT_PHRASES = {
     foundTarget: [
@@ -287,12 +288,7 @@ const BotAI = {
 
         // If bot is a companion, dynamically refresh player's party HUD sidebar HP/MP bars
         if (session.followPlayerSession && session.partyCompanion === true) {
-            const playerSession = session.followPlayerSession;
-            if (playerSession && playerSession.actor && playerSession.actor.fetchIsOnline()) {
-                playerSession.dataSendToMe(
-                    ServerResponse.partySmallWindowUpdate(bot)
-                );
-            }
+            PartyCompanionService.updateMember(session);
         }
 
         const Generics = invoke(path.actor);

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -295,6 +295,7 @@ const BotAI = {
 
         // 1. Handle Death State
         if (bot.isDead()) {
+            const wasCompanion = session.partyCompanion === true && !!session.followPlayerSession;
             if (!session.deathTimerStart) {
                 session.deathTimerStart = Date.now();
                 this.say(session, "Oops... I died! Resurrecting shortly.");
@@ -325,19 +326,40 @@ const BotAI = {
                             locZ: session.initialSpawnCoord.locZ
                         };
                     } else {
-                        session.plan = 'hunting'; // Reset plan
-                        
-                        // Teleport back to spawn coordinate to prevent getting stuck in deep water
-                        if (!session.initialSpawnCoord) {
-                            session.initialSpawnCoord = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
+                        const leader = session.followPlayerSession?.actor;
+                        if (wasCompanion && leader?.fetchIsOnline?.()) {
+                            session.plan = 'following';
+                            spawnTarget = session.botStay && session.stayLocation ? {
+                                locX: session.stayLocation.locX,
+                                locY: session.stayLocation.locY,
+                                locZ: session.stayLocation.locZ
+                            } : {
+                                locX: leader.fetchLocX() + utils.oneFromSpan(-80, 80),
+                                locY: leader.fetchLocY() + utils.oneFromSpan(-80, 80),
+                                locZ: leader.fetchLocZ()
+                            };
+                        } else {
+                            if (wasCompanion) {
+                                PartyCompanionService.clearCompanion(session, {
+                                    plan: 'hunting',
+                                    rebuildWindow: false,
+                                    refreshPanel: false
+                                });
+                            }
+                            session.plan = 'hunting'; // Reset plan
+                            
+                            // Teleport back to spawn coordinate to prevent getting stuck in deep water
+                            if (!session.initialSpawnCoord) {
+                                session.initialSpawnCoord = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
+                            }
+                            
+                            spawnTarget = {
+                                locX: session.initialSpawnCoord.locX + (Math.random() - 0.5) * 1000,
+                                locY: session.initialSpawnCoord.locY + (Math.random() - 0.5) * 1000,
+                                locZ: session.initialSpawnCoord.locZ
+                            };
+                            spawnTarget.locZ = GeodataEngine.getHeight(spawnTarget.locX, spawnTarget.locY, spawnTarget.locZ);
                         }
-                        
-                        spawnTarget = {
-                            locX: session.initialSpawnCoord.locX + (Math.random() - 0.5) * 1000,
-                            locY: session.initialSpawnCoord.locY + (Math.random() - 0.5) * 1000,
-                            locZ: session.initialSpawnCoord.locZ
-                        };
-                        spawnTarget.locZ = GeodataEngine.getHeight(spawnTarget.locX, spawnTarget.locY, spawnTarget.locZ);
                     }
                 }
                 

--- a/src/GameServer/Effects/EffectStore.js
+++ b/src/GameServer/Effects/EffectStore.js
@@ -1,0 +1,119 @@
+const DEFAULT_EFFECT_LEVEL = 1;
+
+function now() {
+    return Date.now();
+}
+
+function ensure(actor) {
+    if (!actor) return {};
+    if (!actor.effects) {
+        actor.effects = {};
+    }
+    return actor.effects;
+}
+
+function normalize(effect = {}) {
+    const key = effect.key || effect.name || String(effect.id || effect.skillId || '');
+    const skillId = Number(effect.id || effect.skillId || effect.selfId || 0);
+    const level = Number(effect.level || DEFAULT_EFFECT_LEVEL);
+    const durationMs = Number(effect.durationMs || effect.duration || 0);
+    const expiresAt = effect.expiresAt || (durationMs > 0 ? now() + durationMs : null);
+
+    return {
+        key,
+        id: skillId,
+        level,
+        type: effect.type || 'buff',
+        name: effect.name || key,
+        category: effect.category || null,
+        expiresAt
+    };
+}
+
+function prune(actor) {
+    if (!actor) return {};
+    const store = ensure(actor);
+    const current = now();
+    Object.keys(store).forEach((key) => {
+        const effect = store[key];
+        if (effect?.expiresAt && effect.expiresAt <= current) {
+            delete store[key];
+        }
+    });
+    return store;
+}
+
+function apply(actor, effect) {
+    if (!actor) return null;
+    const normalized = normalize(effect);
+    if (!normalized.key || !normalized.id) return null;
+    ensure(actor)[normalized.key] = normalized;
+    return normalized;
+}
+
+function remove(actor, key) {
+    if (!actor?.effects) return false;
+    if (!actor.effects[key]) return false;
+    delete actor.effects[key];
+    return true;
+}
+
+function remainingMs(actor, key) {
+    const effect = prune(actor)[key];
+    if (!effect) return 0;
+    if (!effect.expiresAt) return 0;
+    return Math.max(0, effect.expiresAt - now());
+}
+
+function list(actor, options = {}) {
+    const includeBuffs = options.includeBuffs !== false;
+    const includeDebuffs = options.includeDebuffs !== false;
+    return Object.values(prune(actor))
+        .filter((effect) => (
+            (effect.type === 'debuff' && includeDebuffs) ||
+            (effect.type !== 'debuff' && includeBuffs)
+        ))
+        .sort((a, b) => a.id - b.id);
+}
+
+function packetEffects(actor, options = {}) {
+    return list(actor, options)
+        .map((effect) => ({
+            id: effect.id,
+            level: effect.level || DEFAULT_EFFECT_LEVEL,
+            duration: Math.max(0, Math.round(remainingMs(actor, effect.key) / 1000)),
+            type: effect.type,
+            key: effect.key
+        }))
+        .filter((effect) => effect.duration > 0);
+}
+
+function activeDebuffs(actor) {
+    return list(actor, { includeBuffs: false, includeDebuffs: true });
+}
+
+function hasDebuff(actor, keys) {
+    const wanted = new Set(Array.isArray(keys) ? keys : [keys]);
+    return activeDebuffs(actor).some((effect) => wanted.has(effect.key) || wanted.has(effect.category));
+}
+
+function impairments(actor) {
+    return {
+        disabled: hasDebuff(actor, ['stun', 'sleep', 'paralyze']),
+        rooted: hasDebuff(actor, ['root']),
+        silenced: hasDebuff(actor, ['silence']),
+        slowed: hasDebuff(actor, ['slow'])
+    };
+}
+
+module.exports = {
+    apply,
+    remove,
+    remainingMs,
+    list,
+    packetEffects,
+    activeDebuffs,
+    hasDebuff,
+    impairments,
+    prune
+};

--- a/src/GameServer/Network/Request/Speak.js
+++ b/src/GameServer/Network/Request/Speak.js
@@ -113,7 +113,7 @@ function consume(session, data) {
         if (data.text.startsWith('/invite ') || data.text.startsWith('.invite ')) {
             const name = data.text.replace(/^\/invite\s+|^\.invite\s+/, '').trim();
             const World = invoke('GameServer/World/World');
-            World.inviteBotByName(session, session.actor, name, 1, 'chat_invite');
+            World.inviteBotByName(session, session.actor, name, undefined, 'chat_invite');
             return;
         }
         if (/^(\/tell|\.tell|\/w|\.w)\s+/i.test(data.text)) {

--- a/src/GameServer/Network/Response/AbnormalStatusUpdate.js
+++ b/src/GameServer/Network/Response/AbnormalStatusUpdate.js
@@ -1,4 +1,5 @@
 const SendPacket = invoke('Packet/Send');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
 
 function abnormalStatusUpdate(buffs = []) {
     const packet = new SendPacket(0x7f); // Opcode 0x7f for MagicEffectIcons / AbnormalStatusUpdate
@@ -15,6 +16,11 @@ function abnormalStatusUpdate(buffs = []) {
 }
 
 abnormalStatusUpdate.fromActor = function(actor) {
+    const effects = EffectStore.packetEffects(actor);
+    if (effects.length > 0) {
+        return abnormalStatusUpdate(effects);
+    }
+
     const buffs = [];
     if (actor && actor.activeBuffs) {
         const now = Date.now();

--- a/src/GameServer/Network/Response/PartySpelled.js
+++ b/src/GameServer/Network/Response/PartySpelled.js
@@ -1,0 +1,26 @@
+const SendPacket = invoke('Packet/Send');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
+
+function partySpelled(objectId, effects = [], summon = 0) {
+    const packet = new SendPacket(0xee);
+
+    packet
+        .writeD(summon)
+        .writeD(objectId)
+        .writeD(effects.length);
+
+    effects.forEach((effect) => {
+        packet
+            .writeD(effect.id)
+            .writeH(effect.level)
+            .writeD(effect.duration);
+    });
+
+    return packet.fetchBuffer();
+}
+
+partySpelled.fromActor = function(actor, summon = 0) {
+    return partySpelled(actor.fetchId(), EffectStore.packetEffects(actor), summon);
+};
+
+module.exports = partySpelled;

--- a/src/GameServer/Network/Response/index.js
+++ b/src/GameServer/Network/Response/index.js
@@ -55,6 +55,7 @@ module.exports = {
  partySmallWindowDelete: require('./PartySmallWindowDelete'),
     partySmallWindowDeleteAll: require('./PartySmallWindowDeleteAll'),
      partySmallWindowUpdate: require('./PartySmallWindowUpdate'),
+              partySpelled: require('./PartySpelled'),
    abnormalStatusUpdate: require('./AbnormalStatusUpdate'),
               joinParty: require('./JoinParty'),
          relationChanged: require('./RelationChanged')

--- a/src/GameServer/Npc/SpoilSweep.js
+++ b/src/GameServer/Npc/SpoilSweep.js
@@ -1,6 +1,7 @@
 const DataCache      = invoke('GameServer/DataCache');
 const ServerResponse = invoke('GameServer/Network/Response');
 const ConsoleText    = invoke('GameServer/ConsoleText');
+const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
 
 const SPOIL_SKILL_ID = 254;
 const SWEEP_SKILL_ID = 42;
@@ -87,6 +88,17 @@ function castUtilitySkill(session, actor, target, skill, effect) {
     }, skill.fetchCalculatedHitTime());
 }
 
+function spoilRecipientSession(session, npc, selfId) {
+    const leaderSession = session?.partyCompanion === true && session.followPlayerSession
+        ? session.followPlayerSession
+        : session;
+    const distribution = PartyCompanionService.distributionForLeader(leaderSession);
+    if (distribution === 2 || distribution === 4) {
+        return PartyCompanionService.resolveLootSession(session, selfId, npc);
+    }
+    return session;
+}
+
 const SpoilSweep = {
     isSpoilSkill(selfId) {
         return Number(selfId) === SPOIL_SKILL_ID;
@@ -170,12 +182,13 @@ const SpoilSweep = {
                 session.dataSendToMe(ServerResponse.actionFailed());
             } else {
                 awarded.forEach((item) => {
-                    invoke('GameServer/World/World').purchaseItem(session, item.selfId, item.amount);
+                    const recipientSession = spoilRecipientSession(session, npc, item.selfId);
+                    invoke('GameServer/World/World').purchaseItem(recipientSession, item.selfId, item.amount);
                     const textName = { kind: ConsoleText.kind.item, value: item.selfId };
                     const textAmount = { kind: ConsoleText.kind.number, value: item.amount };
                     item.amount > 1
-                        ? ConsoleText.transmit(session, ConsoleText.caption.pickupAmountOf, [textName, textAmount])
-                        : ConsoleText.transmit(session, ConsoleText.caption.pickup, [textName]);
+                        ? ConsoleText.transmit(recipientSession, ConsoleText.caption.pickupAmountOf, [textName, textAmount])
+                        : ConsoleText.transmit(recipientSession, ConsoleText.caption.pickup, [textName]);
                     console.info('SpoilSweep :: %s swept %d %s from %s', actor.fetchName(), item.amount, item.name, npc.fetchName());
                 });
             }

--- a/src/GameServer/Session.js
+++ b/src/GameServer/Session.js
@@ -247,6 +247,14 @@ class Session {
             utils.infoWarn('GameServer', 'connection closed');
         }
         if (this.actor) {
+            const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
+            PartyCompanionService.detachAll(this, {
+                event: 'party_dismissed',
+                source: 'leader_disconnect',
+                message: 'My companion disconnected. Returning to hunt.',
+                rebuildWindow: false,
+                refreshPanel: false
+            });
             this.actor.destructor();
             this.actor = null;
         }

--- a/src/GameServer/World/Generics/NpcBypasses/BotParty.js
+++ b/src/GameServer/World/Generics/NpcBypasses/BotParty.js
@@ -75,7 +75,7 @@ function botParty(session, parts) {
         const botName = parts[2];
         const targetSession = BotManager.findSessionByName(botName);
         if (targetSession) {
-            World.inviteBotCompanion(session, actor, targetSession, 1, 'botparty');
+            World.inviteBotCompanion(session, actor, targetSession, undefined, 'botparty');
         }
     }
 

--- a/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
+++ b/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
@@ -1,9 +1,9 @@
 const BotManager = invoke('GameServer/Bot/BotManager');
 const ServerResponse = invoke('GameServer/Network/Response');
 const TeleportTo = invoke('GameServer/Actor/Generics/TeleportTo');
-const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
 const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 const Html = invoke('GameServer/World/Generics/HtmlKit');
+const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
 
 function companionControl(session, parts) {
     const actor = session.actor;
@@ -59,16 +59,11 @@ function companionControl(session, parts) {
                     BotManager.botSay(targetSession, "Summoned to your side!");
                 }
                 else if (subCommand === 'dismiss') {
-                    session.dataSendToMe(ServerResponse.partySmallWindowDelete(bot.fetchId(), bot.fetchName()));
-                    setTimeout(() => {
-                        BotSocialMemory.recordEvent(session, targetSession, 'party_dismissed', 'companion_panel');
-                        BotManager.botSay(targetSession, "Leaving the group. Goodbye!");
-                        targetSession.plan = 'hunting';
-                        targetSession.followPlayerSession = null;
-                        targetSession.partyCompanion = false;
-                        targetSession.botStay = false;
-                        targetSession.stayLocation = null;
-                    }, 1000);
+                    PartyCompanionService.detach(session, targetSession, {
+                        event: 'party_dismissed',
+                        source: 'companion_panel',
+                        message: 'Leaving the group. Goodbye!'
+                    });
                 }
             }
         }
@@ -83,7 +78,7 @@ function renderCompanionPanel(session) {
     if (!actor) return;
 
     // Find all bot sessions following this player
-    const myCompanions = BotManager.sessions.filter(s => s.followPlayerSession === session && s.partyCompanion === true && s.actor);
+    const myCompanions = PartyCompanionService.membersForLeader(session);
 
     if (myCompanions.length === 0) {
         const html = Html.page(

--- a/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
+++ b/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
@@ -175,6 +175,7 @@ function renderCompanionPanel(session) {
         const mpPct = status ? Math.round(status.vitals.mpPct * 100) : 0;
         const roleDecision = status?.roleDecision ? `${status.roleDecision.action}/${status.roleDecision.reason}` : status?.intent;
         const buffText = status?.buffs?.needsRefresh ? ' / buffs low' : '';
+        const debuffText = status?.debuffs?.length ? ` / debuff ${status.debuffs[0].key}` : '';
         const stance = stayActive ? 'hold' : 'follow';
         const pullText = BotRoles.isTank(bot) ? ` / pull ${companionSession.autoTaunt === false ? 'off' : 'auto'}` : '';
         const actions = [
@@ -188,7 +189,7 @@ function renderCompanionPanel(session) {
         body += Html.botCard({
             name: bot.fetchName(),
             badge: status ? Html.font(status.role || 'bot', Html.COLOR.link) : '',
-            subtitle: status ? `${roleDecision} / ${stance}${pullText} / HP ${hpPct}% / MP ${mpPct}%${buffText}` : 'status unavailable',
+            subtitle: status ? `${roleDecision} / ${stance}${pullText} / HP ${hpPct}% / MP ${mpPct}%${buffText}${debuffText}` : 'status unavailable',
             status: actions
         });
         body += Html.spacer(4);

--- a/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
+++ b/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
@@ -5,71 +5,119 @@ const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 const Html = invoke('GameServer/World/Generics/HtmlKit');
 const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
 
+function companionSessions(session) {
+    return PartyCompanionService.membersForLeader(session);
+}
+
+function findCompanion(session, botName) {
+    const lookup = String(botName || '').trim().toLowerCase();
+    if (!lookup) return null;
+    return companionSessions(session).find((targetSession) => (
+        targetSession.actor &&
+        targetSession.actor.fetchName().toLowerCase() === lookup
+    )) || null;
+}
+
+function stayHere(targetSession) {
+    const bot = targetSession.actor;
+    targetSession.botStay = true;
+    targetSession.stayLocation = {
+        locX: bot.fetchLocX(),
+        locY: bot.fetchLocY(),
+        locZ: bot.fetchLocZ()
+    };
+}
+
+function followLeader(targetSession) {
+    targetSession.botStay = false;
+    targetSession.stayLocation = null;
+}
+
+function summonNear(session, targetSession, offset = 60) {
+    const actor = session.actor;
+    const bot = targetSession.actor;
+    const loc = {
+        locX: actor.fetchLocX() + offset,
+        locY: actor.fetchLocY() + offset,
+        locZ: actor.fetchLocZ()
+    };
+    TeleportTo(targetSession, bot, loc);
+    if (targetSession.botStay) {
+        targetSession.stayLocation = loc;
+    }
+}
+
+function setMovementMode(session, mode) {
+    const members = companionSessions(session);
+    PartyCompanionService.updateSettings(session, { movementMode: mode });
+    members.forEach((memberSession) => {
+        if (mode === 'hold') {
+            stayHere(memberSession);
+        } else {
+            followLeader(memberSession);
+        }
+    });
+}
+
+function setCombatMode(session, mode) {
+    const allowed = ['assist', 'protect', 'passive'];
+    if (!allowed.includes(mode)) return;
+    PartyCompanionService.updateSettings(session, { combatMode: mode });
+    companionSessions(session).forEach((memberSession) => {
+        memberSession.currentTargetId = undefined;
+        memberSession.actor?.unselect?.();
+    });
+}
+
+function setPullMode(session, mode) {
+    const pullMode = mode === 'off' ? 'off' : 'auto';
+    PartyCompanionService.updateSettings(session, { pullMode });
+    companionSessions(session).forEach((memberSession) => {
+        memberSession.autoTaunt = pullMode !== 'off';
+    });
+}
+
+function regroup(session) {
+    companionSessions(session).forEach((memberSession, index) => {
+        summonNear(session, memberSession, 60 + (index * 20));
+    });
+}
+
+function handleMemberCommand(session, subCommand, botName) {
+    const targetSession = findCompanion(session, botName);
+    if (!targetSession) return;
+
+    if (subCommand === 'follow') {
+        followLeader(targetSession);
+        BotManager.botSay(targetSession, "Following you again!");
+    } else if (subCommand === 'stay') {
+        stayHere(targetSession);
+        BotManager.botSay(targetSession, "Holding this position.");
+    } else if (subCommand === 'summon') {
+        summonNear(session, targetSession);
+        BotManager.botSay(targetSession, "Summoned to your side!");
+    }
+}
+
 function companionControl(session, parts) {
     const actor = session.actor;
     if (!actor || actor.isDead()) return;
 
-    // Command parameters format:
-    // companion-control <subcommand> <botname>
     const subCommand = parts[1];
+    const value = parts[2];
 
-    if (subCommand && subCommand !== 'refresh') {
-        const botName = parts[2];
-        if (botName) {
-            const targetSession = BotManager.sessions.find(s => s.actor && s.actor.fetchName().toLowerCase() === botName.toLowerCase());
-            
-            if (targetSession && targetSession.followPlayerSession === session && targetSession.partyCompanion === true) {
-                const bot = targetSession.actor;
-                
-                if (subCommand === 'follow') {
-                    targetSession.botStay = false;
-                    targetSession.stayLocation = null;
-                    BotManager.botSay(targetSession, "Following you again!");
-                }
-                else if (subCommand === 'stay') {
-                    targetSession.botStay = true;
-                    targetSession.stayLocation = {
-                        locX: bot.fetchLocX(),
-                        locY: bot.fetchLocY(),
-                        locZ: bot.fetchLocZ()
-                    };
-                    BotManager.botSay(targetSession, "Holding this position.");
-                }
-                else if (subCommand === 'taunt-on') {
-                    targetSession.autoTaunt = true;
-                    BotManager.botSay(targetSession, "Auto-taunt enabled. I will pull monsters.");
-                }
-                else if (subCommand === 'taunt-off') {
-                    targetSession.autoTaunt = false;
-                    BotManager.botSay(targetSession, "Auto-taunt disabled.");
-                }
-                else if (subCommand === 'summon') {
-                    TeleportTo(targetSession, bot, {
-                        locX: actor.fetchLocX() + 60,
-                        locY: actor.fetchLocY() + 60,
-                        locZ: actor.fetchLocZ()
-                    });
-                    if (targetSession.botStay) {
-                        targetSession.stayLocation = {
-                            locX: actor.fetchLocX() + 60,
-                            locY: actor.fetchLocY() + 60,
-                            locZ: actor.fetchLocZ()
-                        };
-                    }
-                    BotManager.botSay(targetSession, "Summoned to your side!");
-                }
-                else if (subCommand === 'dismiss') {
-                    PartyCompanionService.detach(session, targetSession, {
-                        event: 'party_dismissed',
-                        source: 'companion_panel',
-                        message: 'Leaving the group. Goodbye!'
-                    });
-                }
-            }
-        }
+    if (subCommand === 'movement') {
+        setMovementMode(session, value === 'hold' ? 'hold' : 'follow');
+    } else if (subCommand === 'combat') {
+        setCombatMode(session, value);
+    } else if (subCommand === 'pull') {
+        setPullMode(session, value);
+    } else if (subCommand === 'regroup') {
+        regroup(session);
+    } else if (subCommand && subCommand !== 'refresh') {
+        handleMemberCommand(session, subCommand, value);
     }
 
-    // Always redraw the panel
     renderCompanionPanel(session);
 }
 
@@ -77,14 +125,14 @@ function renderCompanionPanel(session) {
     const actor = session.actor;
     if (!actor) return;
 
-    // Find all bot sessions following this player
     const myCompanions = PartyCompanionService.membersForLeader(session);
+    const settings = PartyCompanionService.getSettings(session);
 
     if (myCompanions.length === 0) {
         const html = Html.page(
             Html.emptyState(
-                'Companion Panel',
-                'You currently have no companions in your party. Target a bot and type /invite to recruit them.'
+                'Party Control',
+                'No companions are currently in this party.'
             ),
             { title: 'Party Control' }
         );
@@ -92,41 +140,55 @@ function renderCompanionPanel(session) {
         return;
     }
 
-    let body = `${Html.font('Companion Commands', Html.COLOR.title)}<br>`;
+    const modeLink = (label, active, command) => Html.link(active ? `[${label}]` : label, command, {
+        color: active ? Html.COLOR.title : Html.COLOR.link
+    });
+
+    let body = `${Html.font('Party Control', Html.COLOR.title)}<br1>`;
+    body += Html.statusTable([
+        ['Loot', Html.font(`native #${settings.distribution}`, Html.COLOR.muted)],
+        ['Combat', [
+            modeLink('Assist', settings.combatMode === 'assist', 'companion-control combat assist'),
+            modeLink('Protect', settings.combatMode === 'protect', 'companion-control combat protect'),
+            modeLink('Passive', settings.combatMode === 'passive', 'companion-control combat passive')
+        ].join(' ')],
+        ['Move', [
+            modeLink('Follow', settings.movementMode !== 'hold', 'companion-control movement follow'),
+            modeLink('Hold', settings.movementMode === 'hold', 'companion-control movement hold')
+        ].join(' ')],
+        ['Pull', [
+            modeLink('Auto', settings.pullMode !== 'off', 'companion-control pull auto'),
+            modeLink('Off', settings.pullMode === 'off', 'companion-control pull off')
+        ].join(' ')]
+    ]);
+    body += Html.actionFooter([
+        { label: 'Regroup', command: 'companion-control regroup', color: Html.COLOR.link },
+        { label: 'Refresh', command: 'companion-control refresh', color: Html.COLOR.muted }
+    ]);
+    body += Html.spacer(5);
 
     myCompanions.forEach((companionSession) => {
         const bot = companionSession.actor;
-        const isTank = BotRoles.isTank(bot);
-
         const stayActive = companionSession.botStay === true;
-        const tauntActive = companionSession.autoTaunt !== false; // default true for tanks
         const status = BotManager.getBotStatus(companionSession);
         const hpPct = status ? Math.round(status.vitals.hpPct * 100) : 0;
         const mpPct = status ? Math.round(status.vitals.mpPct * 100) : 0;
-        const spotName = status?.spot?.name || 'no spot';
         const roleDecision = status?.roleDecision ? `${status.roleDecision.action}/${status.roleDecision.reason}` : status?.intent;
         const buffText = status?.buffs?.needsRefresh ? ' / buffs low' : '';
-
-        const movement = stayActive
-            ? Html.link('[STAYING]', `companion-control follow ${bot.fetchName()}`, { color: Html.COLOR.danger })
-            : Html.link('[FOLLOWING]', `companion-control stay ${bot.fetchName()}`, { color: Html.COLOR.ok });
-        let actions = movement;
-
-        if (isTank) {
-            const taunt = tauntActive
-                ? Html.link('[PULL: ON]', `companion-control taunt-off ${bot.fetchName()}`, { color: Html.COLOR.title })
-                : Html.link('[PULL: OFF]', `companion-control taunt-on ${bot.fetchName()}`, { color: Html.COLOR.muted });
-            actions += ` | ${taunt}`;
-        }
-
-        actions += ` | ${Html.link('Summon', `companion-control summon ${bot.fetchName()}`)}`;
-        actions += ` | ${Html.link('Status', `bot-status ${bot.fetchName()}`)}`;
-        actions += ` | ${Html.link('Dismiss', `companion-control dismiss ${bot.fetchName()}`, { color: Html.COLOR.danger })}`;
+        const stance = stayActive ? 'hold' : 'follow';
+        const pullText = BotRoles.isTank(bot) ? ` / pull ${companionSession.autoTaunt === false ? 'off' : 'auto'}` : '';
+        const actions = [
+            stayActive
+                ? Html.link('Follow', `companion-control follow ${bot.fetchName()}`, { color: Html.COLOR.link })
+                : Html.link('Hold', `companion-control stay ${bot.fetchName()}`, { color: Html.COLOR.link }),
+            Html.link('Summon', `companion-control summon ${bot.fetchName()}`),
+            Html.link('Status', `bot-status ${bot.fetchName()}`)
+        ].join(' | ');
 
         body += Html.botCard({
             name: bot.fetchName(),
             badge: status ? Html.font(status.role || 'bot', Html.COLOR.link) : '',
-            subtitle: status ? `${roleDecision} / HP ${hpPct}% / MP ${mpPct}% / ${spotName}${buffText}` : 'status unavailable',
+            subtitle: status ? `${roleDecision} / ${stance}${pullText} / HP ${hpPct}% / MP ${mpPct}%${buffText}` : 'status unavailable',
             status: actions
         });
         body += Html.spacer(4);

--- a/src/GameServer/World/Generics/NpcRewards.js
+++ b/src/GameServer/World/Generics/NpcRewards.js
@@ -1,7 +1,59 @@
 const DataCache = invoke('GameServer/DataCache');
 const SpeckMath = invoke('GameServer/SpeckMath');
-const Database  = invoke('Database');
 const BotLootEtiquette = invoke('GameServer/Bot/AI/BotLootEtiquette');
+const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
+
+function isBotSession(session) {
+    return !!(session && (session.constructor.name === 'BotSession' || (session.accountId && session.accountId.startsWith('bot_'))));
+}
+
+function maybeBragAboutLoot(session, selfId, amount) {
+    if (Math.random() >= 0.15) return;
+
+    try {
+        const BotManager = invoke('GameServer/Bot/BotManager');
+        DataCache.fetchItemFromSelfId(selfId, (itemDetails) => {
+            const itemName = itemDetails.template.name;
+            const adenaLoot = selfId === 57;
+            const lootPhrases = adenaLoot ? [
+                `Aha! Got some sweet adena (${amount} gold)!`,
+                `Money money! +${amount} adena.`,
+                `Sweet, ${amount} adena from that monster!`,
+                `This farming is really paying off! Got ${amount} adena.`
+            ] : [
+                `Whoa! Just got ${itemName}! Nice drop.`,
+                `Aha! Got a sweet ${itemName}!`,
+                `Nice! This creature dropped ${itemName}.`,
+                `Looted ${itemName}! Today is my lucky day!`
+            ];
+            const phrase = lootPhrases[Math.floor(Math.random() * lootPhrases.length)];
+            setTimeout(() => {
+                BotManager.botSay(session, phrase);
+            }, 500 + Math.random() * 500);
+        });
+    } catch (err) {
+        console.error("Bot loot brag error:", err);
+    }
+}
+
+function awardDirect(world, session, selfId, amount) {
+    world.purchaseItem(session, selfId, amount);
+    maybeBragAboutLoot(session, selfId, amount);
+}
+
+function awardPartyLoot(world, session, npc, selfId, amount) {
+    if (selfId === 57) {
+        PartyCompanionService.adenaAllocations(session, amount, npc)
+            .forEach((entry) => world.purchaseItem(entry.session, selfId, entry.amount));
+        return;
+    }
+
+    const recipientSession = PartyCompanionService.resolveLootSession(session, selfId, npc);
+    world.purchaseItem(recipientSession, selfId, amount);
+    if (recipientSession === session) {
+        maybeBragAboutLoot(session, selfId, amount);
+    }
+}
 
 function npcRewards(session, npc) {
     DataCache.fetchNpcRewardsFromSelfId(npc.fetchSelfId(), (result) => {
@@ -18,53 +70,11 @@ function npcRewards(session, npc) {
 
                     if (number <= rewardPartition) { // TODO: Remove locZ hack at some point
                         const amount = utils.oneFromSpan(item.min, item.max);
-                        if (session && (session.constructor.name === 'BotSession' || (session.accountId && session.accountId.startsWith('bot_')))) {
-                            const backpack = session.actor.backpack;
-                            backpack.stackableExists(item.selfId).then((existingItem) => {
-                                const total = existingItem.fetchAmount() + amount;
-                                Database.updateItemAmount(session.actor.fetchId(), existingItem.fetchId(), total).then(() => {
-                                    existingItem.setAmount(total);
-                                });
-                            }).catch(() => {
-                                DataCache.fetchItemFromSelfId(item.selfId, (itemDetails) => {
-                                    Database.setItem(session.actor.fetchId(), {
-                                        selfId: itemDetails.selfId,
-                                        name: itemDetails.template.name,
-                                        amount: amount,
-                                        equipped: false,
-                                        slot: itemDetails.etc?.slot ?? 0
-                                    }).then((packet) => {
-                                        backpack.insertItem(Number(packet.insertId), itemDetails.selfId, { amount: amount });
-                                    });
-                                });
-                            });
-
-                            // Hook 15% loot brag chance
-                            if (Math.random() < 0.15) {
-                                try {
-                                    const BotManager = invoke('GameServer/Bot/BotManager');
-                                    DataCache.fetchItemFromSelfId(item.selfId, (itemDetails) => {
-                                        const itemName = itemDetails.template.name;
-                                        const adenaLoot = (item.selfId === 57);
-                                        const lootPhrases = adenaLoot ? [
-                                            `Aha! Got some sweet adena (${amount} gold)!`,
-                                            `Money money! +${amount} adena.`,
-                                            `Sweet, ${amount} adena from that monster!`,
-                                            `This farming is really paying off! Got ${amount} adena.`
-                                        ] : [
-                                            `Whoa! Just got ${itemName}! Nice drop.`,
-                                            `Aha! Got a sweet ${itemName}!`,
-                                            `Nice! This creature dropped ${itemName}.`,
-                                            `Looted ${itemName}! Today is my lucky day!`
-                                        ];
-                                        const phrase = lootPhrases[Math.floor(Math.random() * lootPhrases.length)];
-                                        setTimeout(() => {
-                                            BotManager.botSay(session, phrase);
-                                        }, 500 + Math.random() * 500);
-                                    });
-                                } catch (err) {
-                                    console.error("Bot loot brag error:", err);
-                                }
+                        if (isBotSession(session)) {
+                            if (session.partyCompanion === true && session.followPlayerSession) {
+                                awardPartyLoot(this, session, npc, item.selfId, amount);
+                            } else {
+                                awardDirect(this, session, item.selfId, amount);
                             }
                         } else {
                             let point = new SpeckMath.Circle(npc.fetchLocX(), npc.fetchLocY(), 50).createPointWithin();

--- a/src/GameServer/World/Generics/PickupItem.js
+++ b/src/GameServer/World/Generics/PickupItem.js
@@ -1,5 +1,16 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const ConsoleText    = invoke('GameServer/ConsoleText');
+const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
+
+function transmitPickup(session, selfId, amount) {
+    const textName   = { kind: ConsoleText.kind.  item, value: selfId };
+    const textAmount = { kind: ConsoleText.kind.number, value: amount };
+    amount > 1
+        ? (selfId === 57
+            ? ConsoleText.transmit(session, ConsoleText.caption.pickupAdenaAmount, [textAmount])
+            : ConsoleText.transmit(session, ConsoleText.caption.pickupAmountOf, [textName, textAmount]))
+        : ConsoleText.transmit(session, ConsoleText.caption.pickup, [textName]);
+}
 
 function pickupItem(session, actor, item) {
     const id     = item.fetchId();
@@ -8,11 +19,19 @@ function pickupItem(session, actor, item) {
 
     this.items.spawns = this.items.spawns.filter((ob) => ob.fetchId() !== id);
     session.dataSendToMeAndOthers(ServerResponse.deleteOb(id), item);
-    this.purchaseItem(session, selfId, amount);
 
-    const textName   = { kind: ConsoleText.kind.  item, value: selfId };
-    const textAmount = { kind: ConsoleText.kind.number, value: amount };
-    amount > 1 ? (selfId === 57 ? ConsoleText.transmit(session, ConsoleText.caption.pickupAdenaAmount, [textAmount]) : ConsoleText.transmit(session, ConsoleText.caption.pickupAmountOf, [textName, textAmount])) : ConsoleText.transmit(session, ConsoleText.caption.pickup, [textName]);
+    if (selfId === 57) {
+        const allocations = PartyCompanionService.adenaAllocations(session, amount, item);
+        allocations.forEach((entry) => {
+            this.purchaseItem(entry.session, selfId, entry.amount);
+            transmitPickup(entry.session, selfId, entry.amount);
+        });
+        return;
+    }
+
+    const recipientSession = PartyCompanionService.resolveLootSession(session, selfId, item);
+    this.purchaseItem(recipientSession, selfId, amount);
+    transmitPickup(recipientSession, selfId, amount);
 }
 
 module.exports = pickupItem;

--- a/src/GameServer/World/World.js
+++ b/src/GameServer/World/World.js
@@ -127,7 +127,7 @@ const World = {
         });
     },
 
-    inviteBotCompanion(session, actor, targetSession, distribution = 1, source = 'invite') {
+    inviteBotCompanion(session, actor, targetSession, distribution, source = 'invite') {
         const BotAvailability = invoke('GameServer/Bot/AI/BotAvailability');
         const BotManager = invoke('GameServer/Bot/BotManager');
         const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
@@ -151,7 +151,12 @@ const World = {
             return false;
         }
 
-        PartyCompanionService.attach(session, targetSession, { distribution: distribution || 1 });
+        const attachOptions = {};
+        if (distribution !== undefined && distribution !== null) {
+            attachOptions.distribution = distribution;
+        }
+
+        PartyCompanionService.attach(session, targetSession, attachOptions);
 
         BotSocialMemory.recordEvent(session, targetSession, 'party_formed', source);
         setTimeout(() => {
@@ -164,7 +169,7 @@ const World = {
         return true;
     },
 
-    inviteBotByName(session, actor, name, distribution = 1, source = 'named_invite') {
+    inviteBotByName(session, actor, name, distribution, source = 'named_invite') {
         const lookup = String(name || '').trim();
         if (!lookup) {
             session.dataSendToMe(ServerResponse.actionFailed());

--- a/src/GameServer/World/World.js
+++ b/src/GameServer/World/World.js
@@ -156,6 +156,7 @@ const World = {
             attachOptions.distribution = distribution;
         }
 
+        const wasResting = targetSession.plan === 'resting';
         PartyCompanionService.attach(session, targetSession, attachOptions);
 
         BotSocialMemory.recordEvent(session, targetSession, 'party_formed', source);

--- a/src/GameServer/World/World.js
+++ b/src/GameServer/World/World.js
@@ -131,6 +131,7 @@ const World = {
         const BotAvailability = invoke('GameServer/Bot/AI/BotAvailability');
         const BotManager = invoke('GameServer/Bot/BotManager');
         const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
+        const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
         const availability = BotAvailability.evaluate(session, targetSession);
         const bot = targetSession.actor;
 
@@ -150,20 +151,7 @@ const World = {
             return false;
         }
 
-        session.dataSendToMe(ServerResponse.joinParty(distribution || 1));
-        session.dataSendToMe(ServerResponse.partySmallWindowDeleteAll());
-
-        const wasResting = targetSession.plan === 'resting';
-        targetSession.plan = wasResting ? 'resting' : 'following';
-        targetSession.followPlayerSession = session;
-        targetSession.partyCompanion = true;
-        targetSession.botStay = false;
-        targetSession.stayLocation = null;
-
-        session.dataSendToMe(ServerResponse.partySmallWindowAll(actor.fetchId(), 0, [bot]));
-
-        const CompanionControl = invoke('GameServer/World/Generics/NpcBypasses/CompanionControl');
-        CompanionControl.render(session);
+        PartyCompanionService.attach(session, targetSession, { distribution: distribution || 1 });
 
         BotSocialMemory.recordEvent(session, targetSession, 'party_formed', source);
         setTimeout(() => {
@@ -305,20 +293,16 @@ const World = {
 
     oustPartyMember(session, actor, data) {
         const BotManager = invoke('GameServer/Bot/BotManager');
+        const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
         let botFound = false;
         BotManager.sessions.forEach((targetSession) => {
             if (targetSession.actor && targetSession.actor.fetchName().toLowerCase() === data.name.toLowerCase() && targetSession.followPlayerSession === session && targetSession.partyCompanion === true) {
                 botFound = true;
-                session.dataSendToMe(ServerResponse.partySmallWindowDelete(targetSession.actor.fetchId(), targetSession.actor.fetchName()));
-                
-                setTimeout(() => {
-                    const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
-                    BotSocialMemory.recordEvent(session, targetSession, 'party_kicked', 'oust');
-                    BotManager.botSay(targetSession, `I have been kicked from the party. Returning to hunt on my own!`);
-                    targetSession.plan = 'hunting';
-                    targetSession.followPlayerSession = null;
-                    targetSession.partyCompanion = false;
-                }, 1000);
+                PartyCompanionService.detach(session, targetSession, {
+                    event: 'party_kicked',
+                    source: 'oust',
+                    message: 'I have been kicked from the party. Returning to hunt on my own!'
+                });
             }
         });
         if (!botFound) {
@@ -327,22 +311,11 @@ const World = {
     },
 
     dismissParty(session, actor) {
-        const BotManager = invoke('GameServer/Bot/BotManager');
-        let botsDisbanded = 0;
-        BotManager.sessions.forEach((targetSession) => {
-            if (targetSession.followPlayerSession === session && targetSession.partyCompanion === true) {
-                botsDisbanded++;
-                session.dataSendToMe(ServerResponse.partySmallWindowDelete(targetSession.actor.fetchId(), targetSession.actor.fetchName()));
-
-                setTimeout(() => {
-                    const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
-                    BotSocialMemory.recordEvent(session, targetSession, 'party_dismissed', 'dismiss');
-                    BotManager.botSay(targetSession, `Party dismissed! Returning to my farming fields.`);
-                    targetSession.plan = 'hunting';
-                    targetSession.followPlayerSession = null;
-                    targetSession.partyCompanion = false;
-                }, 1000);
-            }
+        const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
+        const botsDisbanded = PartyCompanionService.detachAll(session, {
+            event: 'party_dismissed',
+            source: 'dismiss',
+            message: 'Party dismissed! Returning to my farming fields.'
         });
         if (botsDisbanded === 0) {
             session.dataSendToMe(ServerResponse.actionFailed());

--- a/tests/test_c4_protocol_packets.js
+++ b/tests/test_c4_protocol_packets.js
@@ -203,6 +203,15 @@ assert.strictEqual(partyUpdate.readInt32LE(updateVitalsOffset + 8), actor.fetchH
 assert.strictEqual(ServerResponse.partySmallWindowDeleteAll()[0], 0x50, 'C4 party delete all opcode should be 0x50');
 assert.strictEqual(ServerResponse.partySmallWindowDelete(actor.fetchId(), actor.fetchName())[0], 0x51, 'C4 party delete opcode should be 0x51');
 
+const partySpelled = ServerResponse.partySpelled(actor.fetchId(), [{ id: 1040, level: 2, duration: 120 }]);
+assert.strictEqual(partySpelled[0], 0xee, 'C4 PartySpelled opcode should be 0xee');
+assert.strictEqual(partySpelled.readInt32LE(1), 0, 'PartySpelled should mark normal party member effects');
+assert.strictEqual(partySpelled.readInt32LE(5), actor.fetchId(), 'PartySpelled should include member object id');
+assert.strictEqual(partySpelled.readInt32LE(9), 1, 'PartySpelled should include effect count');
+assert.strictEqual(partySpelled.readInt32LE(13), 1040, 'PartySpelled should include effect skill id');
+assert.strictEqual(partySpelled.readInt16LE(17), 2, 'PartySpelled should include effect level');
+assert.strictEqual(partySpelled.readInt32LE(19), 120, 'PartySpelled should include remaining duration');
+
 const npcInfo = ServerResponse.npcInfo(fakeNpc());
 assert.strictEqual(npcInfo[0], 0x16);
 assert.ok(npcInfo.length >= 208, 'C4 NpcInfo should include team/collision tail fields');

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -10,6 +10,7 @@ const ShoppingState = invoke('GameServer/Bot/AI/States/ShoppingState');
 const BotAgentTools = invoke('GameServer/Bot/AI/BotAgentTools');
 const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
 const BotManager = invoke('GameServer/Bot/BotManager');
+const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
 const NpcDied = invoke('GameServer/Actor/Generics/NpcDied');
 const Database = invoke('Database');
 const DataCache = invoke('GameServer/DataCache');
@@ -73,6 +74,9 @@ function fakeActor(id, loc = {}) {
         fetchMaxHp() { return this.maxHp; },
         fetchMp() { return this.mp; },
         fetchMaxMp() { return this.maxMp; },
+        setHp(value) { this.hp = value; },
+        setMp(value) { this.mp = value; },
+        fillupVitals() { this.hp = this.maxHp; this.mp = this.maxMp; },
         fetchExp() { return this.exp; },
         fetchSp() { return this.sp; },
         setExp(data) { this.exp = data; },
@@ -132,7 +136,10 @@ function fakeActor(id, loc = {}) {
             fetchPaperdollId: () => 0,
             fetchPaperdollSelfId: () => 0
         },
-        skillset: { fetchSkill: () => null },
+        skillset: {
+            skills: [],
+            fetchSkill(selfId) { return this.skills.find((skill) => skill.fetchSelfId() === selfId) || null; }
+        },
         automation: { abortAll() {}, replenishVitals() {} }
     };
     return actor;
@@ -162,6 +169,7 @@ const originalUpdateCharacterExperience = Database.updateCharacterExperience;
 const originalExperience = DataCache.experience;
 const originalRandom = Math.random;
 const originalBotSessions = BotManager.sessions;
+const originalApplySupportBuff = BotBuffs.applySupportBuff;
 
 function lastPartyAllPacket(session) {
     return [...session.packets].reverse().find((packet) => packet[0] === 0x4e);
@@ -488,6 +496,56 @@ try {
     assert.strictEqual(pvpAssistSession.currentTargetId, hostileBot.fetchId(), 'companion with no target should acquire bot attacking leader');
     assert.strictEqual(assistedPlayerId, hostileBot.fetchId(), 'companion should assist against bot attacking leader');
 
+    const healerLeader = fakeActor(2000024, { locX: 0, locY: 0 });
+    const healerLeaderSession = fakeSession('player_healer_party', healerLeader);
+    const healerBot = fakeActor(2000025, { locX: 80, locY: 0, classId: 15 });
+    const healerSession = fakeSession('bot_healer_party', healerBot);
+    healerSession.followPlayerSession = healerLeaderSession;
+    healerSession.partyCompanion = true;
+    healerSession.plan = 'following';
+    const woundedCompanion = fakeActor(2000026, { locX: 120, locY: 0, hp: 25, maxHp: 100 });
+    const woundedCompanionSession = fakeSession('bot_wounded_party', woundedCompanion);
+    woundedCompanionSession.followPlayerSession = healerLeaderSession;
+    woundedCompanionSession.partyCompanion = true;
+    woundedCompanionSession.plan = 'following';
+    World.user = { sessions: [healerLeaderSession, healerSession, woundedCompanionSession] };
+    World.fetchNpcsInRadius = () => [];
+    let healedTargetId = null;
+
+    FollowingState.tick(healerSession, healerBot, {
+        skillExec(session, bot, data) { healedTargetId = data.id; }
+    }, { say() {}, executeCombat() {}, executePvPCombat() {} });
+
+    assert.strictEqual(healedTargetId, woundedCompanion.fetchId(), 'healer should heal the wounded companion, not only the leader');
+    assert.strictEqual(healerSession.roleDecision.action, 'heal_party', 'healer role decision should be party-wide');
+
+    const bufferLeader = fakeActor(2000027, { locX: 0, locY: 0 });
+    const bufferLeaderSession = fakeSession('player_buffer_party', bufferLeader);
+    const bufferBot = fakeActor(2000028, { locX: 80, locY: 0, classId: 17 });
+    const bufferSession = fakeSession('bot_buffer_party', bufferBot);
+    bufferSession.followPlayerSession = bufferLeaderSession;
+    bufferSession.partyCompanion = true;
+    bufferSession.plan = 'following';
+    const unbuffedCompanion = fakeActor(2000029, { locX: 120, locY: 0 });
+    unbuffedCompanion.activeBuffs.shield = 0;
+    const unbuffedCompanionSession = fakeSession('bot_unbuffed_party', unbuffedCompanion);
+    unbuffedCompanionSession.followPlayerSession = bufferLeaderSession;
+    unbuffedCompanionSession.partyCompanion = true;
+    unbuffedCompanionSession.plan = 'following';
+    World.user = { sessions: [bufferLeaderSession, bufferSession, unbuffedCompanionSession] };
+    let buffedTargetId = null;
+    let appliedBuffType = null;
+    BotBuffs.applySupportBuff = (targetSession, target, buffType) => {
+        buffedTargetId = target.fetchId();
+        appliedBuffType = buffType;
+        return { name: buffType };
+    };
+
+    FollowingState.tick(bufferSession, bufferBot, {}, { say() {}, executeCombat() {}, executePvPCombat() {} });
+
+    assert.strictEqual(buffedTargetId, unbuffedCompanion.fetchId(), 'buffer should refresh buffs on party companions');
+    assert.strictEqual(appliedBuffType, 'shield', 'buffer should apply the missing support buff');
+
     const rewardLeader = fakeActor(2000010, { locX: 0, locY: 0 });
     const rewardLeaderSession = fakeSession('player_reward', rewardLeader);
     const rewardBot = fakeActor(2000011, { locX: 80, locY: 0 });
@@ -673,6 +731,7 @@ try {
     Database.updateCharacterExperience = originalUpdateCharacterExperience;
     DataCache.experience = originalExperience;
     BotManager.sessions = originalBotSessions;
+    BotBuffs.applySupportBuff = originalApplySupportBuff;
 }
 
 console.log('Party companion rest/follow regression checks passed');

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -14,6 +14,7 @@ const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
 const BotStatus = invoke('GameServer/Bot/AI/BotStatus');
 const BotBrainContext = invoke('GameServer/Bot/AI/BotBrainContext');
 const CompanionControl = invoke('GameServer/World/Generics/NpcBypasses/CompanionControl');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
 const NpcDied = invoke('GameServer/Actor/Generics/NpcDied');
 const Database = invoke('Database');
 const DataCache = invoke('GameServer/DataCache');
@@ -180,6 +181,14 @@ const originalApplySupportBuff = BotBuffs.applySupportBuff;
 
 function lastPartyAllPacket(session) {
     return [...session.packets].reverse().find((packet) => packet[0] === 0x4e);
+}
+
+function lastPartySpelledPacket(session, actorId) {
+    return [...session.packets].reverse().find((packet) => (
+        packet[0] === 0xee &&
+        (!actorId || packet.readInt32LE(5) === actorId) &&
+        packet.readInt32LE(9) > 0
+    ));
 }
 
 try {
@@ -606,6 +615,39 @@ try {
         [partyHudBotA.fetchName(), partyHudBotB.fetchName()],
         'service should preserve both server-side companions'
     );
+
+    const casterBot = fakeActor(2000033, { locX: 20, locY: 0, classId: 17 });
+    const casterSession = fakeSession('bot_party_caster', casterBot);
+    casterSession.followPlayerSession = partyHudLeaderSession;
+    casterSession.partyCompanion = true;
+    casterSession.plan = 'following';
+    originalApplySupportBuff(partyHudBotASession, partyHudBotA, 'shield', { calculateStats() {} }, {
+        casterSession,
+        caster: casterBot
+    });
+    assert(EffectStore.packetEffects(partyHudBotA).some((effect) => effect.id === 1040), 'support buff should be stored as a structured effect');
+    const partyShieldPacket = lastPartySpelledPacket(partyHudLeaderSession, partyHudBotA.fetchId());
+    assert(partyShieldPacket, 'support buff should refresh native party effect icons');
+    assert.strictEqual(partyShieldPacket.readInt32LE(13), 1040, 'party effect packet should include shield skill id');
+    assert(casterSession.packets.some((packet) => packet[0] === 0x48 && packet.readInt32LE(5) === partyHudBotA.fetchId()), 'support buff should broadcast a visible skill cast from the caster');
+
+    EffectStore.apply(partyHudBotB, {
+        key: 'stun',
+        id: 101,
+        level: 1,
+        name: 'Stun',
+        type: 'debuff',
+        category: 'stun',
+        durationMs: 30000
+    });
+    partyHudBotB.moves = [];
+    partyHudBotB.locX = 900;
+    FollowingState.tick(partyHudBotBSession, partyHudBotB, {}, { say() {}, executeCombat() {}, executePvPCombat() {} });
+    assert.strictEqual(partyHudBotB.moves.length, 0, 'stunned companion should not follow or fight');
+    assert.strictEqual(partyHudBotBSession.roleDecision.action, 'disabled', 'stunned companion should expose disabled behavior state');
+    assert(BotStatus.getStatus(partyHudBotBSession).debuffs.some((effect) => effect.key === 'stun'), 'bot status should expose active debuffs');
+    EffectStore.remove(partyHudBotB, 'stun');
+    partyHudBotB.locX = 80;
 
     PartyCompanionService.rebuildWindow(partyHudLeaderSession, 2);
     const changedDistributionPacket = lastPartyAllPacket(partyHudLeaderSession);

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -593,11 +593,12 @@ try {
     const partyHudBotBSession = fakeSession('bot_party_hud_b', partyHudBotB);
     BotManager.sessions = [partyHudBotASession, partyHudBotBSession];
 
-    assert.strictEqual(PartyCompanionService.attach(partyHudLeaderSession, partyHudBotASession), true, 'first companion should attach');
+    assert.strictEqual(PartyCompanionService.attach(partyHudLeaderSession, partyHudBotASession, { distribution: 0 }), true, 'first companion should attach');
     assert.strictEqual(PartyCompanionService.attach(partyHudLeaderSession, partyHudBotBSession), true, 'second companion should attach');
 
     const twoMemberPacket = lastPartyAllPacket(partyHudLeaderSession);
     assert(twoMemberPacket, 'attaching companions should send a party window packet');
+    assert.strictEqual(twoMemberPacket.readInt32LE(5), 0, 'party window should preserve the native loot distribution from invite');
     assert.strictEqual(twoMemberPacket.readInt32LE(9), 2, 'party window should include both active companions');
     assert.deepStrictEqual(
         PartyCompanionService.membersForLeader(partyHudLeaderSession).map((memberSession) => memberSession.actor.fetchName()),
@@ -605,9 +606,16 @@ try {
         'service should preserve both server-side companions'
     );
 
+    PartyCompanionService.rebuildWindow(partyHudLeaderSession, 2);
+    const changedDistributionPacket = lastPartyAllPacket(partyHudLeaderSession);
+    assert(changedDistributionPacket, 'explicit party distribution update should rebuild the party window');
+    assert.strictEqual(changedDistributionPacket.readInt32LE(5), 2, 'explicit party distribution update should be stored');
+    assert.strictEqual(changedDistributionPacket.readInt32LE(9), 2, 'distribution update should keep both party members');
+
     assert.strictEqual(PartyCompanionService.detach(partyHudLeaderSession, partyHudBotASession), true, 'dismiss should detach a companion');
     const oneMemberPacket = lastPartyAllPacket(partyHudLeaderSession);
     assert(oneMemberPacket, 'dismissing one companion should rebuild the party window');
+    assert.strictEqual(oneMemberPacket.readInt32LE(5), 2, 'party window should keep the stored loot distribution after detach');
     assert.strictEqual(oneMemberPacket.readInt32LE(9), 1, 'party window should keep the remaining companion');
     assert.strictEqual(partyHudBotASession.partyCompanion, false, 'dismissed companion should clear party flag');
     assert.strictEqual(partyHudBotASession.followPlayerSession, null, 'dismissed companion should clear leader link');

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -13,6 +13,7 @@ const BotManager = invoke('GameServer/Bot/BotManager');
 const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
 const BotStatus = invoke('GameServer/Bot/AI/BotStatus');
 const BotBrainContext = invoke('GameServer/Bot/AI/BotBrainContext');
+const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
 const CompanionControl = invoke('GameServer/World/Generics/NpcBypasses/CompanionControl');
 const EffectStore = invoke('GameServer/Effects/EffectStore');
 const NpcDied = invoke('GameServer/Actor/Generics/NpcDied');
@@ -210,6 +211,40 @@ try {
 
     assert.strictEqual(bot.moves.length, 1, 'companion should run after the leader at 1200 range');
     assert.strictEqual(bot.fetchLocX(), 1200, 'companion should not teleport at 1200 range');
+
+    const inviteBot = fakeActor(2000033, { locX: 50, locY: 0 });
+    const inviteBotSession = fakeSession('bot_invite_resting', inviteBot);
+    inviteBotSession.plan = 'resting';
+    const originalSetTimeout = global.setTimeout;
+    const originalBotTell = BotManager.botTell;
+    const originalInviteBotSessions = BotManager.sessions;
+    const originalSocialSnapshot = BotSocialMemory.getSnapshot;
+    const originalSocialRecordEvent = BotSocialMemory.recordEvent;
+    let inviteTell = null;
+    try {
+        global.setTimeout = (callback) => {
+            callback();
+            return 0;
+        };
+        BotSocialMemory.getSnapshot = () => ({ trust: 0, familiarity: 0, recentlyAbandonedAt: null });
+        BotSocialMemory.recordEvent = () => Promise.resolve(null);
+        BotManager.botTell = (sourceSession, targetSession, text) => {
+            assert.strictEqual(sourceSession, inviteBotSession, 'invite acknowledgement should come from invited bot');
+            assert.strictEqual(targetSession, leaderSession, 'invite acknowledgement should target party leader');
+            inviteTell = text;
+        };
+        BotManager.sessions = [inviteBotSession];
+
+        assert.strictEqual(World.inviteBotCompanion(leaderSession, leader, inviteBotSession, 1, 'test_invite'), true, 'available resting bot should join the party');
+    } finally {
+        global.setTimeout = originalSetTimeout;
+        BotManager.botTell = originalBotTell;
+        BotManager.sessions = originalInviteBotSessions;
+        BotSocialMemory.getSnapshot = originalSocialSnapshot;
+        BotSocialMemory.recordEvent = originalSocialRecordEvent;
+    }
+    assert.strictEqual(inviteTell, `I'll join you, just need a moment to recover.`, 'resting invite acknowledgement should survive PartyCompanionService.attach');
+    assert.strictEqual(inviteBotSession.plan, 'resting', 'attaching a resting bot should preserve resting state');
 
     const movingBot = fakeActor(2000007, { locX: 500, locY: 0 });
     movingBot.state.setTowards('move');

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -616,6 +616,27 @@ try {
         'service should preserve both server-side companions'
     );
 
+    World.user = { sessions: [partyHudLeaderSession, partyHudBotASession, partyHudBotBSession] };
+    World.fetchNpcsInRadius = () => [];
+    partyHudBotA.locX = 520;
+    partyHudBotB.locX = 540;
+    partyHudBotA.moves = [];
+    partyHudBotB.moves = [];
+    FollowingState.tick(partyHudBotASession, partyHudBotA, {}, { say() {}, executeCombat() {}, executePvPCombat() {} });
+    FollowingState.tick(partyHudBotBSession, partyHudBotB, {}, { say() {}, executeCombat() {}, executePvPCombat() {} });
+    assert(partyHudBotASession.lastFollowMoveTarget, 'first companion should get a formation follow target');
+    assert(partyHudBotBSession.lastFollowMoveTarget, 'second companion should get a formation follow target');
+    assert.notDeepStrictEqual(
+        partyHudBotASession.lastFollowMoveTarget,
+        partyHudBotBSession.lastFollowMoveTarget,
+        'companions should occupy different formation slots'
+    );
+    assert.deepStrictEqual(
+        PartyCompanionService.formationTargetFor(partyHudBotASession),
+        { locX: partyHudLeader.fetchLocX() - 90, locY: partyHudLeader.fetchLocY() - 70, locZ: partyHudLeader.fetchLocZ(), slot: 0 },
+        'first companion should use the first formation slot'
+    );
+
     const casterBot = fakeActor(2000033, { locX: 20, locY: 0, classId: 17 });
     const casterSession = fakeSession('bot_party_caster', casterBot);
     casterSession.followPlayerSession = partyHudLeaderSession;

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -539,6 +539,20 @@ try {
     assert.strictEqual(partyHudBotASession.followPlayerSession, null, 'dismissed companion should clear leader link');
     assert.strictEqual(partyHudBotBSession.partyCompanion, true, 'remaining companion should stay in party');
 
+    const packetsBeforeDisconnectCleanup = partyHudLeaderSession.packets.length;
+    assert.strictEqual(
+        PartyCompanionService.detachAll(partyHudLeaderSession, { rebuildWindow: false, refreshPanel: false }),
+        1,
+        'disconnect cleanup should detach the remaining companion'
+    );
+    assert.strictEqual(
+        partyHudLeaderSession.packets.length,
+        packetsBeforeDisconnectCleanup,
+        'disconnect cleanup should not write party packets to a closing leader session'
+    );
+    assert.strictEqual(partyHudBotBSession.partyCompanion, false, 'disconnect cleanup should clear remaining companion flag');
+    assert.strictEqual(partyHudBotBSession.followPlayerSession, null, 'disconnect cleanup should clear remaining leader link');
+
     const toolBot = fakeActor(2000012, { locX: 0, locY: 0 });
     const toolSession = fakeSession('bot_tool_companion', toolBot);
     toolSession.followPlayerSession = leaderSession;

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -11,6 +11,8 @@ const BotAgentTools = invoke('GameServer/Bot/AI/BotAgentTools');
 const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
 const BotManager = invoke('GameServer/Bot/BotManager');
 const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
+const BotStatus = invoke('GameServer/Bot/AI/BotStatus');
+const BotBrainContext = invoke('GameServer/Bot/AI/BotBrainContext');
 const NpcDied = invoke('GameServer/Actor/Generics/NpcDied');
 const Database = invoke('Database');
 const DataCache = invoke('GameServer/DataCache');
@@ -133,6 +135,10 @@ function fakeActor(id, loc = {}) {
         statusUpdateVitals() {},
         backpack: {
             fetchTotalLoad: () => 0,
+            fetchTotalAdena: () => 0,
+            fetchItems: () => [],
+            fetchItemFromSelfId: () => null,
+            fetchEquippedWeapon: () => null,
             fetchPaperdollId: () => 0,
             fetchPaperdollSelfId: () => 0
         },
@@ -545,6 +551,16 @@ try {
 
     assert.strictEqual(buffedTargetId, unbuffedCompanion.fetchId(), 'buffer should refresh buffs on party companions');
     assert.strictEqual(appliedBuffType, 'shield', 'buffer should apply the missing support buff');
+
+    const compactPartyStatus = BotBrainContext.compactStatus(
+        bufferSession,
+        BotStatus.getStatus(bufferSession),
+        'how is the party?'
+    );
+    assert.strictEqual(compactPartyStatus.party.members.length, 3, 'BotBrain context should include all party members');
+    assert(compactPartyStatus.party.members.some((member) => member.name === unbuffedCompanion.fetchName() && member.hpPct === 100), 'compact party context should expose companion vitals');
+    assert(compactPartyStatus.party.members.some((member) => member.name === bufferBot.fetchName() && member.self === true), 'compact party context should mark the bot itself');
+    assert(compactPartyStatus.party.members.some((member) => member.name === bufferLeader.fetchName() && member.leader === true), 'compact party context should mark the leader');
 
     const rewardLeader = fakeActor(2000010, { locX: 0, locY: 0 });
     const rewardLeaderSession = fakeSession('player_reward', rewardLeader);

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -13,6 +13,7 @@ const BotManager = invoke('GameServer/Bot/BotManager');
 const BotBuffs = invoke('GameServer/Bot/AI/BotBuffs');
 const BotStatus = invoke('GameServer/Bot/AI/BotStatus');
 const BotBrainContext = invoke('GameServer/Bot/AI/BotBrainContext');
+const CompanionControl = invoke('GameServer/World/Generics/NpcBypasses/CompanionControl');
 const NpcDied = invoke('GameServer/Actor/Generics/NpcDied');
 const Database = invoke('Database');
 const DataCache = invoke('GameServer/DataCache');
@@ -611,6 +612,28 @@ try {
     assert(changedDistributionPacket, 'explicit party distribution update should rebuild the party window');
     assert.strictEqual(changedDistributionPacket.readInt32LE(5), 2, 'explicit party distribution update should be stored');
     assert.strictEqual(changedDistributionPacket.readInt32LE(9), 2, 'distribution update should keep both party members');
+
+    partyHudBotASession.currentTargetId = 3001;
+    partyHudBotBSession.currentTargetId = 3002;
+    CompanionControl(partyHudLeaderSession, ['companion-control', 'combat', 'protect']);
+    assert.strictEqual(PartyCompanionService.getSettings(partyHudLeaderSession).combatMode, 'protect', 'party control should store combat mode');
+    assert.strictEqual(partyHudBotASession.currentTargetId, undefined, 'combat mode change should clear stale companion targets');
+    assert.strictEqual(partyHudBotBSession.currentTargetId, undefined, 'combat mode change should clear stale party targets');
+
+    CompanionControl(partyHudLeaderSession, ['companion-control', 'movement', 'hold']);
+    assert.strictEqual(PartyCompanionService.getSettings(partyHudLeaderSession).movementMode, 'hold', 'party control should store movement mode');
+    assert.strictEqual(partyHudBotASession.botStay, true, 'hold mode should park the first companion');
+    assert.strictEqual(partyHudBotBSession.botStay, true, 'hold mode should park the second companion');
+    assert(partyHudBotASession.stayLocation, 'hold mode should record a stay location');
+
+    CompanionControl(partyHudLeaderSession, ['companion-control', 'movement', 'follow']);
+    assert.strictEqual(partyHudBotASession.botStay, false, 'follow mode should release held companions');
+    assert.strictEqual(partyHudBotBSession.botStay, false, 'follow mode should release the full group');
+
+    CompanionControl(partyHudLeaderSession, ['companion-control', 'pull', 'off']);
+    assert.strictEqual(PartyCompanionService.getSettings(partyHudLeaderSession).pullMode, 'off', 'party control should store pull mode');
+    assert.strictEqual(partyHudBotASession.autoTaunt, false, 'pull off should disable companion taunt');
+    assert.strictEqual(partyHudBotBSession.autoTaunt, false, 'pull off should apply to every companion');
 
     assert.strictEqual(PartyCompanionService.detach(partyHudLeaderSession, partyHudBotASession), true, 'dismiss should detach a companion');
     const oneMemberPacket = lastPartyAllPacket(partyHudLeaderSession);

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -613,6 +613,41 @@ try {
     assert.strictEqual(changedDistributionPacket.readInt32LE(5), 2, 'explicit party distribution update should be stored');
     assert.strictEqual(changedDistributionPacket.readInt32LE(9), 2, 'distribution update should keep both party members');
 
+    const lootTarget = {
+        fetchLocX: () => 0,
+        fetchLocY: () => 0
+    };
+    PartyCompanionService.updateSettings(partyHudLeaderSession, { distribution: 3, itemLastLootIndex: -1 });
+    assert.strictEqual(
+        PartyCompanionService.resolveLootSession(partyHudBotASession, 1864, lootTarget),
+        partyHudLeaderSession,
+        'by-turn loot should first route party drops to the leader'
+    );
+    assert.strictEqual(
+        PartyCompanionService.resolveLootSession(partyHudBotASession, 1864, lootTarget),
+        partyHudBotASession,
+        'by-turn loot should rotate to the next companion'
+    );
+    assert.strictEqual(
+        PartyCompanionService.resolveLootSession(partyHudBotASession, 1864, lootTarget),
+        partyHudBotBSession,
+        'by-turn loot should include every nearby party member'
+    );
+    PartyCompanionService.updateSettings(partyHudLeaderSession, { distribution: 0 });
+    assert.strictEqual(
+        PartyCompanionService.resolveLootSession(partyHudBotBSession, 1864, lootTarget),
+        partyHudBotBSession,
+        'finders keepers loot should stay with the looter'
+    );
+    const adenaAllocations = PartyCompanionService.adenaAllocations(partyHudBotASession, 10, lootTarget);
+    assert.strictEqual(adenaAllocations.reduce((sum, entry) => sum + entry.amount, 0), 10, 'party adena split should preserve the full amount');
+    assert.deepStrictEqual(
+        adenaAllocations.map((entry) => entry.session),
+        [partyHudLeaderSession, partyHudBotASession, partyHudBotBSession],
+        'party adena split should include every nearby party member'
+    );
+    PartyCompanionService.rebuildWindow(partyHudLeaderSession, 2);
+
     partyHudBotASession.currentTargetId = 3001;
     partyHudBotBSession.currentTargetId = 3002;
     CompanionControl(partyHudLeaderSession, ['companion-control', 'combat', 'protect']);

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -8,6 +8,8 @@ const HuntingState = invoke('GameServer/Bot/AI/States/HuntingState');
 const RestingState = invoke('GameServer/Bot/AI/States/RestingState');
 const ShoppingState = invoke('GameServer/Bot/AI/States/ShoppingState');
 const BotAgentTools = invoke('GameServer/Bot/AI/BotAgentTools');
+const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
+const BotManager = invoke('GameServer/Bot/BotManager');
 const NpcDied = invoke('GameServer/Actor/Generics/NpcDied');
 const Database = invoke('Database');
 const DataCache = invoke('GameServer/DataCache');
@@ -137,14 +139,17 @@ function fakeActor(id, loc = {}) {
 }
 
 function fakeSession(accountId, actor) {
-    return {
+    const session = {
         accountId,
         actor,
         sent: 0,
-        dataSendToMe() { this.sent++; },
-        dataSendToOthers() { this.sent++; },
-        dataSendToMeAndOthers() { this.sent++; }
+        packets: [],
+        dataSendToMe(packet) { this.sent++; if (packet) this.packets.push(packet); },
+        dataSendToOthers(packet) { this.sent++; if (packet) this.packets.push(packet); },
+        dataSendToMeAndOthers(packet) { this.sent++; if (packet) this.packets.push(packet); }
     };
+    actor.session = session;
+    return session;
 }
 
 const originalUsers = World.user;
@@ -156,6 +161,11 @@ const originalRemoveNpc = World.removeNpc;
 const originalUpdateCharacterExperience = Database.updateCharacterExperience;
 const originalExperience = DataCache.experience;
 const originalRandom = Math.random;
+const originalBotSessions = BotManager.sessions;
+
+function lastPartyAllPacket(session) {
+    return [...session.packets].reverse().find((packet) => packet[0] === 0x4e);
+}
 
 try {
     Math.random = () => 1;
@@ -501,6 +511,34 @@ try {
     assert.strictEqual(rewardBot.fetchExp(), 50, 'companion should keep its split exp from the kill');
     assert.strictEqual(rewardBot.fetchSp(), 10, 'companion should keep its split sp from the kill');
 
+    const partyHudLeader = fakeActor(2000030, { locX: 0, locY: 0 });
+    const partyHudLeaderSession = fakeSession('player_party_hud', partyHudLeader);
+    const partyHudBotA = fakeActor(2000031, { locX: 40, locY: 0 });
+    const partyHudBotASession = fakeSession('bot_party_hud_a', partyHudBotA);
+    const partyHudBotB = fakeActor(2000032, { locX: 80, locY: 0 });
+    const partyHudBotBSession = fakeSession('bot_party_hud_b', partyHudBotB);
+    BotManager.sessions = [partyHudBotASession, partyHudBotBSession];
+
+    assert.strictEqual(PartyCompanionService.attach(partyHudLeaderSession, partyHudBotASession), true, 'first companion should attach');
+    assert.strictEqual(PartyCompanionService.attach(partyHudLeaderSession, partyHudBotBSession), true, 'second companion should attach');
+
+    const twoMemberPacket = lastPartyAllPacket(partyHudLeaderSession);
+    assert(twoMemberPacket, 'attaching companions should send a party window packet');
+    assert.strictEqual(twoMemberPacket.readInt32LE(9), 2, 'party window should include both active companions');
+    assert.deepStrictEqual(
+        PartyCompanionService.membersForLeader(partyHudLeaderSession).map((memberSession) => memberSession.actor.fetchName()),
+        [partyHudBotA.fetchName(), partyHudBotB.fetchName()],
+        'service should preserve both server-side companions'
+    );
+
+    assert.strictEqual(PartyCompanionService.detach(partyHudLeaderSession, partyHudBotASession), true, 'dismiss should detach a companion');
+    const oneMemberPacket = lastPartyAllPacket(partyHudLeaderSession);
+    assert(oneMemberPacket, 'dismissing one companion should rebuild the party window');
+    assert.strictEqual(oneMemberPacket.readInt32LE(9), 1, 'party window should keep the remaining companion');
+    assert.strictEqual(partyHudBotASession.partyCompanion, false, 'dismissed companion should clear party flag');
+    assert.strictEqual(partyHudBotASession.followPlayerSession, null, 'dismissed companion should clear leader link');
+    assert.strictEqual(partyHudBotBSession.partyCompanion, true, 'remaining companion should stay in party');
+
     const toolBot = fakeActor(2000012, { locX: 0, locY: 0 });
     const toolSession = fakeSession('bot_tool_companion', toolBot);
     toolSession.followPlayerSession = leaderSession;
@@ -620,6 +658,7 @@ try {
     World.removeNpc = originalRemoveNpc;
     Database.updateCharacterExperience = originalUpdateCharacterExperience;
     DataCache.experience = originalExperience;
+    BotManager.sessions = originalBotSessions;
 }
 
 console.log('Party companion rest/follow regression checks passed');


### PR DESCRIPTION
## Summary
- centralize party companion state and lifecycle handling
- respect native party loot distribution for rewards, pickups, and spoil/sweep
- add native party buff/debuff visibility plus structured effect state
- expand companion control modes, party-wide support behavior, and formation slots

## Validation
- npm run check
- npm test