### PR TITLE
Fix client-safe bot equipment and tell replies

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -2,6 +2,7 @@ const { spawnSync } = require('child_process');
 
 const tests = [
     'tests/test_bot_ai_visibility.js',
+    'tests/test_bot_chat_text.js',
     'tests/test_bot_gear.js',
     'tests/test_c4_protocol_packets.js',
     'tests/test_geodata_regions.js',

--- a/src/GameServer/Bot/AI/BotAgentTools.js
+++ b/src/GameServer/Bot/AI/BotAgentTools.js
@@ -20,7 +20,8 @@ const ACTIONS = [
 ];
 
 function clean(text) {
-    return String(text || '').trim().slice(0, 120);
+    const BotChatText = invoke('GameServer/Bot/AI/BotChatText');
+    return BotChatText.normalize(text).slice(0, BotChatText.DEFAULT_LINE_LIMIT * BotChatText.DEFAULT_MAX_LINES);
 }
 
 function isRealPlayer(session) {

--- a/src/GameServer/Bot/AI/BotBrain.js
+++ b/src/GameServer/Bot/AI/BotBrain.js
@@ -126,7 +126,7 @@ function schema() {
             },
             reply: {
                 type: 'string',
-                description: 'Short in-character bot line, max 120 chars. Empty string when no reply is needed.'
+                description: 'Short in-character bot reply. Empty string when no reply is needed. Long factual lists may be up to 360 chars.'
             },
             targetPlayerName: {
                 type: 'string',
@@ -181,6 +181,7 @@ function userPayload(event, session, status, visiblePlayers, text) {
         tools: BotAgentTools.toolDescriptions(),
         constraints: {
             keepReplyShort: true,
+            splitLongRepliesIntoChatLines: true,
             avoidSpam: true,
             noCombatMicromanagement: true
         },

--- a/src/GameServer/Bot/AI/BotChatText.js
+++ b/src/GameServer/Bot/AI/BotChatText.js
@@ -1,0 +1,57 @@
+const DEFAULT_LINE_LIMIT = 120;
+const DEFAULT_MAX_LINES = 3;
+
+function normalize(text) {
+    return String(text || '').replace(/\s+/g, ' ').trim();
+}
+
+function splitLine(text, limit) {
+    if (text.length <= limit) return [text, ''];
+
+    const window = text.slice(0, limit + 1);
+    const comma = Math.max(window.lastIndexOf(', '), window.lastIndexOf('; '));
+    const sentence = Math.max(window.lastIndexOf('. '), window.lastIndexOf('! '), window.lastIndexOf('? '));
+    const space = window.lastIndexOf(' ');
+    const punctuation = Math.max(comma, sentence);
+    const preferredMinimum = Math.floor(limit * 0.45);
+    const splitAt = punctuation > preferredMinimum ? punctuation : space;
+
+    if (splitAt > Math.floor(limit * 0.55)) {
+        return [text.slice(0, splitAt + 1).trim(), text.slice(splitAt + 1).trim()];
+    }
+
+    return [text.slice(0, limit).trim(), text.slice(limit).trim()];
+}
+
+function splitForTell(text, options = {}) {
+    const limit = Number(options.limit || DEFAULT_LINE_LIMIT);
+    const maxLines = Number(options.maxLines || DEFAULT_MAX_LINES);
+    const lines = [];
+    let rest = normalize(text);
+
+    while (rest && lines.length < maxLines) {
+        const [line, next] = splitLine(rest, limit);
+        if (!line) break;
+
+        if (next && lines.length === maxLines - 1) {
+            const suffix = '...';
+            const shortened = line.length + suffix.length > limit
+                ? line.slice(0, limit - suffix.length).trimEnd()
+                : line;
+            lines.push(`${shortened}${suffix}`);
+            return lines;
+        }
+
+        lines.push(line);
+        rest = next;
+    }
+
+    return lines;
+}
+
+module.exports = {
+    DEFAULT_LINE_LIMIT,
+    DEFAULT_MAX_LINES,
+    normalize,
+    splitForTell
+};

--- a/src/GameServer/Bot/AI/BotEquipmentUpgrade.js
+++ b/src/GameServer/Bot/AI/BotEquipmentUpgrade.js
@@ -81,6 +81,13 @@ function armorKindsFor(role, slot) {
     return [];
 }
 
+function isUnsafeFullBodyRobe(role, item, slot) {
+    return ['mage', 'healer', 'buffer'].includes(role) &&
+        Number(slot) === ARMOR_SLOTS.fullArmor &&
+        item.fetchKind() === 'Armor.Fabric' &&
+        item.fetchRank?.() === 'none';
+}
+
 function isSuitableItem(actor, item) {
     if (!item?.isWearable?.() || item.fetchEquipped?.()) return false;
     if (!rankAllowed(item, actor)) return false;
@@ -99,6 +106,7 @@ function isSuitableItem(actor, item) {
 
     if (item.isArmor()) {
         if (slot === ARMOR_SLOTS.shield && ['mage', 'healer', 'buffer', 'archer', 'dagger'].includes(role)) return false;
+        if (isUnsafeFullBodyRobe(role, item, slot)) return false;
         return armorKindsFor(role, slot).includes(kind);
     }
 

--- a/src/GameServer/Bot/AI/BotRemoteChat.js
+++ b/src/GameServer/Bot/AI/BotRemoteChat.js
@@ -108,7 +108,7 @@ function schema() {
         properties: {
             reply: {
                 type: 'string',
-                description: 'Short in-character private reply, max 120 chars.'
+                description: 'Short in-character private reply. Long factual lists may be up to 360 chars.'
             },
             intent: {
                 type: 'string',
@@ -185,7 +185,8 @@ async function requestLlmReply(payload, cfg) {
         if (!content) return null;
 
         const parsed = JSON.parse(content);
-        const reply = String(parsed.reply || '').trim().slice(0, 120);
+        const BotChatText = invoke('GameServer/Bot/AI/BotChatText');
+        const reply = BotChatText.normalize(parsed.reply).slice(0, BotChatText.DEFAULT_LINE_LIMIT * BotChatText.DEFAULT_MAX_LINES);
         if (!reply || Number(parsed.confidence || 0) < 0.35) return null;
 
         return {

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -489,13 +489,16 @@ const BotAI = {
 
     tell(session, targetSession, text) {
         if (!session.actor || !targetSession || !targetSession.dataSendToMe) return;
-        const clean = String(text || '').trim().slice(0, 120);
-        if (!clean) return;
+        const BotChatText = invoke('GameServer/Bot/AI/BotChatText');
+        const lines = BotChatText.splitForTell(text);
+        if (!lines.length) return;
 
         const ServerResponse = invoke('GameServer/Network/Response');
-        targetSession.dataSendToMe(
-            ServerResponse.speak(session.actor, { kind: 2, text: clean })
-        );
+        lines.forEach((line) => {
+            targetSession.dataSendToMe(
+                ServerResponse.speak(session.actor, { kind: 2, text: line })
+            );
+        });
     },
 
     trade(session, text) {

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -563,11 +563,14 @@ const BotManager = {
 
     botTell(session, targetSession, text) {
         if (!session.actor || !targetSession || !targetSession.dataSendToMe) return;
-        const clean = String(text || '').trim().slice(0, 120);
-        if (!clean) return;
+        const BotChatText = invoke('GameServer/Bot/AI/BotChatText');
+        const lines = BotChatText.splitForTell(text);
+        if (!lines.length) return;
 
         const ServerResponse = invoke('GameServer/Network/Response');
-        targetSession.dataSendToMe(ServerResponse.speak(session.actor, { kind: 2, text: clean }));
+        lines.forEach((line) => {
+            targetSession.dataSendToMe(ServerResponse.speak(session.actor, { kind: 2, text: line }));
+        });
     },
 
     botShout(session, text) {

--- a/src/GameServer/Network/Response/CharInfo.js
+++ b/src/GameServer/Network/Response/CharInfo.js
@@ -2,6 +2,7 @@ const SendPacket = invoke('Packet/Send');
 
 function charInfo(actor) {
     const packet = new SendPacket(0x03);
+    const weaponDisplayId = actor.backpack.fetchPaperdollSelfId(7) || actor.backpack.fetchPaperdollSelfId(14) || 0;
     const pvpFlag = actor.fetchPvpFlag();
     const karma = actor.fetchKarma();
     const runSpeed = actor.fetchCollectiveRunSpd();
@@ -25,14 +26,14 @@ function charInfo(actor) {
         .writeD(actor.fetchClassId())
         .writeD(0x00)  // Hair all
         .writeD(actor.backpack.fetchPaperdollSelfId( 6)) // Head
-        .writeD(actor.backpack.fetchPaperdollSelfId( 7)) // Weapon
+        .writeD(weaponDisplayId) // Weapon
         .writeD(actor.backpack.fetchPaperdollSelfId( 8)) // Shield
         .writeD(actor.backpack.fetchPaperdollSelfId( 9)) // Hands
         .writeD(actor.backpack.fetchPaperdollSelfId(10)) // Chest
         .writeD(actor.backpack.fetchPaperdollSelfId(11)) // Pants
         .writeD(actor.backpack.fetchPaperdollSelfId(12)) // Feet
         .writeD(0x00)  // Back
-        .writeD(actor.backpack.fetchPaperdollSelfId( 7)) // Two-hand weapon display
+        .writeD(weaponDisplayId) // Two-hand weapon display
         .writeD(0x00)  // Hair
         .writeD(pvpFlag)  // Purple = 0x01
         .writeD(karma)

--- a/src/GameServer/World/World.js
+++ b/src/GameServer/World/World.js
@@ -18,12 +18,16 @@ function coldActor(state) {
 }
 
 function coldBotTell(playerSession, state, text) {
-    const clean = String(text || '').trim().slice(0, 120);
-    if (!clean || !state || !playerSession?.dataSendToMe) return;
+    if (!state || !playerSession?.dataSendToMe) return;
+    const BotChatText = invoke('GameServer/Bot/AI/BotChatText');
+    const lines = BotChatText.splitForTell(text);
+    if (!lines.length) return;
 
-    playerSession.dataSendToMe(
-        ServerResponse.speak(coldActor(state), { kind: 2, text: clean })
-    );
+    lines.forEach((line) => {
+        playerSession.dataSendToMe(
+            ServerResponse.speak(coldActor(state), { kind: 2, text: line })
+        );
+    });
 }
 
 function waitForBotSession(BotManager, name, attempts = 40) {

--- a/tests/test_bot_chat_text.js
+++ b/tests/test_bot_chat_text.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const BotAI = invoke('GameServer/Bot/BotAI');
+const BotChatText = invoke('GameServer/Bot/AI/BotChatText');
+const ReceivePacket = invoke('Packet/Receive');
+
+function actor(name, id = 2000001) {
+    return {
+        fetchId: () => id,
+        fetchName: () => name
+    };
+}
+
+function speakText(buffer) {
+    const packet = new ReceivePacket(buffer);
+    packet
+        .readD()
+        .readD()
+        .readS()
+        .readS();
+    return {
+        actorId: packet.data[0],
+        kind: packet.data[1],
+        name: packet.data[2],
+        text: packet.data[3]
+    };
+}
+
+const equipmentReply = 'I have a Staff of Sentinel, Feriotic Tunic, Feriotic Stockings, Leather Cap, Short Gloves, Cotton Shoes, two Earrings of Strength, a Necklace of Knowledge, and two Rings of Anguish.';
+const chunks = BotChatText.splitForTell(equipmentReply);
+
+assert.ok(chunks.length > 1, 'long equipment replies should be split into multiple chat lines');
+assert.ok(chunks.length <= BotChatText.DEFAULT_MAX_LINES, 'chat splitter should cap line count');
+assert.ok(chunks.every((line) => line.length <= BotChatText.DEFAULT_LINE_LIMIT), 'each chat line should fit the safe tell limit');
+assert.ok(!chunks.some((line) => /\bof$/.test(line)), 'chat splitter should avoid awkward mid-item breaks when punctuation is available');
+
+const sourceSession = {
+    actor: actor('Merek', 2000002)
+};
+const targetSession = {
+    packets: [],
+    dataSendToMe(packet) {
+        this.packets.push(packet);
+    }
+};
+
+BotAI.tell(sourceSession, targetSession, equipmentReply);
+
+assert.strictEqual(targetSession.packets.length, chunks.length, 'BotAI.tell should send one packet per split line');
+const decoded = targetSession.packets.map(speakText);
+assert.ok(decoded.every((packet) => packet.kind === 2), 'split bot replies should remain private tells');
+assert.ok(decoded.every((packet) => packet.name === 'Merek'), 'split bot replies should preserve the bot speaker name');
+assert.deepStrictEqual(decoded.map((packet) => packet.text), chunks);
+
+console.log('Bot chat text checks passed');

--- a/tests/test_bot_gear.js
+++ b/tests/test_bot_gear.js
@@ -91,6 +91,17 @@ upgrades = BotEquipmentUpgrade.findBestUpgrades(upgradeSession({
 assert.strictEqual(upgrades.length, 1, 'mage should only upgrade to a suitable caster weapon');
 assert.strictEqual(upgrades[0].item.fetchId(), 1103);
 
+const mageTunic = wearable(1110, { kind: 'Armor.Fabric', slot: 10, pDef: 21, maxMp: 38, equipped: true });
+const mageStockings = wearable(1111, { kind: 'Armor.Fabric', slot: 11, pDef: 13, maxMp: 23, equipped: true });
+const cottonRobe = wearable(1112, { kind: 'Armor.Fabric', slot: 15, pDef: 35, maxMp: 61, price: 3550 });
+upgrades = BotEquipmentUpgrade.findBestUpgrades(upgradeSession({
+    classId: 10,
+    level: 11,
+    items: [mageTunic, mageStockings, cottonRobe],
+    paperdoll: { 10: { id: 1110 }, 11: { id: 1111 } }
+}));
+assert.strictEqual(upgrades.length, 0, 'mage should not upgrade into no-grade full-body robes');
+
 const lowOldSword = wearable(1201, { kind: 'Weapon.Sword', slot: 7, pAtk: 8, equipped: true });
 const tooHighGradeSword = wearable(1202, { kind: 'Weapon.Sword', slot: 7, pAtk: 80, rank: 'd' });
 upgrades = BotEquipmentUpgrade.findBestUpgrades(upgradeSession({

--- a/tests/test_c4_protocol_packets.js
+++ b/tests/test_c4_protocol_packets.js
@@ -15,10 +15,9 @@ function fakePaperdoll() {
     }));
 }
 
-function fakeActor() {
+function fakeActor(paperdoll = fakePaperdoll()) {
     const paperdollIdSlots = [];
     const paperdollSelfIdSlots = [];
-    const paperdoll = fakePaperdoll();
 
     const actor = {
         paperdollIdSlots,
@@ -132,6 +131,18 @@ function findUtf16Terminator(buffer, offset) {
     return -1;
 }
 
+function charInfoEquipment(buffer) {
+    const nameEnd = findUtf16Terminator(buffer, 21);
+    const equipmentOffset = nameEnd + 2 + 16;
+
+    return {
+        head: buffer.readInt32LE(equipmentOffset),
+        weapon: buffer.readInt32LE(equipmentOffset + 4),
+        shield: buffer.readInt32LE(equipmentOffset + 8),
+        twoHand: buffer.readInt32LE(equipmentOffset + 32)
+    };
+}
+
 const authGG = AuthResponse.authGG(0x12345678);
 assert.strictEqual(authGG[0], 0x0b, 'C4 AuthGG response opcode should be 0x0b');
 assert.strictEqual(authGG.readInt32LE(1), 0x12345678);
@@ -175,12 +186,22 @@ assert.ok(userInfo.includes(0xff), 'C4 UserInfo should include trailing name-col
 const charInfo = ServerResponse.charInfo(actor);
 assert.strictEqual(charInfo[0], 0x03);
 assert.ok(charInfo.includes(0xff), 'C4 CharInfo should include trailing name-color bytes');
+assert.strictEqual(charInfoEquipment(charInfo).weapon, 1007, 'C4 CharInfo should display right-hand weapons');
 const nameColorOffset = charInfo.lastIndexOf(Buffer.from([0xff, 0xff, 0xff, 0x00]));
 assert.ok(nameColorOffset > 0, 'C4 CharInfo should end its meaningful payload with name color');
 const charInfoTail = charInfo.subarray(nameColorOffset + 4 - 37, nameColorOffset + 4);
 assert.strictEqual(charInfoTail.readInt32LE(0), 0, 'C4 CharInfo should send mount NPC id before class id');
 assert.strictEqual(charInfoTail.readInt32LE(4), 10, 'C4 CharInfo should send class id after mount NPC id');
 assert.strictEqual(charInfoTail.readInt32LE(8), 0, 'C4 CharInfo should not send CP in the public tail');
+
+const dualPaperdoll = fakePaperdoll();
+dualPaperdoll[7] = {};
+dualPaperdoll[8] = {};
+dualPaperdoll[14] = { id: 4000014, selfId: 999014 };
+const dualCharInfo = ServerResponse.charInfo(fakeActor(dualPaperdoll));
+const dualEquipment = charInfoEquipment(dualCharInfo);
+assert.strictEqual(dualEquipment.weapon, 999014, 'C4 CharInfo should display slot 14 two-hand weapons in the weapon field');
+assert.strictEqual(dualEquipment.twoHand, 999014, 'C4 CharInfo should display slot 14 two-hand weapons in the two-hand field');
 
 const partyAll = ServerResponse.partySmallWindowAll(actor.fetchId(), 1, [actor]);
 assert.strictEqual(partyAll[0], 0x4e);


### PR DESCRIPTION
## Summary
- keep low-level caster bots on client-safe tunic/stockings instead of no-grade full-body robes
- show slot 14 two-hand weapons in public CharInfo so staves render for nearby clients
- split long bot private replies into bounded chat-sized tell messages

## Why
Some generated bot gear was technically equipped but not client-safe: full-body robes and slot 14 staves could appear missing or partially invisible in the C4 client. Long bot equipment replies were also being truncated by the server before they reached the client.

## Validation
- npm run check
- npm test
- live client check: bot armor and Staff of Sentinel now render correctly