### PR TITLE
Polish companion control panel

### DIFF
--- a/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
+++ b/src/GameServer/World/Generics/NpcBypasses/CompanionControl.js
@@ -96,7 +96,142 @@ function handleMemberCommand(session, subCommand, botName) {
     } else if (subCommand === 'summon') {
         summonNear(session, targetSession);
         BotManager.botSay(targetSession, "Summoned to your side!");
+    } else if (subCommand === 'dismiss') {
+        PartyCompanionService.detach(session, targetSession, {
+            event: 'party_kicked',
+            source: 'panel',
+            message: 'Leaving the party. Good luck out there!'
+        });
     }
+}
+
+function compactText(value, fallback = 'idle') {
+    return String(value || fallback)
+        .replace(/_/g, ' ')
+        .replace(/\s+/g, ' ')
+        .slice(0, 32);
+}
+
+function lootLabel(distribution) {
+    return ({
+        0: 'Finders',
+        1: 'Random',
+        2: 'Random+Spoil',
+        3: 'By Turn',
+        4: 'Turn+Spoil'
+    })[distribution] || `Native #${distribution}`;
+}
+
+function actionRow(items, options = {}) {
+    const columns = options.columns || items.length;
+    const width = Math.floor(Html.WIDTH / columns);
+    const cells = [];
+    for (let i = 0; i < columns; i++) {
+        const item = items[i];
+        if (!item) {
+            cells.push(Html.cell('', { width, align: 'center' }));
+            continue;
+        }
+        cells.push(Html.cell(Html.link(item.label, item.command, {
+            color: item.active ? Html.COLOR.title : (item.color || Html.COLOR.link)
+        }), { width, align: 'center' }));
+    }
+    return Html.table([Html.row(cells)]);
+}
+
+function renderModePanel(settings, count) {
+    const title = `${Html.font('Party Control', Html.COLOR.title)} ${Html.font(`${count} active`, Html.COLOR.ok)}`;
+    const summary = [
+        `Combat ${settings.combatMode}`,
+        `Move ${settings.movementMode === 'hold' ? 'hold' : 'follow'}`,
+        `Pull ${settings.pullMode === 'off' ? 'off' : 'auto'}`
+    ].join(' / ');
+
+    return [
+        Html.table([
+            Html.row([
+                Html.cell(title, { width: Html.WIDTH, align: 'center' })
+            ]),
+            Html.row([
+                Html.cell(Html.font(summary, Html.COLOR.muted), { width: Html.WIDTH, align: 'center' })
+            ])
+        ]),
+        actionRow([
+            { label: 'Refresh', command: 'companion-control refresh', color: Html.COLOR.muted }
+        ], { columns: 1 }),
+        Html.font('Combat', Html.COLOR.muted),
+        actionRow([
+            { label: 'Assist', active: settings.combatMode === 'assist', command: 'companion-control combat assist' },
+            { label: 'Protect', active: settings.combatMode === 'protect', command: 'companion-control combat protect' },
+            { label: 'Passive', active: settings.combatMode === 'passive', command: 'companion-control combat passive' }
+        ]),
+        Html.font('Move', Html.COLOR.muted),
+        actionRow([
+            { label: 'Follow', active: settings.movementMode !== 'hold', command: 'companion-control movement follow' },
+            { label: 'Hold', active: settings.movementMode === 'hold', command: 'companion-control movement hold' },
+            { label: 'Regroup', command: 'companion-control regroup', color: Html.COLOR.ok }
+        ]),
+        Html.font('Pull', Html.COLOR.muted),
+        actionRow([
+            { label: 'Auto', active: settings.pullMode !== 'off', command: 'companion-control pull auto' },
+            null,
+            { label: 'Off', active: settings.pullMode === 'off', command: 'companion-control pull off' }
+        ]),
+        Html.font(`Loot: ${lootLabel(settings.distribution)}`, Html.COLOR.muted),
+        '<br1>'
+    ].join('');
+}
+
+function renderCompanionCard(companionSession) {
+    const bot = companionSession.actor;
+    const stayActive = companionSession.botStay === true;
+    const status = BotManager.getBotStatus(companionSession);
+    const role = status?.role || BotRoles.inferRole(bot);
+    const stance = stayActive ? 'hold' : 'follow';
+    const intent = compactText(status?.intent || companionSession.plan, 'idle');
+    const roleDecision = status?.roleDecision
+        ? compactText(`${status.roleDecision.action}/${status.roleDecision.reason}`)
+        : intent;
+    const target = status?.target
+        ? compactText(status.target.name || status.target.id, 'target')
+        : null;
+    const blocker = status?.blockers?.[0]
+        ? compactText(status.blockers[0])
+        : null;
+    const buffWarning = status?.buffs?.needsRefresh ? 'buffs low' : null;
+    const debuff = status?.debuffs?.[0]?.key ? `debuff ${status.debuffs[0].key}` : null;
+    const note = blocker || debuff || buffWarning || target || 'ready';
+    const noteColor = blocker || debuff ? Html.COLOR.warn : Html.COLOR.muted;
+    const pullText = BotRoles.isTank(bot)
+        ? ` / pull ${companionSession.autoTaunt === false ? 'off' : 'auto'}`
+        : '';
+    const primaryAction = stayActive
+        ? { label: 'Follow', command: `companion-control follow ${bot.fetchName()}`, color: Html.COLOR.ok }
+        : { label: 'Hold', command: `companion-control stay ${bot.fetchName()}` };
+
+    const summary = Html.table([
+        Html.row([
+            Html.cell(`${Html.font(bot.fetchName(), Html.COLOR.ok)} ${Html.font(`Lv ${bot.fetchLevel()} ${role}`, Html.COLOR.link)}`, { width: 186 }),
+            Html.cell(Html.font(stance, stance === 'follow' ? Html.COLOR.ok : Html.COLOR.warn), { width: 84, align: 'right' })
+        ]),
+        Html.row([
+            Html.cell(Html.font('Order', Html.COLOR.muted), { width: 54 }),
+            Html.cell(Html.font(roleDecision, Html.COLOR.title), { width: 216, align: 'left' })
+        ]),
+        Html.row([
+            Html.cell(Html.font('State', Html.COLOR.muted), { width: 54 }),
+            Html.cell(`${Html.font(note, noteColor)}${Html.font(pullText, Html.COLOR.muted)}`, { width: 216, align: 'left' })
+        ])
+    ]);
+
+    const actions = actionRow([
+        primaryAction,
+        { label: 'Call', command: `companion-control summon ${bot.fetchName()}` },
+        { label: 'Info', command: `bot-status ${bot.fetchName()}` },
+        { label: 'Dismiss', command: `companion-control dismiss ${bot.fetchName()}`, color: Html.COLOR.warn }
+    ]);
+
+    return `${Html.line(Html.TEXTURE.line, Html.WIDTH, 1)}${summary}${actions}<br1>`;
 }
 
 function companionControl(session, parts) {
@@ -140,58 +275,11 @@ function renderCompanionPanel(session) {
         return;
     }
 
-    const modeLink = (label, active, command) => Html.link(active ? `[${label}]` : label, command, {
-        color: active ? Html.COLOR.title : Html.COLOR.link
-    });
-
-    let body = `${Html.font('Party Control', Html.COLOR.title)}<br1>`;
-    body += Html.statusTable([
-        ['Loot', Html.font(`native #${settings.distribution}`, Html.COLOR.muted)],
-        ['Combat', [
-            modeLink('Assist', settings.combatMode === 'assist', 'companion-control combat assist'),
-            modeLink('Protect', settings.combatMode === 'protect', 'companion-control combat protect'),
-            modeLink('Passive', settings.combatMode === 'passive', 'companion-control combat passive')
-        ].join(' ')],
-        ['Move', [
-            modeLink('Follow', settings.movementMode !== 'hold', 'companion-control movement follow'),
-            modeLink('Hold', settings.movementMode === 'hold', 'companion-control movement hold')
-        ].join(' ')],
-        ['Pull', [
-            modeLink('Auto', settings.pullMode !== 'off', 'companion-control pull auto'),
-            modeLink('Off', settings.pullMode === 'off', 'companion-control pull off')
-        ].join(' ')]
-    ]);
-    body += Html.actionFooter([
-        { label: 'Regroup', command: 'companion-control regroup', color: Html.COLOR.link },
-        { label: 'Refresh', command: 'companion-control refresh', color: Html.COLOR.muted }
-    ]);
+    let body = renderModePanel(settings, myCompanions.length);
     body += Html.spacer(5);
 
     myCompanions.forEach((companionSession) => {
-        const bot = companionSession.actor;
-        const stayActive = companionSession.botStay === true;
-        const status = BotManager.getBotStatus(companionSession);
-        const hpPct = status ? Math.round(status.vitals.hpPct * 100) : 0;
-        const mpPct = status ? Math.round(status.vitals.mpPct * 100) : 0;
-        const roleDecision = status?.roleDecision ? `${status.roleDecision.action}/${status.roleDecision.reason}` : status?.intent;
-        const buffText = status?.buffs?.needsRefresh ? ' / buffs low' : '';
-        const debuffText = status?.debuffs?.length ? ` / debuff ${status.debuffs[0].key}` : '';
-        const stance = stayActive ? 'hold' : 'follow';
-        const pullText = BotRoles.isTank(bot) ? ` / pull ${companionSession.autoTaunt === false ? 'off' : 'auto'}` : '';
-        const actions = [
-            stayActive
-                ? Html.link('Follow', `companion-control follow ${bot.fetchName()}`, { color: Html.COLOR.link })
-                : Html.link('Hold', `companion-control stay ${bot.fetchName()}`, { color: Html.COLOR.link }),
-            Html.link('Summon', `companion-control summon ${bot.fetchName()}`),
-            Html.link('Status', `bot-status ${bot.fetchName()}`)
-        ].join(' | ');
-
-        body += Html.botCard({
-            name: bot.fetchName(),
-            badge: status ? Html.font(status.role || 'bot', Html.COLOR.link) : '',
-            subtitle: status ? `${roleDecision} / ${stance}${pullText} / HP ${hpPct}% / MP ${mpPct}%${buffText}${debuffText}` : 'status unavailable',
-            status: actions
-        });
+        body += renderCompanionCard(companionSession);
         body += Html.spacer(4);
     });
 

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -192,6 +192,18 @@ function lastPartySpelledPacket(session, actorId) {
     ));
 }
 
+function lastNpcHtml(session) {
+    const packet = [...session.packets].reverse().find((candidate) => candidate[0] === 0x0f);
+    if (!packet) return '';
+
+    let end = 5;
+    while (end + 1 < packet.length) {
+        if (packet[end] === 0 && packet[end + 1] === 0) break;
+        end += 2;
+    }
+    return packet.toString('ucs2', 5, end);
+}
+
 try {
     Math.random = () => 1;
     Database.updateCharacterExperience = () => {};
@@ -767,6 +779,24 @@ try {
     assert.strictEqual(PartyCompanionService.getSettings(partyHudLeaderSession).pullMode, 'off', 'party control should store pull mode');
     assert.strictEqual(partyHudBotASession.autoTaunt, false, 'pull off should disable companion taunt');
     assert.strictEqual(partyHudBotBSession.autoTaunt, false, 'pull off should apply to every companion');
+    const companionHtml = lastNpcHtml(partyHudLeaderSession);
+    assert(companionHtml.includes('2 active'), 'party control panel should show active companion count');
+    assert(companionHtml.includes('Loot: Random+Spoil'), 'party control panel should show readable loot mode');
+    assert(companionHtml.includes('<a action='), 'party control panel should use compact links for controls');
+    assert(!companionHtml.includes('<button'), 'party control panel should avoid legacy buttons because they break this client layout');
+    assert(!companionHtml.includes('['), 'active party control items should use color only, not bracket labels');
+    assert(
+        /companion-control pull auto[\s\S]*<td width=90 align=center><\/td>[\s\S]*companion-control pull off/.test(companionHtml),
+        'pull controls should keep Auto in the first column and Off in the third column'
+    );
+    assert(companionHtml.includes('Call'), 'companion cards should expose summon as a compact call action');
+    assert(companionHtml.includes('Info'), 'companion cards should keep a compact status action');
+    assert(companionHtml.includes('Dismiss'), 'companion cards should expose a dismiss action');
+    assert(!companionHtml.includes('HP '), 'party control panel should not duplicate native party HP display');
+    assert(!companionHtml.includes('MP '), 'party control panel should not duplicate native party MP display');
+    assert(!companionHtml.includes('native #'), 'party control panel should not expose raw native loot debug text');
+    assert(!companionHtml.includes('bgcolor=222222'), 'party control panel should avoid the flat grey panel background');
+    assert(!companionHtml.includes('bgcolor=333333'), 'companion cards should avoid the flat grey card background');
 
     assert.strictEqual(PartyCompanionService.detach(partyHudLeaderSession, partyHudBotASession), true, 'dismiss should detach a companion');
     const oneMemberPacket = lastPartyAllPacket(partyHudLeaderSession);


### PR DESCRIPTION
## Summary

Refines the companion party control HTML panel so it behaves reliably in the legacy client:

- replaces unstable button-style controls with compact link-based rows
- removes duplicate HP/MP vitals that already exist in the native party panel
- keeps party actions aligned with fixed-width control cells
- adds a direct dismiss action for companion members
- extends the companion regression test to cover the panel markup constraints

## Validation

- `node --check src\GameServer\World\Generics\NpcBypasses\CompanionControl.js`
- `node --check tests\test_party_companion_rest_follow.js`
- `node tests\test_party_companion_rest_follow.js`
- `npm run check`
- `npm test`