### PR TITLE
Improve C4 combat fidelity

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,15 +1,19 @@
 const { spawnSync } = require('child_process');
 
 const tests = [
+    'tests/test_attack_hit_flags.js',
     'tests/test_bot_ai_visibility.js',
     'tests/test_bot_chat_text.js',
     'tests/test_bot_gear.js',
+    'tests/test_c4_buff_modifiers.js',
     'tests/test_c4_protocol_packets.js',
     'tests/test_geodata_regions.js',
     'tests/test_party_companion_rest_follow.js',
     'tests/test_path_obstacle.js',
     'tests/test_pathfinder_astar.js',
     'tests/test_private_tell_routing.js',
+    'tests/test_shot_consumption.js',
+    'tests/test_skill_damage_formulas.js',
     'tests/test_town_pathfinder.js'
 ];
 

--- a/src/GameServer/Actor/Attack.js
+++ b/src/GameServer/Actor/Attack.js
@@ -1,6 +1,7 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const ConsoleText    = invoke('GameServer/ConsoleText');
 const Formulas       = invoke('GameServer/Formulas');
+const DataCache      = invoke('GameServer/DataCache');
 
 class Attack {
     constructor() {
@@ -82,8 +83,11 @@ class Attack {
         }
 
         const speed = Formulas.calcMeleeAtkTime(actor.fetchCollectiveAtkSpd());
-        const hitLanded = Formulas.calcHitChance();
-        session.dataSendToMeAndOthers(ServerResponse.attack(actor, creature.fetchId(), hitLanded ? 0x00 : 0x80), actor);
+        const hitLanded = Formulas.calcHitChance(actor, creature, Math.random, this.positionContext(actor, creature));
+        const usedSoulshot = hitLanded && !!actor.soulshotLoaded;
+        const hit = this.prepareMeleeHit(actor, creature, hitLanded, usedSoulshot);
+
+        session.dataSendToMeAndOthers(ServerResponse.attack(actor, creature.fetchId(), hit), actor);
         actor.state.setHits(true);
 
         this.queueTimer(() => {
@@ -92,16 +96,11 @@ class Attack {
             }
 
             if (hitLanded) {
-                const pAtk  = actor.fetchCollectivePAtk();
-                const pRand = actor.backpack.fetchTotalWeaponPAtkRnd() ?? 0;
-                let damage = Formulas.calcMeleeHit(pAtk, pRand, creature.fetchCollectivePDef());
-                
-                if (actor.soulshotLoaded) {
-                    damage = Math.round(damage * 2.0); // Double physical damage!
+                if (usedSoulshot) {
                     actor.soulshotLoaded = false;
                 }
-                
-                this.hit(session, actor, creature, damage);
+
+                this.hit(session, actor, creature, hit.damage);
             }
             else {
                 ConsoleText.transmit(session, ConsoleText.caption.missedHit);
@@ -136,24 +135,11 @@ class Attack {
             return;
         }
 
-        if (!actor.spiritshotLoaded && actor.backpack && typeof actor.backpack.consumeSpiritshot === 'function') {
-            actor.backpack.consumeSpiritshot(session, (success) => {
-                if (success) {
-                    actor.spiritshotLoaded = true;
+        const magicSkill = this.isMagicSkill(skill);
+        this.chargeShotForSkill(session, actor, magicSkill);
 
-                    session.dataSendToMeAndOthers(
-                        ServerResponse.skillStarted(actor, actor.fetchId(), {
-                            fetchSelfId: () => 2047,
-                            fetchCalculatedHitTime: () => 0,
-                            fetchReuseTime: () => 0
-                        }),
-                        actor
-                    );
-                }
-            });
-        }
-
-        skill.setCalculatedHitTime(Formulas.calcRemoteAtkTime(skill.fetchHitTime(), actor.fetchCollectiveCastSpd()));
+        const attackRate = magicSkill ? actor.fetchCollectiveCastSpd() : actor.fetchCollectiveAtkSpd();
+        skill.setCalculatedHitTime(Formulas.calcRemoteAtkTime(skill.fetchHitTime(), attackRate));
         session.dataSendToMeAndOthers(ServerResponse.skillStarted(actor, creature.fetchId(), skill), actor);
         session.dataSendToMe(ServerResponse.skillDurationBar(skill.fetchCalculatedHitTime()));
         actor.state.setCasts(true);
@@ -166,12 +152,7 @@ class Attack {
             actor.setMp(actor.fetchMp() - skill.fetchConsumedMp());
             actor.statusUpdateVitals(actor);
 
-            const mAtk = actor.fetchCollectiveMAtk();
-            let damage = Formulas.calcRemoteHit(mAtk, skill.fetchPower(), creature.fetchCollectiveMDef());
-            if (actor.spiritshotLoaded) {
-                damage = Math.round(damage * 2.0);
-                actor.spiritshotLoaded = false;
-            }
+            const damage = this.prepareSkillDamage(actor, creature, skill, magicSkill);
             this.hit(session, actor, creature, damage);
             actor.state.setCasts(false);
 
@@ -188,6 +169,214 @@ class Attack {
         this.queueTimer(() => {
             // TODO: Prohibit same skill use before reuse time
         }, skill.fetchReuseTime());
+    }
+
+    chargeShotForSkill(session, actor, magicSkill) {
+        if (magicSkill) {
+            if (!actor.spiritshotLoaded && actor.backpack && typeof actor.backpack.consumeSpiritshot === 'function') {
+                actor.backpack.consumeSpiritshot(session, (success) => {
+                    if (success) {
+                        actor.spiritshotLoaded = true;
+                        this.broadcastShotCharge(session, actor, 2047);
+                    }
+                });
+            }
+            return;
+        }
+
+        if (!actor.soulshotLoaded && actor.backpack && typeof actor.backpack.consumeSoulshot === 'function') {
+            actor.backpack.consumeSoulshot(session, (success) => {
+                if (success) {
+                    actor.soulshotLoaded = true;
+                    this.broadcastShotCharge(session, actor, 2039);
+                }
+            });
+        }
+    }
+
+    broadcastShotCharge(session, actor, skillId) {
+        session.dataSendToMeAndOthers(
+            ServerResponse.skillStarted(actor, actor.fetchId(), {
+                fetchSelfId: () => skillId,
+                fetchCalculatedHitTime: () => 0,
+                fetchReuseTime: () => 0
+            }),
+            actor
+        );
+    }
+
+    isMagicSkill(skill) {
+        return skill.fetchSpell ? skill.fetchSpell() : true;
+    }
+
+    prepareSkillDamage(actor, creature, skill, magicSkill, rng = Math.random) {
+        const shield = Formulas.rollShieldUse({
+            shieldRate: this.fetchShieldRate(creature),
+            dex: creature.fetchDex ? creature.fetchDex() : 0,
+            facing: this.isFacing(creature, actor),
+            bow: this.isBowAttack(actor)
+        }, rng);
+
+        if (shield === Formulas.SHIELD_DEFENSE_PERFECT_BLOCK) {
+            this.clearLoadedShot(actor, magicSkill);
+            return 1;
+        }
+
+        if (magicSkill) {
+            const usedSpiritshot = !!actor.spiritshotLoaded;
+            const shieldMDef = shield === Formulas.SHIELD_DEFENSE_SUCCEED ? this.fetchShieldPDef(creature) : 0;
+            const damage = Math.round(Formulas.calcMagicDamage(
+                actor.fetchCollectiveMAtk(),
+                skill.fetchPower(),
+                creature.fetchCollectiveMDef() + shieldMDef,
+                { spiritshot: usedSpiritshot }
+            ));
+            this.clearLoadedShot(actor, magicSkill);
+            return damage;
+        }
+
+        const usedSoulshot = !!actor.soulshotLoaded;
+        const shieldPDef = shield === Formulas.SHIELD_DEFENSE_SUCCEED ? this.fetchShieldPDef(creature) : 0;
+        const damage = Math.round(Formulas.calcPhysicalDamage(
+            actor.fetchCollectivePAtk(),
+            actor.backpack.fetchTotalWeaponPAtkRnd() ?? 0,
+            creature.fetchCollectivePDef() + shieldPDef,
+            skill.fetchPower(),
+            { soulshot: usedSoulshot }
+        ));
+        this.clearLoadedShot(actor, magicSkill);
+        return damage;
+    }
+
+    clearLoadedShot(actor, magicSkill) {
+        if (magicSkill) actor.spiritshotLoaded = false;
+        else actor.soulshotLoaded = false;
+    }
+
+    prepareMeleeHit(actor, creature, hitLanded, usedSoulshot, rng = Math.random) {
+        if (!hitLanded) {
+            return {
+                damage: 0,
+                flags: ServerResponse.attack.HITFLAG_MISS
+            };
+        }
+
+        const pAtk  = actor.fetchCollectivePAtk();
+        const pRand = actor.backpack.fetchTotalWeaponPAtkRnd() ?? 0;
+        const shieldPDef = this.fetchShieldPDef(creature);
+        const shield = Formulas.rollShieldUse({
+            shieldRate: this.fetchShieldRate(creature),
+            dex: creature.fetchDex ? creature.fetchDex() : 0,
+            facing: this.isFacing(creature, actor),
+            bow: this.isBowAttack(actor)
+        }, rng);
+        const shielded = shield > Formulas.SHIELD_DEFENSE_FAILED;
+        const pDef = creature.fetchCollectivePDef() + (shield === Formulas.SHIELD_DEFENSE_SUCCEED ? shieldPDef : 0);
+        const critical = Formulas.rollCritical(actor.fetchCollectiveCritical ? actor.fetchCollectiveCritical() : 0, rng);
+        const damage = shield === Formulas.SHIELD_DEFENSE_PERFECT_BLOCK
+            ? 1
+            : Math.round(Formulas.calcMeleeDamage(pAtk, pRand, pDef, { critical, soulshot: usedSoulshot }));
+        let flags = usedSoulshot ? ServerResponse.attack.soulshotFlags(actor) : 0;
+
+        if (critical) flags |= ServerResponse.attack.HITFLAG_CRIT;
+        if (shielded) flags |= ServerResponse.attack.HITFLAG_SHLD;
+
+        return {
+            damage,
+            flags
+        };
+    }
+
+    prepareNpcMeleeHit(src, dst, hitLanded, rng = Math.random) {
+        if (!hitLanded) {
+            return {
+                damage: 0,
+                flags: ServerResponse.attack.HITFLAG_MISS
+            };
+        }
+
+        const shieldPDef = this.fetchShieldPDef(dst);
+        const shield = Formulas.rollShieldUse({
+            shieldRate: this.fetchShieldRate(dst),
+            dex: dst.fetchDex ? dst.fetchDex() : 0,
+            facing: this.isFacing(dst, src),
+            bow: this.isBowAttack(src)
+        }, rng);
+        const shielded = shield > Formulas.SHIELD_DEFENSE_FAILED;
+        const pDef = dst.fetchCollectivePDef() + (shield === Formulas.SHIELD_DEFENSE_SUCCEED ? shieldPDef : 0);
+        const critical = Formulas.rollCritical(src.fetchCollectiveCritical ? src.fetchCollectiveCritical() : 0, rng);
+        const damage = shield === Formulas.SHIELD_DEFENSE_PERFECT_BLOCK
+            ? 1
+            : Math.round(Formulas.calcMeleeDamage(src.fetchCollectivePAtk(), 0, pDef, { critical }));
+        let flags = 0;
+
+        if (critical) flags |= ServerResponse.attack.HITFLAG_CRIT;
+        if (shielded) flags |= ServerResponse.attack.HITFLAG_SHLD;
+
+        return { damage, flags };
+    }
+
+    fetchShieldPDef(creature) {
+        if (creature?.backpack?.fetchTotalShieldPDef) {
+            return creature.backpack.fetchTotalShieldPDef();
+        }
+
+        const shield = this.fetchNpcShieldItem(creature);
+        return Number(shield?.stats?.pDef || shield?.pDef || 0);
+    }
+
+    fetchShieldRate(creature) {
+        if (creature?.backpack?.fetchTotalShieldRate) {
+            return creature.backpack.fetchTotalShieldRate();
+        }
+
+        return this.fetchNpcShieldItem(creature) || this.fetchShieldPDef(creature) > 0 ? Formulas.DEFAULT_SHIELD_RATE : 0;
+    }
+
+    isBowAttack(creature) {
+        const kind = creature?.backpack?.fetchTotalWeaponKind ? creature.backpack.fetchTotalWeaponKind() : this.fetchNpcWeaponKind(creature);
+        return kind === 'Weapon.Bow';
+    }
+
+    fetchNpcWeaponKind(creature) {
+        if (!creature?.fetchWeapon || !DataCache.items) return '';
+        const item = DataCache.items.find((entry) => Number(entry.selfId) === Number(creature.fetchWeapon()));
+        return item?.template?.kind || '';
+    }
+
+    fetchNpcShieldItem(creature) {
+        if (!creature?.fetchShield || !DataCache.items) return null;
+        const shieldId = Number(creature.fetchShield());
+        if (!shieldId) return null;
+        return DataCache.items.find((entry) => Number(entry.selfId) === shieldId) || null;
+    }
+
+    isFacing(target, attacker, degrees = Formulas.DEFAULT_SHIELD_DEFENCE_ANGLE) {
+        if (!target?.fetchHead || !attacker?.fetchLocX || degrees >= 360) return true;
+
+        const dx = attacker.fetchLocX() - target.fetchLocX();
+        const dy = attacker.fetchLocY() - target.fetchLocY();
+        if (dx === 0 && dy === 0) return true;
+
+        const heading = Number(target.fetchHead()) || 0;
+        const facingRadians = (heading / 65535) * Math.PI * 2;
+        const targetRadians = Math.atan2(dy, dx);
+        let diff = Math.abs(facingRadians - targetRadians) % (Math.PI * 2);
+        if (diff > Math.PI) diff = (Math.PI * 2) - diff;
+
+        return diff <= (degrees / 2) * (Math.PI / 180);
+    }
+
+    isBehindTarget(attacker, target) {
+        if (!target?.fetchHead || !attacker?.fetchLocX) return false;
+        return this.isFacing(target, attacker, 60) === false && this.isFacing(target, attacker, 240) === false;
+    }
+
+    positionContext(attacker, target) {
+        return {
+            behind: this.isBehindTarget(attacker, target),
+            front: this.isFacing(target, attacker, 120)
+        };
     }
 
     checkParticipants(src, dst) {

--- a/src/GameServer/Actor/Backpack.js
+++ b/src/GameServer/Actor/Backpack.js
@@ -69,8 +69,9 @@ class Backpack extends BackpackModel {
         }
 
         const found = this.items.find(item => item.fetchSelfId() === plan.selfId);
-        if (found) {
-            this.deleteItem(session, found.fetchId(), 1, () => {
+        const cost = this.fetchShotCost('soulshot');
+        if (cost > 0 && found && found.fetchAmount() >= cost) {
+            this.deleteItem(session, found.fetchId(), cost, () => {
                 callback(true);
             });
         } else {
@@ -89,8 +90,9 @@ class Backpack extends BackpackModel {
         }
 
         const found = this.items.find(item => item.fetchSelfId() === plan.selfId);
-        if (found) {
-            this.deleteItem(session, found.fetchId(), 1, () => {
+        const cost = this.fetchShotCost('spiritshot');
+        if (cost > 0 && found && found.fetchAmount() >= cost) {
+            this.deleteItem(session, found.fetchId(), cost, () => {
                 callback(true);
             });
         } else {
@@ -122,7 +124,11 @@ class Backpack extends BackpackModel {
                     if (session.actor.soulshotLoaded) {
                         return; // Already loaded
                     }
-                    this.deleteItem(session, id, 1, () => {
+                    const cost = this.fetchShotCost('soulshot');
+                    if (cost <= 0 || item.fetchAmount() < cost) {
+                        return;
+                    }
+                    this.deleteItem(session, id, cost, () => {
                         session.actor.soulshotLoaded = true;
                         
                         // Play activation effect (Skill 2039)
@@ -142,7 +148,11 @@ class Backpack extends BackpackModel {
                     if (session.actor.spiritshotLoaded) {
                         return; // Already loaded
                     }
-                    this.deleteItem(session, id, 1, () => {
+                    const cost = this.fetchShotCost('spiritshot');
+                    if (cost <= 0 || item.fetchAmount() < cost) {
+                        return;
+                    }
+                    this.deleteItem(session, id, cost, () => {
                         session.actor.spiritshotLoaded = true;
 
                         // Play activation effect (Skill 2047)
@@ -202,6 +212,14 @@ class Backpack extends BackpackModel {
                 utils.infoWarn('GameServer', 'unhandled item action');
             }
         });
+    }
+
+    fetchShotCost(kind) {
+        const weapon = this.fetchEquippedWeapon ? this.fetchEquippedWeapon() : null;
+        const cost = kind === 'spiritshot'
+            ? weapon?.fetchSpiritshot?.()
+            : weapon?.fetchSoulshot?.();
+        return Math.max(0, Number(cost) || 0);
     }
 
     equipGear(session, item) {

--- a/src/GameServer/Actor/Generics/CalculateStats.js
+++ b/src/GameServer/Actor/Generics/CalculateStats.js
@@ -1,4 +1,5 @@
 const Formulas = invoke('GameServer/Formulas');
+const BuffCatalog = invoke('GameServer/Effects/BuffCatalog');
 
 function setCollectiveTotalHp(actor) {
     const base = Formulas.calcHp(actor.fetchLevel(), actor.fetchClassId(), actor.fetchCon());
@@ -31,9 +32,7 @@ function setCollectiveTotalLoad(actor) {
 function setCollectiveTotalPAtk(actor) {
     const pAtk = actor.backpack.fetchTotalWeaponPAtk() ?? actor.fetchPAtk();
     let base = Formulas.calcPAtk(actor.fetchLevel(), actor.fetchStr(), pAtk);
-    if (actor.activeBuffs && actor.activeBuffs.might && Date.now() < actor.activeBuffs.might) {
-        base = Math.round(base * 1.15); // +15% P.Atk
-    }
+    base = Math.round(base * BuffCatalog.statMultiplier(actor, 'might', 'pAtkMul'));
     actor.setCollectivePAtk(base);
 }
 
@@ -46,9 +45,7 @@ function setCollectiveTotalMAtk(actor) {
 function setCollectiveTotalPDef(actor) {
     const pDef = actor.backpack.fetchTotalArmorPDef(actor.isSpellcaster()) ?? actor.fetchPDef();
     let base = Formulas.calcPDef(actor.fetchLevel(), pDef);
-    if (actor.activeBuffs && actor.activeBuffs.shield && Date.now() < actor.activeBuffs.shield) {
-        base = Math.round(base * 1.15); // +15% P.Def
-    }
+    base = Math.round(base * BuffCatalog.statMultiplier(actor, 'shield', 'pDefMul'));
     actor.setCollectivePDef(base);
 }
 
@@ -79,9 +76,7 @@ function setCollectiveTotalCritical(actor) {
 function setCollectiveTotalAtkSpd(actor) {
     const atkSpd = actor.backpack.fetchTotalWeaponAtkSpd() ?? actor.fetchAtkSpd();
     let base   = Formulas.calcAtkSpd(actor.fetchDex(), atkSpd);
-    if (actor.activeBuffs && actor.activeBuffs.haste && Date.now() < actor.activeBuffs.haste) {
-        base = Math.round(base * 1.15); // +15% Atk.Spd
-    }
+    base = Math.round(base * BuffCatalog.statMultiplier(actor, 'haste', 'pAtkSpdMul'));
     actor.setCollectiveAtkSpd(base);
 }
 
@@ -97,9 +92,7 @@ function setCollectiveTotalWalkSpd(actor) {
 
 function setCollectiveTotalRunSpd(actor) {
     let base = Formulas.calcSpeed(actor.fetchDex(), actor.fetchRunSpd());
-    if (actor.activeBuffs && actor.activeBuffs.windWalk && Date.now() < actor.activeBuffs.windWalk) {
-        base += 33; // +33 Run Speed
-    }
+    base += BuffCatalog.statAdd(actor, 'windwalk', 'runSpdAdd');
     actor.setCollectiveRunSpd(base);
 }
 

--- a/src/GameServer/Bot/AI/BotBuffs.js
+++ b/src/GameServer/Bot/AI/BotBuffs.js
@@ -1,15 +1,10 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const EffectStore = invoke('GameServer/Effects/EffectStore');
+const BuffCatalog = invoke('GameServer/Effects/BuffCatalog');
 
 const BUFF_DURATION_MS = 20 * 60 * 1000;
 const REFRESH_THRESHOLD_MS = 2 * 60 * 1000;
-
-const ALL_BUFFS = {
-    windwalk: { key: 'windWalk', id: 1204, level: 2, name: 'Wind Walk' },
-    shield: { key: 'shield', id: 1040, level: 2, name: 'Shield' },
-    haste: { key: 'haste', id: 1086, level: 2, name: 'Haste' },
-    might: { key: 'might', id: 1068, level: 2, name: 'Might' }
-};
+const ALL_BUFFS = BuffCatalog.ALL_BUFFS;
 
 const NEWBIE_BUFF_TYPES = ['windwalk', 'shield', 'haste'];
 const SUPPORT_BUFF_TYPES = ['might', 'shield', 'haste', 'windwalk'];

--- a/src/GameServer/Effects/BuffCatalog.js
+++ b/src/GameServer/Effects/BuffCatalog.js
@@ -1,0 +1,59 @@
+const ALL_BUFFS = {
+    windwalk: {
+        key: 'windWalk',
+        id: 1204,
+        level: 2,
+        name: 'Wind Walk',
+        stats: { runSpdAdd: 33 }
+    },
+    shield: {
+        key: 'shield',
+        id: 1040,
+        level: 2,
+        name: 'Shield',
+        stats: { pDefMul: 1.12 }
+    },
+    haste: {
+        key: 'haste',
+        id: 1086,
+        level: 2,
+        name: 'Haste',
+        stats: { pAtkSpdMul: 1.33 }
+    },
+    might: {
+        key: 'might',
+        id: 1068,
+        level: 2,
+        name: 'Might',
+        stats: { pAtkMul: 1.12 }
+    }
+};
+
+function byTypeOrKey(typeOrKey) {
+    return ALL_BUFFS[typeOrKey] || Object.values(ALL_BUFFS).find((buff) => buff.key === typeOrKey);
+}
+
+function isActive(actor, typeOrKey, at = Date.now()) {
+    const buff = byTypeOrKey(typeOrKey);
+    return !!(buff && actor?.activeBuffs?.[buff.key] && at < actor.activeBuffs[buff.key]);
+}
+
+function statMultiplier(actor, typeOrKey, stat, fallback = 1) {
+    const buff = byTypeOrKey(typeOrKey);
+    if (!buff || !isActive(actor, typeOrKey)) return fallback;
+    return Number(buff.stats?.[stat]) || fallback;
+}
+
+function statAdd(actor, typeOrKey, stat, fallback = 0) {
+    const buff = byTypeOrKey(typeOrKey);
+    if (!buff || !isActive(actor, typeOrKey)) return fallback;
+    return Number(buff.stats?.[stat]) || fallback;
+}
+
+module.exports = {
+    ALL_BUFFS,
+    byTypeOrKey,
+    isActive,
+    statMultiplier,
+    statAdd
+};

--- a/src/GameServer/Formulas.js
+++ b/src/GameServer/Formulas.js
@@ -1,4 +1,11 @@
 const Formulas = {
+    SHIELD_DEFENSE_FAILED: 0,
+    SHIELD_DEFENSE_SUCCEED: 1,
+    SHIELD_DEFENSE_PERFECT_BLOCK: 2,
+    DEFAULT_SHIELD_RATE: 20,
+    DEFAULT_SHIELD_DEFENCE_ANGLE: 120,
+    DEFAULT_PERFECT_SHIELD_BLOCK_RATE: 0,
+
     calcBaseHp: (() => {
         const table = utils.tupleAlloc(100, (level) => {
             utils.infoFail('GameServer', 'unknown HP Table for Level %d', level);
@@ -152,7 +159,8 @@ const Formulas = {
     },
 
     calcMeleeAtkTime(atkSpd) {
-        return 500000 / atkSpd;
+        const rate = Number(atkSpd) || 0;
+        return rate < 2 ? 2700 : 470000 / rate;
     },
 
     calcRemoteAtkTime(time, castSpd) {
@@ -160,17 +168,90 @@ const Formulas = {
     },
 
     calcMeleeHit(pAtk, pAtkRnd, pDef) {
+        return this.calcMeleeDamage(pAtk, pAtkRnd, pDef);
+    },
+
+    calcMeleeDamage(pAtk, pAtkRnd, pDef, { critical = false, soulshot = false, skillPower = 0 } = {}) {
         const pAtkRndMul = 1 + (utils.oneFromSpan(-pAtkRnd, pAtkRnd) / 100);
-        return (77 * pAtk * pAtkRndMul) / pDef;
+        let damage = (pAtk * (soulshot ? 2 : 1)) + (Number(skillPower) || 0);
+
+        if (critical) {
+            damage = 2 * (70 * damage / pDef);
+        }
+        else {
+            damage = 70 * damage / pDef;
+        }
+
+        return damage * pAtkRndMul;
+    },
+
+    calcPhysicalDamage(pAtk, pAtkRnd, pDef, power, options = {}) {
+        return this.calcMeleeDamage(pAtk, pAtkRnd, pDef, {
+            ...options,
+            skillPower: power
+        });
+    },
+
+    rollCritical(critical, rng = Math.random) {
+        return (Number(critical) || 0) > rng() * 1000;
+    },
+
+    rollShieldUse({ shieldRate = 0, dex = 0, facing = true, bow = false, perfectBlockRate = this.DEFAULT_PERFECT_SHIELD_BLOCK_RATE } = {}, rng = Math.random) {
+        if ((Number(shieldRate) || 0) <= 0 || !facing) return this.SHIELD_DEFENSE_FAILED;
+
+        let rate = Number(shieldRate) * this.calcBaseMod.DEX(Math.max(0, Math.min(Math.round(Number(dex) || 0), 99)));
+        if (bow) rate *= 1.3;
+
+        if (rate > 0 && 100 - Number(perfectBlockRate || 0) < rng() * 100) {
+            return this.SHIELD_DEFENSE_PERFECT_BLOCK;
+        }
+
+        return rate > rng() * 100
+            ? this.SHIELD_DEFENSE_SUCCEED
+            : this.SHIELD_DEFENSE_FAILED;
+    },
+
+    calcHitChance(attacker, target, rng = Math.random, context = {}) {
+        const accuracy = safeNumber(attacker?.fetchCollectiveAccur?.(), safeNumber(attacker?.fetchAccur?.(), 0));
+        const evasion = safeNumber(target?.fetchCollectiveEvasion?.(), safeNumber(target?.fetchEvasion?.(), 0));
+        let chance = (80 + (2 * (accuracy - evasion))) * 10;
+        let modifier = 100;
+
+        const zDiff = safeNumber(attacker?.fetchLocZ?.(), 0) - safeNumber(target?.fetchLocZ?.(), 0);
+        if (zDiff > 50) modifier += 3;
+        else if (zDiff < -50) modifier -= 3;
+
+        if (context.behind) modifier += 10;
+        else if (context.front === false) modifier += 5;
+        if (context.night) modifier -= 10;
+
+        chance *= modifier / 100;
+        chance = Math.max(Math.min(chance, 980), 200);
+        return chance >= rng() * 1000;
+    },
+
+    calcMagicDamage(mAtk, power, mDef, { spiritshot = false, blessedSpiritshot = false, magicCritical = false } = {}) {
+        let boostedMAtk = Number(mAtk) || 0;
+        if (blessedSpiritshot) boostedMAtk *= 4;
+        else if (spiritshot) boostedMAtk *= 2;
+
+        let damage = (91 * utils.sqrt(boostedMAtk) * power) / mDef;
+        if (magicCritical) damage *= 4;
+        return damage;
     },
 
     calcRemoteHit(mAtk, power, mDef) {
-        return (91 * utils.sqrt(mAtk) * power) / mDef;
+        return this.calcMagicDamage(mAtk, power, mDef);
     },
 
-    calcHitChance() { // TODO: This is faked for now
-        return Math.random() <= 90.0 / 100.0;
+    calcHitMiss(attacker, target, rng = Math.random, context = {}) {
+        return !this.calcHitChance(attacker, target, rng, context);
     }
 };
+
+function safeNumber(value, fallback) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : fallback;
+}
 
 module.exports = Formulas;

--- a/src/GameServer/Item/Item.js
+++ b/src/GameServer/Item/Item.js
@@ -81,6 +81,10 @@ class Item extends ItemModel {
         return this.model.pDef ?? 0;
     }
 
+    fetchShieldRate() {
+        return this.model.shieldRate ?? 0;
+    }
+
     fetchMDef() {
         return this.model.mDef ?? 0;
     }

--- a/src/GameServer/Model/Actor.js
+++ b/src/GameServer/Model/Actor.js
@@ -102,22 +102,6 @@ class ActorModel extends CreatureModel {
         return this.model.sp;
     }
 
-    fetchAccur() {
-        return 0;
-    }
-
-    fetchCollectiveAccur() {
-        return this.model.collectiveAccur ?? this.fetchAccur();
-    }
-
-    fetchEvasion() {
-        return 0;
-    }
-
-    fetchCollectiveEvasion() {
-        return this.model.collectiveEvasion ?? this.fetchEvasion();
-    }
-
     fetchCritical() {
         return this.model.crit;
     }

--- a/src/GameServer/Model/Backpack.js
+++ b/src/GameServer/Model/Backpack.js
@@ -95,6 +95,16 @@ class BackpackModel {
         );
     }
 
+    fetchTotalShieldPDef() {
+        return this.fetchEquippedArmor(this.equipment.shield)?.fetchPDef() ?? 0;
+    }
+
+    fetchTotalShieldRate() {
+        const shield = this.fetchEquippedArmor(this.equipment.shield);
+        if (!shield) return 0;
+        return shield.fetchShieldRate?.() || 20;
+    }
+
     fetchTotalArmorMDef() {
         const equip = this.equipment;
 
@@ -139,6 +149,18 @@ class BackpackModel {
 
     fetchTotalWeaponAccur() {
         return this.fetchEquippedWeapon()?.fetchAccur();
+    }
+
+    fetchTotalWeaponKind() {
+        return this.fetchEquippedWeapon()?.fetchKind();
+    }
+
+    fetchTotalWeaponSoulshot() {
+        return this.fetchEquippedWeapon()?.fetchSoulshot() ?? 1;
+    }
+
+    fetchTotalWeaponSpiritshot() {
+        return this.fetchEquippedWeapon()?.fetchSpiritshot() ?? 1;
     }
 
     fetchTotalLoad() {

--- a/src/GameServer/Model/Creature.js
+++ b/src/GameServer/Model/Creature.js
@@ -178,6 +178,22 @@ class CreatureModel extends SelectedModel {
         return this.model.pDef;
     }
 
+    fetchAccur() {
+        return this.model.accur ?? 0;
+    }
+
+    fetchCollectiveAccur() {
+        return this.model.collectiveAccur ?? this.fetchAccur();
+    }
+
+    fetchEvasion() {
+        return this.model.evasion ?? 0;
+    }
+
+    fetchCollectiveEvasion() {
+        return this.model.collectiveEvasion ?? this.fetchEvasion();
+    }
+
     fetchCollectivePDef() {
         return this.model.collectivePDef ?? this.fetchPDef();
     }

--- a/src/GameServer/Model/Skill.js
+++ b/src/GameServer/Model/Skill.js
@@ -23,6 +23,10 @@ class SkillModel {
         return this.model.passive;
     }
 
+    fetchSpell() {
+        return this.model.spell === true;
+    }
+
     fetchDistance() {
         return this.model.distance;
     }

--- a/src/GameServer/Network/Response/AbnormalStatusUpdate.js
+++ b/src/GameServer/Network/Response/AbnormalStatusUpdate.js
@@ -1,5 +1,6 @@
 const SendPacket = invoke('Packet/Send');
 const EffectStore = invoke('GameServer/Effects/EffectStore');
+const BuffCatalog = invoke('GameServer/Effects/BuffCatalog');
 
 function abnormalStatusUpdate(buffs = []) {
     const packet = new SendPacket(0x7f); // Opcode 0x7f for MagicEffectIcons / AbnormalStatusUpdate
@@ -24,34 +25,16 @@ abnormalStatusUpdate.fromActor = function(actor) {
     const buffs = [];
     if (actor && actor.activeBuffs) {
         const now = Date.now();
-        if (actor.activeBuffs.windWalk && now < actor.activeBuffs.windWalk) {
-            buffs.push({
-                id: 1204, // Wind Walk
-                level: 2,
-                duration: Math.round((actor.activeBuffs.windWalk - now) / 1000)
-            });
-        }
-        if (actor.activeBuffs.shield && now < actor.activeBuffs.shield) {
-            buffs.push({
-                id: 1040, // Shield
-                level: 2,
-                duration: Math.round((actor.activeBuffs.shield - now) / 1000)
-            });
-        }
-        if (actor.activeBuffs.haste && now < actor.activeBuffs.haste) {
-            buffs.push({
-                id: 1086, // Haste
-                level: 2,
-                duration: Math.round((actor.activeBuffs.haste - now) / 1000)
-            });
-        }
-        if (actor.activeBuffs.might && now < actor.activeBuffs.might) {
-            buffs.push({
-                id: 1068, // Might
-                level: 2,
-                duration: Math.round((actor.activeBuffs.might - now) / 1000)
-            });
-        }
+        Object.values(BuffCatalog.ALL_BUFFS).forEach((buff) => {
+            const expiresAt = actor.activeBuffs[buff.key];
+            if (expiresAt && now < expiresAt) {
+                buffs.push({
+                    id: buff.id,
+                    level: buff.level,
+                    duration: Math.round((expiresAt - now) / 1000)
+                });
+            }
+        });
     }
     return abnormalStatusUpdate(buffs);
 };

--- a/src/GameServer/Network/Response/Attack.js
+++ b/src/GameServer/Network/Response/Attack.js
@@ -1,13 +1,52 @@
 const SendPacket = invoke('Packet/Send');
 
-function attack(src, destId, params) {
+const HITFLAG_USESS = 0x10;
+const HITFLAG_CRIT  = 0x20;
+const HITFLAG_SHLD  = 0x40;
+const HITFLAG_MISS  = 0x80;
+
+const SOULSHOT_GRADES = {
+    none: 0,
+    d: 1,
+    c: 2,
+    b: 3,
+    a: 4,
+    s: 5
+};
+
+function normalizeHit(params) {
+    if (params && typeof params === 'object') {
+        return {
+            damage: Math.max(0, Math.round(Number(params.damage) || 0)),
+            flags: Number(params.flags) || 0
+        };
+    }
+
+    return {
+        damage: 1,
+        flags: Number(params) || 0
+    };
+}
+
+function soulshotGrade(actor) {
+    const weapon = actor?.backpack?.fetchEquippedWeapon ? actor.backpack.fetchEquippedWeapon() : null;
+    const rank = String(weapon?.fetchRank ? weapon.fetchRank() : 'none').toLowerCase();
+    return SOULSHOT_GRADES[rank] ?? SOULSHOT_GRADES.none;
+}
+
+function soulshotFlags(actor) {
+    return HITFLAG_USESS | soulshotGrade(actor);
+}
+
+function attack(src, destId, params = {}) {
     const packet = new SendPacket(0x05);
+    const hit = normalizeHit(params);
 
     packet
         .writeD(src.fetchId())
         .writeD(destId)
-        .writeD(0x01) // Hit?
-        .writeC(params)
+        .writeD(hit.damage)
+        .writeC(hit.flags)
         .writeD(src.fetchLocX())
         .writeD(src.fetchLocY())
         .writeD(src.fetchLocZ())
@@ -15,5 +54,11 @@ function attack(src, destId, params) {
 
     return packet.fetchBuffer();
 }
+
+attack.HITFLAG_USESS = HITFLAG_USESS;
+attack.HITFLAG_CRIT = HITFLAG_CRIT;
+attack.HITFLAG_SHLD = HITFLAG_SHLD;
+attack.HITFLAG_MISS = HITFLAG_MISS;
+attack.soulshotFlags = soulshotFlags;
 
 module.exports = attack;

--- a/src/GameServer/Npc/Npc.js
+++ b/src/GameServer/Npc/Npc.js
@@ -5,6 +5,8 @@ const ConsoleText    = invoke('GameServer/ConsoleText');
 const SpeckMath      = invoke('GameServer/SpeckMath');
 const Formulas       = invoke('GameServer/Formulas');
 const GeodataEngine  = invoke('GameServer/Geodata/GeodataEngine');
+const Attack         = invoke('GameServer/Actor/Attack');
+const AttackHelper   = new Attack();
 
 class Npc extends NpcModel {
     constructor(id, data) {
@@ -137,8 +139,10 @@ class Npc extends NpcModel {
         }
 
         const speed = Formulas.calcMeleeAtkTime(src.fetchCollectiveAtkSpd());
-        const hitLanded = Formulas.calcHitChance();
-        session.dataSendToMeAndOthers(ServerResponse.attack(src, dst.fetchId(), hitLanded ? 0x00 : 0x80), this);
+        const hitLanded = Formulas.calcHitChance(src, dst, Math.random, AttackHelper.positionContext(src, dst));
+        const hit = AttackHelper.prepareNpcMeleeHit(src, dst, hitLanded);
+
+        session.dataSendToMeAndOthers(ServerResponse.attack(src, dst.fetchId(), hit), this);
         src.state.setHits(true);
 
         setTimeout(() => {
@@ -147,8 +151,7 @@ class Npc extends NpcModel {
             }
 
             if (hitLanded) {
-                const pAtk = src.fetchCollectivePAtk();
-                this.hit(session, dst, Formulas.calcMeleeHit(pAtk, 0, dst.fetchCollectivePDef()));
+                this.hit(session, dst, hit.damage);
             }
 
         }, speed * 0.644);

--- a/tests/test_attack_hit_flags.js
+++ b/tests/test_attack_hit_flags.js
@@ -1,0 +1,104 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const Attack = invoke('GameServer/Actor/Attack');
+const ServerResponse = invoke('GameServer/Network/Response');
+const DataCache = invoke('GameServer/DataCache');
+
+function attacker(options = {}) {
+    return {
+        fetchCollectivePAtk: () => 100,
+        fetchCollectiveCritical: () => options.critical ?? 0,
+        fetchLocX: () => 1,
+        fetchLocY: () => 2,
+        fetchLocZ: () => 3,
+        fetchId: () => 2000001,
+        backpack: {
+            fetchTotalWeaponPAtkRnd: () => 0,
+            fetchEquippedWeapon: () => ({
+                fetchRank: () => 'd'
+            })
+        }
+    };
+}
+
+function target(options = {}) {
+    return {
+        fetchCollectivePDef: () => options.pDef ?? 100,
+        fetchLevel: () => options.level ?? 20,
+        fetchDex: () => options.dex ?? 30,
+        fetchLocX: () => 0,
+        fetchLocY: () => 0,
+        fetchHead: () => 8192,
+        backpack: {
+            fetchTotalShieldPDef: () => options.shieldPDef ?? 100,
+            fetchTotalShieldRate: () => options.shieldRate ?? 20
+        }
+    };
+}
+
+const attack = new Attack();
+
+const plainHit = attack.prepareMeleeHit(attacker(), target({ shieldPDef: 0 }), true, false, () => 0.99);
+assert.strictEqual(plainHit.flags, 0, 'plain melee hit should not include extra visual flags');
+assert.strictEqual(plainHit.damage, 70, 'plain melee hit should preserve base physical damage');
+
+let rolls = [0.0, 0.0, 0.0];
+const critShieldSoulshot = attack.prepareMeleeHit(
+    attacker({ critical: 1000 }),
+    target({ shieldPDef: 100, shieldRate: 100, level: 20 }),
+    true,
+    true,
+    () => rolls.shift()
+);
+
+assert.ok(critShieldSoulshot.flags & ServerResponse.attack.HITFLAG_USESS, 'soulshot hit should include soulshot flag');
+assert.ok(critShieldSoulshot.flags & ServerResponse.attack.HITFLAG_CRIT, 'critical hit should include crit flag');
+assert.ok(critShieldSoulshot.flags & ServerResponse.attack.HITFLAG_SHLD, 'shield block should include shield flag');
+assert.strictEqual(critShieldSoulshot.flags & 0x0f, 1, 'D-grade soulshot should include grade 1');
+assert.strictEqual(critShieldSoulshot.damage, 140, 'critical soulshot shielded damage should match server damage');
+
+DataCache.items = [{
+    selfId: 945,
+    template: { kind: 'Armor.Shield' },
+    stats: { pDef: 69 }
+}];
+let npcRolls = [0.0, 0.0, 0.99];
+const npcShieldHit = attack.prepareMeleeHit(attacker(), {
+    fetchCollectivePDef: () => 100,
+    fetchDex: () => 30,
+    fetchLocX: () => 0,
+    fetchLocY: () => 0,
+    fetchHead: () => 8192,
+    fetchShield: () => 945
+}, true, false, () => npcRolls.shift());
+assert.ok(npcShieldHit.flags & ServerResponse.attack.HITFLAG_SHLD, 'NPC shield equipment should roll shield block');
+assert.strictEqual(npcShieldHit.damage, 41, 'NPC shield equipment should add shield P.Def to damage mitigation');
+
+const missedHit = attack.prepareMeleeHit(attacker(), target(), false, true);
+assert.deepStrictEqual(missedHit, {
+    damage: 0,
+    flags: ServerResponse.attack.HITFLAG_MISS
+}, 'miss should carry only the miss flag');
+
+const accurate = {
+    fetchCollectiveAccur: () => 60,
+    fetchLocZ: () => 100
+};
+const evasive = {
+    fetchCollectiveEvasion: () => 40,
+    fetchLocZ: () => 0
+};
+assert.strictEqual(
+    invoke('GameServer/Formulas').calcHitChance(accurate, evasive, () => 0.97),
+    true,
+    'high accuracy should use L2J-style clamped hit chance'
+);
+assert.strictEqual(
+    invoke('GameServer/Formulas').calcHitChance(accurate, evasive, () => 0.99),
+    false,
+    'L2J-style hit chance should still allow misses above the 98% clamp'
+);
+
+console.log('Attack hit flag checks passed');

--- a/tests/test_c4_buff_modifiers.js
+++ b/tests/test_c4_buff_modifiers.js
@@ -1,0 +1,100 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const calculateStats = invoke('GameServer/Actor/Generics/CalculateStats');
+const Formulas = invoke('GameServer/Formulas');
+
+function actorWithBuffs() {
+    const actor = {
+        level: 20,
+        classId: 0,
+        hp: 100,
+        mp: 100,
+        activeBuffs: {
+            might: Date.now() + 60000,
+            shield: Date.now() + 60000,
+            haste: Date.now() + 60000,
+            windWalk: Date.now() + 60000
+        },
+        fetchLevel() { return this.level; },
+        fetchClassId() { return this.classId; },
+        fetchCon() { return 30; },
+        fetchMen() { return 30; },
+        fetchStr() { return 30; },
+        fetchDex() { return 30; },
+        fetchInt() { return 30; },
+        fetchWit() { return 30; },
+        fetchHp() { return this.hp; },
+        fetchMp() { return this.mp; },
+        fetchMaxHp() { return this.maxHp; },
+        fetchMaxMp() { return this.maxMp; },
+        fetchPAtk() { return 10; },
+        fetchMAtk() { return 10; },
+        fetchPDef() { return 10; },
+        fetchMDef() { return 10; },
+        fetchAccur() { return 0; },
+        fetchEvasion() { return 0; },
+        fetchCritical() { return 40; },
+        fetchAtkSpd() { return 300; },
+        fetchWalkSpd() { return 80; },
+        fetchRunSpd() { return 120; },
+        isSpellcaster() { return 0; },
+        setMaxHp(value) { this.maxHp = value; },
+        setHp(value) { this.hp = value; },
+        setMaxMp(value) { this.maxMp = value; },
+        setMp(value) { this.mp = value; },
+        setMaxLoad(value) { this.maxLoad = value; },
+        setLoad(value) { this.load = value; },
+        setCollectivePAtk(value) { this.collectivePAtk = value; },
+        setCollectiveMAtk(value) { this.collectiveMAtk = value; },
+        setCollectivePDef(value) { this.collectivePDef = value; },
+        setCollectiveMDef(value) { this.collectiveMDef = value; },
+        setCollectiveAccur(value) { this.collectiveAccur = value; },
+        setCollectiveEvasion(value) { this.collectiveEvasion = value; },
+        setCollectiveCritical(value) { this.collectiveCritical = value; },
+        setCollectiveAtkSpd(value) { this.collectiveAtkSpd = value; },
+        setCollectiveCastSpd(value) { this.collectiveCastSpd = value; },
+        setCollectiveWalkSpd(value) { this.collectiveWalkSpd = value; },
+        setCollectiveRunSpd(value) { this.collectiveRunSpd = value; },
+        backpack: {
+            fetchTotalArmorBonusMp: () => 0,
+            fetchTotalLoad: () => 0,
+            fetchTotalWeaponPAtk: () => 100,
+            fetchTotalWeaponMAtk: () => 50,
+            fetchTotalArmorPDef: () => 100,
+            fetchTotalArmorMDef: () => 80,
+            fetchTotalWeaponAccur: () => 5,
+            fetchTotalArmorEvasion: () => 2,
+            fetchTotalWeaponCritical: () => 40,
+            fetchTotalWeaponAtkSpd: () => 300
+        }
+    };
+    return actor;
+}
+
+const actor = actorWithBuffs();
+calculateStats({}, actor);
+
+assert.strictEqual(
+    actor.collectivePAtk,
+    Math.round(Formulas.calcPAtk(20, 30, 100) * 1.12),
+    'Might level 2 should use the C4/L2J 1.12 PAtk multiplier'
+);
+assert.strictEqual(
+    actor.collectivePDef,
+    Math.round(Formulas.calcPDef(20, 100) * 1.12),
+    'Shield level 2 should use the C4/L2J 1.12 PDef multiplier'
+);
+assert.strictEqual(
+    actor.collectiveAtkSpd,
+    Math.round(Formulas.calcAtkSpd(30, 300) * 1.33),
+    'Haste level 2 should use the C4/L2J 1.33 PAtkSpd multiplier'
+);
+assert.strictEqual(
+    actor.collectiveRunSpd,
+    Formulas.calcSpeed(30, 120) + 33,
+    'Wind Walk level 2 should add 33 run speed'
+);
+
+console.log('C4 buff modifier checks passed');

--- a/tests/test_c4_protocol_packets.js
+++ b/tests/test_c4_protocol_packets.js
@@ -233,6 +233,18 @@ assert.strictEqual(partySpelled.readInt32LE(13), 1040, 'PartySpelled should incl
 assert.strictEqual(partySpelled.readInt16LE(17), 2, 'PartySpelled should include effect level');
 assert.strictEqual(partySpelled.readInt32LE(19), 120, 'PartySpelled should include remaining duration');
 
+const attack = ServerResponse.attack(actor, 3000001, {
+    damage: 123,
+    flags: ServerResponse.attack.HITFLAG_USESS | 1
+});
+assert.strictEqual(attack[0], 0x05, 'C4 Attack opcode should be 0x05');
+assert.strictEqual(attack.readInt32LE(1), actor.fetchId(), 'C4 Attack should include attacker id');
+assert.strictEqual(attack.readInt32LE(5), 3000001, 'C4 Attack should include target id');
+assert.strictEqual(attack.readInt32LE(9), 123, 'C4 Attack should include actual damage');
+assert.strictEqual(attack[13], 0x11, 'C4 Attack should include soulshot flag and grade');
+assert.strictEqual(attack.readInt32LE(14), actor.fetchLocX(), 'C4 Attack should include attacker X');
+assert.strictEqual(attack.readInt16LE(26), 0, 'C4 Attack should send no extra hits for a single target');
+
 const npcInfo = ServerResponse.npcInfo(fakeNpc());
 assert.strictEqual(npcInfo[0], 0x16);
 assert.ok(npcInfo.length >= 208, 'C4 NpcInfo should include team/collision tail fields');

--- a/tests/test_shot_consumption.js
+++ b/tests/test_shot_consumption.js
@@ -1,0 +1,86 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const DataCache = invoke('GameServer/DataCache');
+DataCache.init();
+
+const Backpack = invoke('GameServer/Actor/Backpack');
+const Item = invoke('GameServer/Item/Item');
+const Database = invoke('Database');
+
+Database.updateItemAmount = () => Promise.resolve();
+Database.deleteItem = () => Promise.resolve();
+
+function item(id, data) {
+    return new Item(id, {
+        selfId: data.selfId,
+        kind: data.kind,
+        amount: data.amount,
+        equipped: data.equipped || false,
+        slot: data.slot || 0,
+        soulshot: data.soulshot || 0,
+        spiritshot: data.spiritshot || 0,
+        rank: data.rank || 'none'
+    });
+}
+
+function sessionFor(backpack, classId = 0) {
+    const actor = {
+        backpack,
+        fetchId: () => 2000001,
+        fetchClassId: () => classId,
+        isDead: () => false
+    };
+    return {
+        actor,
+        dataSendToMe() {},
+        dataSendToMeAndOthers() {}
+    };
+}
+
+const soulBackpack = new Backpack({ paperdoll: Array.from({ length: 16 }, () => ({})), items: [] });
+soulBackpack.items = [
+    item(1, { selfId: 1, kind: 'Weapon.Sword', equipped: true, slot: 7, soulshot: 2, rank: 'none' }),
+    item(2, { selfId: 1835, kind: 'Other.Shot', amount: 5 })
+];
+let consumed = false;
+soulBackpack.consumeSoulshot(sessionFor(soulBackpack), (ok) => { consumed = ok; });
+assert.strictEqual(consumed, true, 'soulshot should consume when enough shots exist');
+assert.strictEqual(soulBackpack.fetchItemFromSelfId(1835).fetchAmount(), 3, 'soulshot consume should use weapon shot cost');
+
+const lowBackpack = new Backpack({ paperdoll: Array.from({ length: 16 }, () => ({})), items: [] });
+lowBackpack.items = [
+    item(3, { selfId: 1, kind: 'Weapon.Sword', equipped: true, slot: 7, soulshot: 3, rank: 'none' }),
+    item(4, { selfId: 1835, kind: 'Other.Shot', amount: 2 })
+];
+consumed = true;
+lowBackpack.consumeSoulshot(sessionFor(lowBackpack), (ok) => { consumed = ok; });
+assert.strictEqual(consumed, false, 'soulshot should not charge when stack is below weapon shot cost');
+assert.strictEqual(lowBackpack.fetchItemFromSelfId(1835).fetchAmount(), 2, 'failed charge should not delete remaining shots');
+
+const zeroCostBackpack = new Backpack({ paperdoll: Array.from({ length: 16 }, () => ({})), items: [] });
+zeroCostBackpack.items = [
+    item(7, { selfId: 1, kind: 'Weapon.Sword', equipped: true, slot: 7, soulshot: 0, rank: 'none' }),
+    item(8, { selfId: 1835, kind: 'Other.Shot', amount: 5 })
+];
+consumed = true;
+const zeroCostSession = sessionFor(zeroCostBackpack);
+zeroCostBackpack.consumeSoulshot(zeroCostSession, (ok) => { consumed = ok; });
+assert.strictEqual(consumed, false, 'soulshot should not charge for weapons with explicit zero shot cost');
+assert.strictEqual(zeroCostBackpack.fetchItemFromSelfId(1835).fetchAmount(), 5, 'zero-cost weapon should not consume shots');
+zeroCostBackpack.useItem(zeroCostSession, 8);
+assert.strictEqual(zeroCostSession.actor.soulshotLoaded, undefined, 'manual use should not load soulshot for zero-cost weapons');
+assert.strictEqual(zeroCostBackpack.fetchItemFromSelfId(1835).fetchAmount(), 5, 'manual zero-cost charge should not consume shots');
+
+const spiritBackpack = new Backpack({ paperdoll: Array.from({ length: 16 }, () => ({})), items: [] });
+spiritBackpack.items = [
+    item(5, { selfId: 10, kind: 'Weapon.Blunt', equipped: true, slot: 7, spiritshot: 2, rank: 'none' }),
+    item(6, { selfId: 2509, kind: 'Other.Shot', amount: 4 })
+];
+consumed = false;
+spiritBackpack.consumeSpiritshot(sessionFor(spiritBackpack, 10), (ok) => { consumed = ok; });
+assert.strictEqual(consumed, true, 'spiritshot should consume for caster classes');
+assert.strictEqual(spiritBackpack.fetchItemFromSelfId(2509).fetchAmount(), 2, 'spiritshot consume should use weapon shot cost');
+
+console.log('Shot consumption checks passed');

--- a/tests/test_skill_damage_formulas.js
+++ b/tests/test_skill_damage_formulas.js
@@ -1,0 +1,107 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const Attack = invoke('GameServer/Actor/Attack');
+const Formulas = invoke('GameServer/Formulas');
+
+function actor() {
+    return {
+        soulshotLoaded: false,
+        spiritshotLoaded: false,
+        fetchId: () => 2000001,
+        fetchLocX: () => 1,
+        fetchLocY: () => 2,
+        fetchLocZ: () => 3,
+        fetchCollectivePAtk: () => 100,
+        fetchCollectiveMAtk: () => 100,
+        fetchCollectiveAtkSpd: () => 333,
+        fetchCollectiveCastSpd: () => 666,
+        backpack: {
+            fetchTotalWeaponPAtkRnd: () => 0
+        }
+    };
+}
+
+function target() {
+    return {
+        fetchCollectivePDef: () => 100,
+        fetchCollectiveMDef: () => 50,
+        fetchDex: () => 30,
+        fetchLocX: () => 0,
+        fetchLocY: () => 0,
+        fetchLocZ: () => 0,
+        fetchHead: () => 8192
+    };
+}
+
+function skill({ spell, power }) {
+    return {
+        fetchSpell: () => spell,
+        fetchPower: () => power
+    };
+}
+
+const magicNoShot = Math.round(Formulas.calcMagicDamage(100, 10, 50));
+const magicWithSpiritshot = Math.round(Formulas.calcMagicDamage(100, 10, 50, { spiritshot: true }));
+assert.strictEqual(magicNoShot, 182, 'magic damage should use 91 * sqrt(MAtk) * power / MDef');
+assert.strictEqual(magicWithSpiritshot, 257, 'spiritshot should multiply MAtk before sqrt, not final damage');
+
+const physicalWithSoulshot = Math.round(Formulas.calcPhysicalDamage(100, 0, 100, 25, { soulshot: true }));
+assert.strictEqual(physicalWithSoulshot, 158, 'physical skills should add skill power after soulshot boosts PAtk');
+assert.strictEqual(Math.round(Formulas.calcMeleeAtkTime(1000)), 470, 'melee attack time should use the L2J 470000/rate constant');
+assert.strictEqual(Formulas.calcMeleeAtkTime(1), 2700, 'melee attack time should keep the L2J low-rate guard');
+assert.strictEqual(Math.round(Formulas.calcRemoteAtkTime(1500, 333)), 1500, 'skill hit time should scale with the 333/rate constant');
+
+const attack = new Attack();
+const magicActor = actor();
+magicActor.spiritshotLoaded = true;
+const castDamage = attack.prepareSkillDamage(magicActor, target(), skill({ spell: true, power: 10 }), true, () => 0.99);
+assert.strictEqual(castDamage, 257, 'magic skill damage should follow C4 magic formula with spiritshot');
+assert.strictEqual(magicActor.spiritshotLoaded, false, 'magic skill should clear used spiritshot charge');
+
+const physicalActor = actor();
+physicalActor.soulshotLoaded = true;
+const strikeDamage = attack.prepareSkillDamage(physicalActor, target(), skill({ spell: false, power: 25 }), false, () => 0.99);
+assert.strictEqual(strikeDamage, 158, 'physical skill damage should follow C4 physical formula with soulshot');
+assert.strictEqual(physicalActor.soulshotLoaded, false, 'physical skill should clear used soulshot charge');
+
+const physicalChargeActor = actor();
+let soulshotConsumed = false;
+let spiritshotConsumed = false;
+physicalChargeActor.backpack.consumeSoulshot = (session, callback) => {
+    soulshotConsumed = true;
+    callback(true);
+};
+physicalChargeActor.backpack.consumeSpiritshot = (session, callback) => {
+    spiritshotConsumed = true;
+    callback(true);
+};
+attack.chargeShotForSkill({
+    actor: physicalChargeActor,
+    dataSendToMeAndOthers() {}
+}, physicalChargeActor, false);
+assert.strictEqual(soulshotConsumed, true, 'physical skill should try to charge soulshot');
+assert.strictEqual(spiritshotConsumed, false, 'physical skill should not try to charge spiritshot');
+assert.strictEqual(physicalChargeActor.soulshotLoaded, true, 'physical skill should load soulshot on successful consume');
+
+const magicChargeActor = actor();
+soulshotConsumed = false;
+spiritshotConsumed = false;
+magicChargeActor.backpack.consumeSoulshot = (session, callback) => {
+    soulshotConsumed = true;
+    callback(true);
+};
+magicChargeActor.backpack.consumeSpiritshot = (session, callback) => {
+    spiritshotConsumed = true;
+    callback(true);
+};
+attack.chargeShotForSkill({
+    actor: magicChargeActor,
+    dataSendToMeAndOthers() {}
+}, magicChargeActor, true);
+assert.strictEqual(soulshotConsumed, false, 'magic skill should not try to charge soulshot');
+assert.strictEqual(spiritshotConsumed, true, 'magic skill should try to charge spiritshot');
+assert.strictEqual(magicChargeActor.spiritshotLoaded, true, 'magic skill should load spiritshot on successful consume');
+
+console.log('Skill damage formula checks passed');


### PR DESCRIPTION
## Summary
- Add C4-style attack hit flags for soulshots, critical hits, shield blocks, and misses so target impact effects match combat results.
- Route melee, physical-skill, and magic-skill damage through shared C4/L2J-like formulas, including hit chance, critical damage, shield defense, shot bonuses, and attack timing.
- Normalize C4 buff stat modifiers and shot consumption behavior, including NPC shield handling and zero-cost weapon shot guards.

## Validation
- `npm run check`
- `npm test`