### PR TITLE
Enforce skill cooldowns

### DIFF
--- a/src/GameServer/Actor/Actor.js
+++ b/src/GameServer/Actor/Actor.js
@@ -15,6 +15,7 @@ class Actor extends ActorModel {
         this.backpack   = new Backpack(data);
         this.attack     = new Attack();
         this.automation = new Automation();
+        this.skillReuseUntil = new Map();
 
         this.session    = session;
         this.previousXY = undefined;
@@ -84,6 +85,15 @@ class Actor extends ActorModel {
         invoke(path.actor).skillRequest(
             this.session, this, data
         );
+    }
+
+    canUseSkill(skill, now = Date.now()) {
+        return (this.skillReuseUntil.get(skill.fetchSelfId()) || 0) <= now;
+    }
+
+    markSkillReuse(skill, now = Date.now()) {
+        const reuse = Math.max(0, Number(skill.fetchReuseTime()) || 0);
+        this.skillReuseUntil.set(skill.fetchSelfId(), now + reuse);
     }
 
     revive() {

--- a/src/GameServer/Actor/Attack.js
+++ b/src/GameServer/Actor/Attack.js
@@ -154,6 +154,11 @@ class Attack {
             return;
         }
 
+        if (actor.canUseSkill?.(skill) === false) {
+            session.dataSendToMe?.(ServerResponse.actionFailed());
+            return;
+        }
+
         if (actor.fetchMp() < skill.fetchConsumedMp()) {
             ConsoleText.transmit(session, ConsoleText.caption.depletedMp);
             return;
@@ -170,6 +175,7 @@ class Attack {
 
         const attackRate = magicSkill ? actor.fetchCollectiveCastSpd() : actor.fetchCollectiveAtkSpd();
         skill.setCalculatedHitTime(Formulas.calcRemoteAtkTime(skill.fetchHitTime(), attackRate));
+        actor.markSkillReuse?.(skill);
         session.dataSendToMeAndOthers(ServerResponse.skillStarted(actor, creature.fetchId(), skill), actor);
         session.dataSendToMe(ServerResponse.skillDurationBar(skill.fetchCalculatedHitTime()));
         actor.state.setCasts(true);
@@ -224,9 +230,6 @@ class Attack {
 
         }, skill.fetchCalculatedHitTime());
 
-        this.queueTimer(() => {
-            // TODO: Prohibit same skill use before reuse time
-        }, skill.fetchReuseTime());
     }
 
     captureShotState(actor) {

--- a/src/GameServer/Actor/Backpack.js
+++ b/src/GameServer/Actor/Backpack.js
@@ -528,6 +528,11 @@ class Backpack extends BackpackModel {
             return false;
         }
 
+        if (session.actor.canUseSkill?.(skill) === false) {
+            session.dataSendToMe(ServerResponse.actionFailed());
+            return true;
+        }
+
         if (['corpse_player', 'corpse_pet'].includes(skill.fetchTargetKind())) {
             return this.useResurrectionItem(session, id, itemSkill, skill);
         }
@@ -569,6 +574,7 @@ class Backpack extends BackpackModel {
         }
 
         const castTime = skill.fetchHitTime() || 0;
+        session.actor.markSkillReuse?.(skill);
         session.actor.state.setCasts(true);
         session.dataSendToMeAndOthers(ServerResponse.skillStarted(session.actor, session.actor.fetchId(), skill), session.actor);
         if (castTime > 0) {
@@ -616,6 +622,7 @@ class Backpack extends BackpackModel {
         }
 
         const feed = Number(skill.fetchSemantic().feed) || 0;
+        session.actor.markSkillReuse?.(skill);
         this.deleteItem(session, id, itemSkill.consumeCount || 1, () => {
             this.applyPetFood(eater, feed);
             session.dataSendToMeAndOthers(ServerResponse.skillStarted(eater, eater.fetchId(), skill), eater);
@@ -689,6 +696,7 @@ class Backpack extends BackpackModel {
             return true;
         }
 
+        session.actor.markSkillReuse?.(skill);
         this.deleteItem(session, id, 1, () => {
             if (weapon.model) {
                 weapon.model.chargedFishShot = true;
@@ -712,6 +720,7 @@ class Backpack extends BackpackModel {
             return true;
         }
 
+        session.actor.markSkillReuse?.(skill);
         DataCache.fetchNpcFromSelfId(itemSkill.npcId, (npcData) => {
             const npc = new Npc(World.npc.nextId++, {
                 ...utils.crushOb(npcData),
@@ -753,6 +762,7 @@ class Backpack extends BackpackModel {
         }
 
         const castTime = skill.fetchHitTime() || 0;
+        session.actor.markSkillReuse?.(skill);
         session.actor.state.setCasts(true);
         session.dataSendToMeAndOthers(ServerResponse.skillStarted(session.actor, session.actor.fetchId(), skill), session.actor);
         if (castTime > 0) {
@@ -1009,6 +1019,7 @@ class Backpack extends BackpackModel {
 
     castTargetedItemSkill(session, target, skill, apply) {
         const castTime = skill.fetchHitTime() || 0;
+        session.actor.markSkillReuse?.(skill);
         session.actor.state.setCasts(true);
         session.dataSendToMeAndOthers(ServerResponse.skillStarted(session.actor, target.fetchId(), skill), session.actor);
         if (castTime > 0) {
@@ -1187,6 +1198,7 @@ class Backpack extends BackpackModel {
         }
 
         const castTime = skill.fetchHitTime() || 0;
+        session.actor.markSkillReuse?.(skill);
         session.actor.state.setCasts(true);
         session.dataSendToMeAndOthers(ServerResponse.skillStarted(session.actor, target.fetchId(), skill), session.actor);
         if (castTime > 0) {
@@ -1234,6 +1246,7 @@ class Backpack extends BackpackModel {
 
         const startCast = () => {
             const castTime = skill.fetchHitTime() || 0;
+            session.actor.markSkillReuse?.(skill);
             session.actor.state.setCasts(true);
             session.dataSendToMeAndOthers(ServerResponse.skillStarted(session.actor, target.fetchId(), skill), session.actor);
             if (castTime > 0) {

--- a/src/GameServer/Actor/Generics/SkillRequest.js
+++ b/src/GameServer/Actor/Generics/SkillRequest.js
@@ -28,6 +28,11 @@ function skillRequest(session, actor, data) {
         return;
     }
 
+    if (!actor.canUseSkill(skill)) {
+        EffectRestrictions.reject(session);
+        return;
+    }
+
     if (actor.isBlocked()) {
         Generics.queueRequest(session, actor, 'skill', data);
         return;

--- a/src/GameServer/Npc/Npc.js
+++ b/src/GameServer/Npc/Npc.js
@@ -176,18 +176,21 @@ class Npc extends NpcModel {
     }
 
     selectCombatSkill(actor) {
-        const now = Date.now();
         return this.fetchCombatSkills().find((skill) => {
             if (skill.fetchTargetKind() !== 'enemy') return false;
             if (this.fetchMp() < skill.fetchConsumedMp()) return false;
-            return (this.skillReuseUntil.get(skill.fetchSelfId()) || 0) <= now;
+            return this.canUseSkill(skill);
         }) || null;
     }
 
-    markSkillReuse(skill) {
+    canUseSkill(skill, now = Date.now()) {
+        return (this.skillReuseUntil.get(skill.fetchSelfId()) || 0) <= now;
+    }
+
+    markSkillReuse(skill, now = Date.now()) {
         this.skillReuseUntil.set(
             skill.fetchSelfId(),
-            Date.now() + Math.max(1000, Number(skill.fetchReuseTime()) || 0)
+            now + Math.max(1000, Number(skill.fetchReuseTime()) || 0)
         );
     }
 
@@ -203,7 +206,6 @@ class Npc extends NpcModel {
     }
 
     castSkill(session, actor, skill) {
-        this.markSkillReuse(skill);
         AttackHelper.remoteHit({
             actor: this,
             dataSendToMe() {},

--- a/src/GameServer/Npc/SummonControl.js
+++ b/src/GameServer/Npc/SummonControl.js
@@ -406,6 +406,11 @@ function useSkillAction(session, actor, summon, actionId) {
         return true;
     }
 
+    if (summon.canUseSkill?.(skill) === false) {
+        session.dataSendToMe(ServerResponse.actionFailed());
+        return true;
+    }
+
     resolveSkillTarget(actor, summon, config).then((target) => {
         if (!target) {
             session.dataSendToMe(ServerResponse.actionFailed());

--- a/tests/test_cast_interrupt.js
+++ b/tests/test_cast_interrupt.js
@@ -5,6 +5,7 @@ require('../src/Global');
 const Attack = invoke('GameServer/Actor/Attack');
 const State = invoke('GameServer/Model/State');
 const destCancel = invoke('GameServer/Network/Request/DestCancel');
+const skillRequest = invoke('GameServer/Actor/Generics/SkillRequest');
 
 function actor(overrides = {}) {
     const state = new State();
@@ -12,6 +13,7 @@ function actor(overrides = {}) {
         state,
         attack: null,
         storedSpell: { selfId: 1 },
+        skillReuseUntil: new Map(),
         fetchId: () => overrides.id ?? 2000001,
         fetchMp: () => overrides.mp ?? 50,
         setMp(value) { this.mp = value; },
@@ -32,6 +34,12 @@ function actor(overrides = {}) {
             consumeSpiritshot(session, callback) { callback(false); },
             consumeSoulshot(session, callback) { callback(false); },
             fetchTotalWeaponPAtkRnd: () => 0
+        },
+        canUseSkill(skill, now = Date.now()) {
+            return (this.skillReuseUntil.get(skill.fetchSelfId()) || 0) <= now;
+        },
+        markSkillReuse(skill, now = Date.now()) {
+            this.skillReuseUntil.set(skill.fetchSelfId(), now + skill.fetchReuseTime());
         },
         isDead: () => false
     };
@@ -64,6 +72,7 @@ function skill(overrides = {}) {
         fetchSelfId: () => 1011,
         fetchLevel: () => 1,
         fetchPower: () => overrides.power ?? 10,
+        fetchTargetKind: () => 'enemy',
         fetchSemantic: () => ({ skillType: 'damage', trait: 'wind' }),
         fetchSsBoost: () => 1
     };
@@ -95,7 +104,8 @@ try {
 
     attack.remoteHit(session, victim, skill());
     assert.strictEqual(caster.state.fetchCasts(), true, 'remote skill should mark actor as casting before hit time');
-    assert.strictEqual(timers.length, 2, 'remote skill should schedule hit and reuse timers');
+    assert.strictEqual(timers.length, 1, 'remote skill should only schedule the cast landing timer');
+    assert.strictEqual(caster.canUseSkill(skill()), false, 'starting a cast should start that skill reuse timer');
 
     destCancel(session, Buffer.from([0x37, 0x00, 0x00]));
     assert.strictEqual(caster.state.fetchCasts(), false, 'ESC target cancel should clear casting state');
@@ -120,6 +130,26 @@ try {
     landingAttack.remoteHit(landingSession, victim, skill({ power: 0 }));
     timers.find((timer) => !timer.canceled && timer.delay > 0).callback();
     assert(packets.some((packet) => packet[0] === 0x76 && packet.readInt32LE(5) === 1011), 'completed magic cast should broadcast MagicSkillLaunched on landing');
+
+    const cooldownPackets = [];
+    const cooldownActor = actor();
+    cooldownActor.skillReuseUntil.set(1011, Date.now() + 1000);
+    cooldownActor.skillset = { fetchSkill: () => skill() };
+    cooldownActor.fetchDestId = () => victim.fetchId();
+    cooldownActor.isBlocked = () => {
+        throw new Error('a skill on reuse must not be queued');
+    };
+    skillRequest({
+        actor: cooldownActor,
+        dataSendToMe(packet) { cooldownPackets.push(packet); }
+    }, cooldownActor, { selfId: 1011 });
+    assert(cooldownPackets.some((packet) => packet[0] === 0x25), 'a skill on reuse should be rejected before it can be cast or queued');
+
+    timers.length = 0;
+    packets.length = 0;
+    landingAttack.remoteHit(landingSession, victim, skill());
+    assert.strictEqual(timers.length, 0, 'a direct cast path must not schedule a skill that is still on reuse');
+    assert(packets.some((packet) => packet[0] === 0x25), 'a direct cast path should reject a skill that is still on reuse');
 } finally {
     global.setTimeout = savedSetTimeout;
     global.clearTimeout = savedClearTimeout;

--- a/tests/test_summon_runtime.js
+++ b/tests/test_summon_runtime.js
@@ -210,6 +210,23 @@ async function withFastTimers(callback) {
     assert.strictEqual(actionPet.controlMode, 'idle', 'legacy pet cancel action 17 should be handled');
     session.actor.summon = { state: { fetchDead: () => true } };
     assert.strictEqual(SummonControl.activeSummon(session.actor), actionPet, 'live pet should remain controllable when a stale dead summon reference exists');
+
+    const originalNpcSkillsForNpc = NpcSkills.forNpc;
+    let clearedCooldownSummonTimers = 0;
+    NpcSkills.forNpc = () => [{ fetchSelfId: () => 4230 }];
+    try {
+        session.packets.length = 0;
+        SummonControl.useSkillAction(session, session.actor, {
+            canUseSkill: () => false,
+            attack: { clearTimers() { clearedCooldownSummonTimers += 1; } },
+            automation: { abortAll() { throw new Error('a skill on reuse must not abort summon automation'); } }
+        }, 0x20);
+        assert.strictEqual(clearedCooldownSummonTimers, 0, 'a summon skill on reuse must preserve the active cast timers');
+        assert(session.packets.some((packet) => packet[0] === 0x25), 'a summon skill on reuse should return ActionFailed');
+    } finally {
+        NpcSkills.forNpc = originalNpcSkillsForNpc;
+    }
+
     actionPet.destructor(session);
     session.actor.pet = null;
 


### PR DESCRIPTION
## Summary

Enforces per-skill reuse timers on the server for player, bot, NPC, summon, and item-skill execution paths.

## Root cause

Reuse times were sent to the client but were not retained or checked by the server. A placeholder timer in the cast path performed no enforcement, allowing repeated requests such as Power Strike to execute immediately.

## Changes

- Track each actor's skill reuse deadline and reject attempts during reuse.
- Enforce reuse at the shared cast boundary, including direct summon casts.
- Apply item-skill reuse checks and start timers when item skills begin.
- Preserve active summon casts when a cooldown retry is received.
- Add regressions for normal and direct cast paths plus summon cooldown retries.

## Validation

- `node scripts/check-syntax.js`
- `node scripts/run-tests.js`