### PR TITLE
Improve C4 geodata city pathing

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -4,6 +4,7 @@ const tests = [
     'tests/test_bot_ai_visibility.js',
     'tests/test_bot_gear.js',
     'tests/test_c4_protocol_packets.js',
+    'tests/test_geodata_regions.js',
     'tests/test_party_companion_rest_follow.js',
     'tests/test_path_obstacle.js',
     'tests/test_pathfinder_astar.js',

--- a/src/GameServer/Actor/Generics/MoveTo.js
+++ b/src/GameServer/Actor/Generics/MoveTo.js
@@ -18,18 +18,6 @@ function moveTo(session, actor, coords) {
     const requestedTo = { ...coords.to };
     let townRouteDiagnostics = null;
 
-    // Dynamic city exit/entrance routing middleware for bots
-    if (isBot) {
-        const TownPathfinder = invoke('GameServer/Bot/AI/TownPathfinder');
-        const routeResult = TownPathfinder.routeWithSession(session, actor, coords.from, coords.to);
-        const routedTo = routeResult.to;
-        townRouteDiagnostics = routeResult.diagnostics;
-        
-        coords.to.locX = routedTo.locX;
-        coords.to.locY = routedTo.locY;
-        coords.to.locZ = routedTo.locZ;
-    }
-
     if (!isBot) {
         // Normal player movement
         session.dataSendToMeAndOthers(ServerResponse.moveToLocation(actor.fetchId(), coords), actor);
@@ -38,9 +26,6 @@ function moveTo(session, actor, coords) {
         const startX = coords.from.locX;
         const startY = coords.from.locY;
         const startZ = coords.from.locZ;
-        const endX = coords.to.locX;
-        const endY = coords.to.locY;
-        const endZ = coords.to.locZ;
 
         // Helper to fetch distance to closest real player
         const getDistanceToClosestPlayer = () => {
@@ -72,16 +57,17 @@ function moveTo(session, actor, coords) {
 
         if (distanceToPlayer > 1500 && !isCompanion) {
             // Low LOD: instant warp (we do not calculate movements at all)
-            const snappedTo = { ...coords.to };
+            const snappedTo = { ...requestedTo };
             snappedTo.locZ = GeodataEngine.getHeight(snappedTo.locX, snappedTo.locY, snappedTo.locZ);
             actor.setLocXYZ(snappedTo);
             session.lastPathfinding = {
                 requestedTo,
-                routedTo: { ...coords.to },
-                townRoute: townRouteDiagnostics,
+                routedTo: { ...snappedTo },
+                townRoute: null,
                 pathLength: 0,
                 lowLodWarp: true,
                 distanceToPlayer,
+                strategy: 'low_lod_direct',
                 at: Date.now()
             };
             return;
@@ -89,19 +75,37 @@ function moveTo(session, actor, coords) {
 
         const isClose = isCompanion || distanceToPlayer <= 500;
 
-        // Compute path using geodata
-        let path = GeodataEngine.findPath(startX, startY, startZ, endX, endY, endZ);
-        console.log(`[PATHFIND] Bot ${actor.fetchName()}: from (${startX}, ${startY}, ${startZ}) to (${endX}, ${endY}, ${endZ}) -> Waypoints: ${path ? path.length : 0}`);
+        let pathTarget = { ...requestedTo };
+        let path = GeodataEngine.findPath(startX, startY, startZ, requestedTo.locX, requestedTo.locY, requestedTo.locZ);
+        let pathStrategy = 'direct_geodata';
+
         if (!path || path.length <= 1) {
-            path = [{ locX: endX, locY: endY, locZ: endZ }];
+            const TownPathfinder = invoke('GameServer/Bot/AI/TownPathfinder');
+            const routeResult = TownPathfinder.routeWithSession(session, actor, coords.from, requestedTo);
+            pathTarget = { ...routeResult.to };
+            townRouteDiagnostics = routeResult.diagnostics;
+            coords.to.locX = pathTarget.locX;
+            coords.to.locY = pathTarget.locY;
+            coords.to.locZ = pathTarget.locZ;
+            pathStrategy = townRouteDiagnostics?.changedTarget ? 'town_waypoint_fallback' : 'direct_fallback';
+
+            path = GeodataEngine.findPath(startX, startY, startZ, pathTarget.locX, pathTarget.locY, pathTarget.locZ);
+        } else if (session) {
+            session.townRoutePlan = null;
+        }
+
+        console.log(`[PATHFIND] Bot ${actor.fetchName()}: from (${startX}, ${startY}, ${startZ}) to (${pathTarget.locX}, ${pathTarget.locY}, ${pathTarget.locZ}) strategy=${pathStrategy} -> Waypoints: ${path ? path.length : 0}`);
+        if (!path || path.length <= 1) {
+            path = [{ locX: pathTarget.locX, locY: pathTarget.locY, locZ: pathTarget.locZ }];
         }
         session.lastPathfinding = {
             requestedTo,
-            routedTo: { ...coords.to },
+            routedTo: { ...pathTarget },
             townRoute: townRouteDiagnostics,
             pathLength: path.length,
             lowLodWarp: false,
             distanceToPlayer,
+            strategy: pathStrategy,
             at: Date.now()
         };
 

--- a/src/GameServer/Geodata/GeodataEngine.js
+++ b/src/GameServer/Geodata/GeodataEngine.js
@@ -2,6 +2,25 @@ const fs = require('fs');
 const path = require('path');
 const VirtualObstacles = invoke('GameServer/Geodata/VirtualObstacles/index');
 
+const REGION_OFFSET_X = 20;
+const REGION_OFFSET_Y = 18;
+
+function getRegionX(x) {
+    return (x >> 15) + REGION_OFFSET_X;
+}
+
+function getRegionY(y) {
+    return (y >> 15) + REGION_OFFSET_Y;
+}
+
+function getLocalX(x, regionX) {
+    return x - ((regionX - REGION_OFFSET_X) << 15);
+}
+
+function getLocalY(y, regionY) {
+    return y - ((regionY - REGION_OFFSET_Y) << 15);
+}
+
 const GeodataEngine = {
     regions: {}, // Loaded region buffers, keyed by "XX_YY"
     missing: {}, // Keys of missing regions, to prevent console spam and repeat disk checks
@@ -10,48 +29,53 @@ const GeodataEngine = {
         console.info("GeodataEngine :: Initializing...");
         VirtualObstacles.init();
         // Preload active regions on startup
-        // NOTE: Giran (27_21), Elven Village (26_18), Orc Village (27_17),
-        //       Dwarven Village (28_11) are beyond geodata coverage (max regionX=26).
-        //       These cities will use fallback Z-height from current actor position.
+        // L2J geodata file names follow client map regions, e.g. T_22_19.
         const activeRegions = [
             // Talking Island (x≈-84k, y≈244k)
-            { x: 22, y: 24 }, // Talking Island Village (core)
-            { x: 22, y: 23 }, // Talking Island (west)
-            { x: 22, y: 25 }, // Talking Island (east)
+            { x: 17, y: 25 }, // Talking Island Village (core)
+            { x: 17, y: 24 }, // Talking Island (south)
 
             // Gludin (x≈-80k, y≈149k)
-            { x: 22, y: 21 }, // Gludin Town (core)
-            { x: 22, y: 20 }, // Gludin (south)
-            { x: 22, y: 22 }, // Gludin (north)
+            { x: 17, y: 22 }, // Gludin Town (core)
+            { x: 17, y: 21 }, // Gludin (south)
+            { x: 17, y: 23 }, // Gludin (north)
 
             // Gludio (x≈-12k, y≈122k)
-            { x: 24, y: 20 }, // Gludio Town (core)
-            { x: 24, y: 19 }, // Gludio (south)
-            { x: 24, y: 21 }, // Gludio (north)
+            { x: 19, y: 21 }, // Gludio Town (core)
+            { x: 19, y: 20 }, // Gludio (south)
+            { x: 19, y: 22 }, // Gludio (north)
 
             // Dion (x≈15k, y≈142k)
-            { x: 25, y: 21 }, // Dion Town (core)
-            { x: 25, y: 20 }, // Dion (south)
+            { x: 20, y: 22 }, // Dion Town (core)
+            { x: 20, y: 21 }, // Dion (south)
 
             // Dark Elven Village (x≈9k, y≈15k)
-            { x: 25, y: 17 }, // Dark Elven Village (core)
-            { x: 24, y: 17 }, // Dark Elven (west)
-            { x: 25, y: 18 }, // Dark Elven (north)
+            { x: 20, y: 18 }, // Dark Elven Village (core)
+            { x: 19, y: 18 }, // Dark Elven (west)
+            { x: 20, y: 19 }, // Dark Elven (north)
 
-            // Orc Village area (x≈84k — outside geodata coverage, but nearby regions)
-            { x: 25, y: 16 }, // Orc Village adjacent area
-            { x: 24, y: 16 }, // Orc Village adjacent area
+            // Orc Village area (x≈84k, y≈-112k)
+            { x: 22, y: 14 }, // Orc Village area
+            { x: 21, y: 14 }, // Orc Village adjacent area
 
             // Neutral Zone / Elven Forest (x≈-10k, y≈75k)
-            { x: 24, y: 19 }, // Neutral Zone area (already loaded for Gludio south)
+            { x: 19, y: 20 }, // Neutral Zone area (already loaded for Gludio south)
 
             // General world areas for pathfinding
-            { x: 25, y: 19 }, // Central area
-            { x: 24, y: 18 }, // Between cities
+            { x: 20, y: 20 }, // Central area
+            { x: 19, y: 19 }, // Between cities
         ];
         activeRegions.forEach(reg => {
             this.loadRegion(reg.x, reg.y);
         });
+    },
+
+    getGeodataDir() {
+        return process.env.L2NODE_GEODATA_DIR || path.join(__dirname, '../../../data/Geodata');
+    },
+
+    getRegionKey(x, y) {
+        return `${getRegionX(x)}_${getRegionY(y)}`;
     },
 
     loadRegion(regionX, regionY) {
@@ -60,8 +84,7 @@ const GeodataEngine = {
             return false;
         }
         
-        // Adjust path to find the Geodata directory under data/Geodata/
-        const filePath = path.join(__dirname, `../../../data/Geodata/${key}.l2j`);
+        const filePath = path.join(this.getGeodataDir(), `${key}.l2j`);
         
         if (fs.existsSync(filePath)) {
             try {
@@ -97,9 +120,8 @@ const GeodataEngine = {
     },
 
     getHeight(x, y, z) {
-        // Lineage 2 coordinate scaling region formula
-        const regionX = (x >> 15) + 25;
-        const regionY = (y >> 15) + 17;
+        const regionX = getRegionX(x);
+        const regionY = getRegionY(y);
 
         const buffer = this.getRegionBuffer(regionX, regionY);
         if (!buffer) {
@@ -107,8 +129,8 @@ const GeodataEngine = {
         }
 
         // Calculate local coordinates inside the region (0 to 32767)
-        const localX = x - ((regionX - 25) << 15);
-        const localY = y - ((regionY - 17) << 15);
+        const localX = getLocalX(x, regionX);
+        const localY = getLocalY(y, regionY);
 
         // Calculate block index inside the region (0 to 255)
         const blockX = localX >> 7;
@@ -180,8 +202,8 @@ const GeodataEngine = {
     },
 
     getCellData(x, y, z) {
-        const regionX = (x >> 15) + 25;
-        const regionY = (y >> 15) + 17;
+        const regionX = getRegionX(x);
+        const regionY = getRegionY(y);
         const regionKey = `${regionX}_${regionY}`;
 
         if (this.checkVirtualObstacles(x, y, regionKey)) {
@@ -193,8 +215,8 @@ const GeodataEngine = {
             return { z: z, nswe: 15 };
         }
 
-        const localX = x - ((regionX - 25) << 15);
-        const localY = y - ((regionY - 17) << 15);
+        const localX = getLocalX(x, regionX);
+        const localY = getLocalY(y, regionY);
 
         const blockX = localX >> 7;
         const blockY = localY >> 7;

--- a/src/GameServer/Geodata/VirtualObstacles/Dion.js
+++ b/src/GameServer/Geodata/VirtualObstacles/Dion.js
@@ -1,6 +1,6 @@
 module.exports = {
     name: "Dion Town",
-    region: "25_21",
+    region: "20_22",
     
     // Developer: Add custom virtual obstacles below to prevent bots from walking through solid structures.
     // Use the coordinates from the map/game client to define town walls and buildings with doors.

--- a/src/GameServer/Geodata/VirtualObstacles/Giran.js
+++ b/src/GameServer/Geodata/VirtualObstacles/Giran.js
@@ -1,6 +1,6 @@
 module.exports = {
     name: "Giran Town",
-    region: "27_21",
+    region: "22_22",
     
     // Developer: Add custom virtual obstacles below to prevent bots from walking through solid structures.
     // Use the coordinates from the map/game client to define town walls and buildings with doors.

--- a/src/GameServer/Geodata/VirtualObstacles/Gludio.js
+++ b/src/GameServer/Geodata/VirtualObstacles/Gludio.js
@@ -1,6 +1,6 @@
 module.exports = {
     name: "Gludio Town",
-    region: "24_20",
+    region: "19_21",
     
     // Developer: Add custom virtual obstacles below to prevent bots from walking through solid structures.
     // Use the coordinates from the map/game client to define town walls and buildings with doors.

--- a/src/GameServer/Geodata/VirtualObstacles/Oren.js
+++ b/src/GameServer/Geodata/VirtualObstacles/Oren.js
@@ -1,6 +1,6 @@
 module.exports = {
     name: "Oren Town",
-    region: "27_18",
+    region: "22_19",
     
     // Developer: Add custom virtual obstacles below to prevent bots from walking through solid structures.
     // Use the coordinates from the map/game client to define town walls and buildings with doors.

--- a/src/GameServer/Geodata/VirtualObstacles/TalkingIsland.js
+++ b/src/GameServer/Geodata/VirtualObstacles/TalkingIsland.js
@@ -1,6 +1,6 @@
 module.exports = {
     name: "Talking Island Town",
-    region: "22_24",
+    region: "17_25",
     walls: [
         { type: "horizontal", y: 243227, minX: -85400, maxX: -83150, gateX: -84081, gateWidth: 300 },
         { type: "horizontal", y: 245800, minX: -85400, maxX: -83150, gateX: -84318, gateWidth: 300 },

--- a/tests/test_geodata_regions.js
+++ b/tests/test_geodata_regions.js
@@ -1,0 +1,21 @@
+require('../src/Global');
+const assert = require('assert');
+const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
+
+const cases = [
+    ['Talking Island', -84108, 244604, '17_25'],
+    ['Gludin', -80752, 149776, '17_22'],
+    ['Gludio', -12736, 122816, '19_21'],
+    ['Dion', 15631, 142885, '20_22'],
+    ['Oren', 82960, 53177, '22_19'],
+    ['Giran', 113845, 144186, '23_22'],
+    ['Aden', 147450, 26741, '24_18'],
+    ['Dwarven Village', 116226, -178529, '23_12'],
+    ['Antharas', 185708, 114298, '25_21']
+];
+
+for (const [name, x, y, expected] of cases) {
+    assert.strictEqual(GeodataEngine.getRegionKey(x, y), expected, name);
+}
+
+console.log('Geodata region mapping checks passed');

--- a/tests/test_path_obstacle.js
+++ b/tests/test_path_obstacle.js
@@ -1,28 +1,24 @@
 require('../src/Global');
+const assert = require('assert');
 const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
 GeodataEngine.init();
 
-console.log("Testing pathfinding around Talking Island South Wall...");
-// Start outside south wall, offset from the gate (gate is at -84081)
+console.log("Testing pathfinding to Talking Island south gate staging point...");
 const startX = -84500;
 const startY = 242800;
 const startZ = -3730;
 
-// End inside town
-const endX = -84318;
-const endY = 244100;
-const endZ = -3730;
+const endX = -83990;
+const endY = 243336;
+const endZ = -3700;
 
 const startTime = Date.now();
 const path = GeodataEngine.findPath(startX, startY, startZ, endX, endY, endZ);
 const elapsed = Date.now() - startTime;
 
 console.log(`Pathfinding took ${elapsed}ms`);
-if (path) {
-    console.log("SUCCESS! Path found with", path.length, "waypoints:");
-    path.forEach((pt, idx) => {
-        console.log(`  Waypoint ${idx}: X: ${pt.locX}, Y: ${pt.locY}, Z: ${pt.locZ}`);
-    });
-} else {
-    console.log("FAILED to find path");
-}
+assert(path, "Expected path to Talking Island south gate staging point");
+console.log("SUCCESS! Path found with", path.length, "waypoints:");
+path.forEach((pt, idx) => {
+    console.log(`  Waypoint ${idx}: X: ${pt.locX}, Y: ${pt.locY}, Z: ${pt.locZ}`);
+});

--- a/tests/test_pathfinder_astar.js
+++ b/tests/test_pathfinder_astar.js
@@ -5,13 +5,20 @@ const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
 // Initialize geodata engine
 GeodataEngine.init();
 
-const blockX = 108;
-const blockY = 114;
+const sampleX = -84108;
+const sampleY = 244604;
+const regionX = (sampleX >> 15) + 20;
+const regionY = (sampleY >> 15) + 18;
+const localX = sampleX - ((regionX - 20) << 15);
+const localY = sampleY - ((regionY - 18) << 15);
+const blockX = localX >> 7;
+const blockY = localY >> 7;
+const regionKey = `${regionX}_${regionY}`;
 
-const buffer = GeodataEngine.getRegionBuffer(22, 24);
-const offsetIndex = GeodataEngine.index_22_24;
+const buffer = GeodataEngine.getRegionBuffer(regionX, regionY);
+const offsetIndex = GeodataEngine[`index_${regionKey}`];
 if (!buffer || !offsetIndex) {
-    console.log("SKIP: raw geodata region 22_24 is not available");
+    console.log(`SKIP: raw geodata region ${regionKey} is not available`);
     process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- correct L2J/C4 geodata region mapping and preload active city regions with the C4 coordinate offsets
- route visible bot movement through direct geodata A* first, keeping the town waypoint router as a fallback
- update virtual obstacle region keys and add regression coverage for region mapping/pathfinding

## Validation
- git diff --cached --check
- npm run check
- npm test
- validated the external C4 geodata pack through L2NODE_GEODATA_DIR without committing geodata files