### PR TITLE
Add C4 auto-shot hotbar toggles

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -2,6 +2,7 @@ const { spawnSync } = require('child_process');
 
 const tests = [
     'tests/test_admin_tools.js',
+    'tests/test_auto_soulshots.js',
     'tests/test_attack_hit_flags.js',
     'tests/test_armor_stats.js',
     'tests/test_bot_ai_visibility.js',

--- a/src/GameServer/Actor/Attack.js
+++ b/src/GameServer/Actor/Attack.js
@@ -85,8 +85,8 @@ class Attack {
             return;
         }
 
-        // Auto-consume Soulshot if available in backpack and not already loaded
-        if (!actor.soulshotLoaded && actor.backpack && typeof actor.backpack.consumeSoulshot === 'function') {
+        // Soulshots are only reloaded after the player enables their hotbar toggle.
+        if (!actor.soulshotLoaded && actor.backpack?.isAutoShotEnabled?.(actor, 'soulshot') && typeof actor.backpack.consumeSoulshot === 'function') {
             actor.backpack.consumeSoulshot(session, (success) => {
                 if (success) {
                     actor.soulshotLoaded = true;
@@ -333,18 +333,20 @@ class Attack {
         }
 
         if (magicSkill) {
-            if (!actor.spiritshotLoaded && actor.backpack && typeof actor.backpack.consumeSpiritshot === 'function') {
+            const shotKind = actor.backpack?.fetchAutoSpiritshotKind?.(actor);
+            if (!actor.spiritshotLoaded && shotKind && typeof actor.backpack.consumeSpiritshot === 'function') {
                 actor.backpack.consumeSpiritshot(session, (success, shot = {}) => {
                     if (success) {
                         actor.spiritshotLoaded = true;
+                        actor.blessedSpiritshotLoaded = !!shot.blessedSpiritshot;
                         this.broadcastShotCharge(session, actor, shot.skillId || 2047);
                     }
-                });
+                }, shotKind);
             }
             return;
         }
 
-        if (!actor.soulshotLoaded && actor.backpack && typeof actor.backpack.consumeSoulshot === 'function') {
+        if (!actor.soulshotLoaded && actor.backpack?.isAutoShotEnabled?.(actor, 'soulshot') && typeof actor.backpack.consumeSoulshot === 'function') {
             actor.backpack.consumeSoulshot(session, (success, shot = {}) => {
                 if (success) {
                     actor.soulshotLoaded = true;

--- a/src/GameServer/Actor/Backpack.js
+++ b/src/GameServer/Actor/Backpack.js
@@ -118,12 +118,12 @@ class Backpack extends BackpackModel {
         }
     }
 
-    consumeSpiritshot(session, callback = () => {}) {
+    consumeSpiritshot(session, callback = () => {}, kind = 'spiritshot') {
         if (session.actor.isDead()) {
             return callback(false);
         }
 
-        const plan = ShotStock.planForActorKind('spiritshot', session.actor);
+        const plan = ShotStock.planForActorKind(kind, session.actor);
 
         const found = this.items.find(item => item.fetchSelfId() === plan.selfId);
         const cost = this.fetchShotCost('spiritshot');
@@ -141,8 +141,26 @@ class Backpack extends BackpackModel {
         return {
             selfId,
             skillId: itemSkill?.skillId || (ShotStock.SPIRITSHOT_IDS.includes(selfId) ? 2047 : 2039),
-            blessedSpiritshot: !!itemSkill?.blessedSpiritshot
+            blessedSpiritshot: ShotStock.BLESSED_SPIRITSHOT_IDS.includes(selfId)
         };
+    }
+
+    isAutoShotEnabled(actor, kind) {
+        const selfId = ShotStock.planForActorKind(kind, actor).selfId;
+        return !!actor.autoSoulshots?.has(selfId);
+    }
+
+    fetchAutoSpiritshotKind(actor) {
+        const enabled = actor.autoSoulshots;
+        if (!enabled) return null;
+
+        const spiritshot = ShotStock.planForActorKind('spiritshot', actor).selfId;
+        const blessedSpiritshot = ShotStock.planForActorKind('blessedSpiritshot', actor).selfId;
+        for (const selfId of enabled) {
+            if (selfId === spiritshot) return 'spiritshot';
+            if (selfId === blessedSpiritshot) return 'blessedSpiritshot';
+        }
+        return null;
     }
 
     dropItem(session, id, amount, locX, locY, locZ) {

--- a/src/GameServer/Inventory/ShotStock.js
+++ b/src/GameServer/Inventory/ShotStock.js
@@ -23,9 +23,19 @@ const SPIRITSHOT_BY_RANK = {
     s: 2514
 };
 
+const BLESSED_SPIRITSHOT_BY_RANK = {
+    none: 3947,
+    d: 3948,
+    c: 3949,
+    b: 3950,
+    a: 3951,
+    s: 3952
+};
+
 const SOULSHOT_IDS = Object.values(SOULSHOT_BY_RANK);
 const SPIRITSHOT_IDS = Object.values(SPIRITSHOT_BY_RANK);
-const SHOT_IDS = [...SOULSHOT_IDS, ...SPIRITSHOT_IDS];
+const BLESSED_SPIRITSHOT_IDS = Object.values(BLESSED_SPIRITSHOT_BY_RANK);
+const SHOT_IDS = [...SOULSHOT_IDS, ...SPIRITSHOT_IDS, ...BLESSED_SPIRITSHOT_IDS];
 
 function normalizeRank(rank) {
     const value = String(rank || 'none').toLowerCase();
@@ -84,10 +94,14 @@ function planFor({ classId, rank = 'none' } = {}) {
 
 function planForKind(kind, rank = 'none') {
     const normalizedRank = normalizeRank(rank);
-    const normalizedKind = kind === 'spiritshot' ? 'spiritshot' : 'soulshot';
-    const selfId = normalizedKind === 'spiritshot'
-        ? SPIRITSHOT_BY_RANK[normalizedRank]
-        : SOULSHOT_BY_RANK[normalizedRank];
+    const normalizedKind = kind === 'blessedSpiritshot'
+        ? 'blessedSpiritshot'
+        : kind === 'spiritshot' ? 'spiritshot' : 'soulshot';
+    const selfId = normalizedKind === 'blessedSpiritshot'
+        ? BLESSED_SPIRITSHOT_BY_RANK[normalizedRank]
+        : normalizedKind === 'spiritshot'
+            ? SPIRITSHOT_BY_RANK[normalizedRank]
+            : SOULSHOT_BY_RANK[normalizedRank];
 
     return {
         kind: normalizedKind,
@@ -240,6 +254,7 @@ module.exports = {
     DEFAULT_TARGET_AMOUNT,
     SOULSHOT_IDS,
     SPIRITSHOT_IDS,
+    BLESSED_SPIRITSHOT_IDS,
     SHOT_IDS,
     planFor,
     planForKind,

--- a/src/GameServer/Network/Opcodes.js
+++ b/src/GameServer/Network/Opcodes.js
@@ -65,7 +65,7 @@ const Opcodes = {
         table[0xc1] = () => {}; // Macro
         table[0x4a] = () => {}; // StartRotating
         table[0x4b] = () => {}; // FinishRotating
-        table[0xd0] = () => {}; // Multi-purpose extended request root in later clients.
+        table[0xd0] = ClientRequest.extendedRequest;
 
         return table;
     })()

--- a/src/GameServer/Network/Request/AutoSoulShot.js
+++ b/src/GameServer/Network/Request/AutoSoulShot.js
@@ -1,0 +1,76 @@
+const ServerResponse = invoke('GameServer/Network/Response');
+const ReceivePacket  = invoke('Packet/Receive');
+const ShotStock      = invoke('GameServer/Inventory/ShotStock');
+
+function autoSoulShot(session, buffer) {
+    if (buffer.length < 11) {
+        return;
+    }
+
+    const packet = new ReceivePacket(buffer);
+    packet
+        .readH() // Extended request id (0x05)
+        .readD() // Item id
+        .readD(); // 1 = on, 0 = off
+
+    const [requestId, selfId, enabled] = packet.data;
+    if (requestId !== 5 || session.actor.isDead?.() || ![0, 1].includes(enabled)) {
+        return;
+    }
+
+    if (!ShotStock.SHOT_IDS.includes(selfId) || !session.actor.backpack.fetchItemFromSelfId(selfId)) {
+        return;
+    }
+
+    const autoShots = session.actor.autoSoulshots || (session.actor.autoSoulshots = new Set());
+    if (enabled) {
+        autoShots.add(selfId);
+    }
+    else {
+        autoShots.delete(selfId);
+    }
+
+    session.dataSendToMe(ServerResponse.autoSoulShot(selfId, enabled));
+    if (enabled) {
+        chargeFirstShot(session, selfId);
+    }
+}
+
+function chargeFirstShot(session, selfId) {
+    const actor = session.actor;
+    const kind = ShotStock.SOULSHOT_IDS.includes(selfId)
+        ? 'soulshot'
+        : ShotStock.BLESSED_SPIRITSHOT_IDS.includes(selfId)
+            ? 'blessedSpiritshot'
+            : 'spiritshot';
+    const expectedId = ShotStock.planForActorKind(kind, actor).selfId;
+    if (expectedId !== selfId) return;
+
+    const charge = (success, shot = {}) => {
+        if (!success) return;
+        if (kind === 'soulshot') {
+            actor.soulshotLoaded = true;
+        }
+        else {
+            actor.spiritshotLoaded = true;
+            actor.blessedSpiritshotLoaded = !!shot.blessedSpiritshot;
+        }
+        session.dataSendToMeAndOthers(
+            ServerResponse.skillStarted(actor, actor.fetchId(), {
+                fetchSelfId: () => shot.skillId,
+                fetchCalculatedHitTime: () => 0,
+                fetchReuseTime: () => 0
+            }),
+            actor
+        );
+    };
+
+    if (kind === 'soulshot' && !actor.soulshotLoaded) {
+        actor.backpack.consumeSoulshot(session, charge);
+    }
+    else if (kind !== 'soulshot' && !actor.spiritshotLoaded) {
+        actor.backpack.consumeSpiritshot(session, charge, kind);
+    }
+}
+
+module.exports = autoSoulShot;

--- a/src/GameServer/Network/Request/ExtendedRequest.js
+++ b/src/GameServer/Network/Request/ExtendedRequest.js
@@ -1,0 +1,19 @@
+const ReceivePacket = invoke('Packet/Receive');
+const AutoSoulShot  = invoke('GameServer/Network/Request/AutoSoulShot');
+
+// C4 multiplexes several requests behind opcode 0xD0. Route only the
+// subcommands we implement; their payloads are not interchangeable.
+function extendedRequest(session, buffer) {
+    if (buffer.length < 3) {
+        return;
+    }
+
+    const packet = new ReceivePacket(buffer);
+    packet.readH();
+
+    if (packet.data[0] === 5) {
+        AutoSoulShot(session, buffer);
+    }
+}
+
+module.exports = extendedRequest;

--- a/src/GameServer/Network/Request/index.js
+++ b/src/GameServer/Network/Request/index.js
@@ -1,6 +1,7 @@
 module.exports = {
                action: require('./Action'),
             actionUse: require('./ActionUse'),
+        autoSoulShot: require('./AutoSoulShot'),
          addTradeItem: require('./AddTradeItem'),
           addShortcut: require('./AddShortcut'),
       answerForTeamUp: require('./AnswerForTeamUp'),
@@ -24,7 +25,8 @@ module.exports = {
              dropItem: require('./DropItem'),
     enterCharCreation: require('./EnterCharCreation'),
            enterWorld: require('./EnterWorld'),
-             htmlLink: require('./HtmlLink'),
+     extendedRequest: require('./ExtendedRequest'),
+            htmlLink: require('./HtmlLink'),
             itemsList: require('./ItemsList'),
                logout: require('./Logout'),
        moveToLocation: require('./MoveToLocation'),

--- a/src/GameServer/Network/Response/AutoSoulShot.js
+++ b/src/GameServer/Network/Response/AutoSoulShot.js
@@ -1,0 +1,12 @@
+const SendPacket = invoke('Packet/Send');
+
+// C4 ExAutoSoulShot: FE:12 dd
+function autoSoulShot(selfId, enabled) {
+    return new SendPacket(0xfe)
+        .writeH(0x12)
+        .writeD(selfId)
+        .writeD(enabled ? 1 : 0)
+        .fetchBuffer();
+}
+
+module.exports = autoSoulShot;

--- a/src/GameServer/Network/Response/index.js
+++ b/src/GameServer/Network/Response/index.js
@@ -1,5 +1,6 @@
 module.exports = {
-          actionFailed: require('./ActionFailed'),
+           actionFailed: require('./ActionFailed'),
+           autoSoulShot: require('./AutoSoulShot'),
            addShortcut: require('./AddShortcut'),
           askForTeamUp: require('./AskForTeamUp'),
           askJoinPledge: require('./AskJoinPledge'),

--- a/tests/test_auto_soulshots.js
+++ b/tests/test_auto_soulshots.js
@@ -1,0 +1,132 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const Backpack = invoke('GameServer/Actor/Backpack');
+const Item = invoke('GameServer/Item/Item');
+const AutoSoulShot = invoke('GameServer/Network/Request/AutoSoulShot');
+const ExtendedRequest = invoke('GameServer/Network/Request/ExtendedRequest');
+const Attack = invoke('GameServer/Actor/Attack');
+const Database = invoke('Database');
+
+Database.updateItemAmount = () => Promise.resolve();
+Database.deleteItem = () => Promise.resolve();
+
+function item(id, data) {
+    return new Item(id, {
+        selfId: data.selfId,
+        kind: data.kind,
+        amount: data.amount,
+        equipped: data.equipped || false,
+        slot: data.slot || 0,
+        soulshot: data.soulshot || 0,
+        spiritshot: data.spiritshot || 0,
+        rank: data.rank || 'none'
+    });
+}
+
+const backpack = new Backpack({ paperdoll: Array.from({ length: 16 }, () => ({})), items: [] });
+backpack.items = [
+    item(1, { selfId: 1, kind: 'Weapon.Sword', equipped: true, slot: 7, soulshot: 2 }),
+    item(2, { selfId: 1835, kind: 'Other.Shot', amount: 10 })
+];
+const session = {
+    actor: {
+        backpack,
+        isDead: () => false,
+        fetchId: () => 2000001,
+        fetchLocX: () => 100,
+        fetchLocY: () => 200,
+        fetchLocZ: () => -300
+    },
+    packets: [],
+    dataSendToMe(packet) { this.packets.push(packet); },
+    dataSendToMeAndOthers() {}
+};
+
+function request(selfId, enabled) {
+    const packet = Buffer.alloc(11);
+    packet[0] = 0xd0;
+    packet.writeInt16LE(5, 1);
+    packet.writeInt32LE(selfId, 3);
+    packet.writeInt32LE(enabled, 7);
+    ExtendedRequest(session, packet);
+}
+
+request(1835, 1);
+assert.strictEqual(session.actor.autoSoulshots.has(1835), true, 'hotbar enable should register the requested soulshot');
+assert.strictEqual(backpack.isAutoShotEnabled(session.actor, 'soulshot'), true, 'only the matching equipped-weapon grade should auto-reload');
+assert.strictEqual(backpack.fetchItemFromSelfId(1835).fetchAmount(), 8, 'enabling a compatible soulshot should immediately charge it');
+assert.strictEqual(session.actor.soulshotLoaded, true, 'enabling a compatible soulshot should set its loaded state');
+const enabledPacket = session.packets.findLast((packet) => packet[0] === 0xfe);
+assert.strictEqual(enabledPacket[0], 0xfe, 'hotbar enable should acknowledge with an extended response');
+assert.strictEqual(enabledPacket.readInt16LE(1), 0x12, 'C4 response should use ExAutoSoulShot sub-id');
+assert.strictEqual(enabledPacket.readInt32LE(3), 1835, 'response should identify the toggled shot item');
+assert.strictEqual(enabledPacket.readInt32LE(7), 1, 'response should mark the shot as enabled');
+
+request(1835, 0);
+assert.strictEqual(backpack.isAutoShotEnabled(session.actor, 'soulshot'), false, 'hotbar disable should stop automatic reloads');
+const disabledPacket = session.packets.findLast((packet) => packet[0] === 0xfe);
+assert.strictEqual(disabledPacket.readInt32LE(7), 0, 'response should mark the shot as disabled');
+
+request(2509, 1);
+assert.strictEqual(session.actor.autoSoulshots.has(2509), false, 'a shot absent from inventory must not be enabled');
+
+assert.doesNotThrow(
+    () => ExtendedRequest(session, Buffer.from([0xd0, 0x01, 0x00])),
+    'unrelated short C4 extended requests must not be parsed as auto-shot packets'
+);
+assert.doesNotThrow(
+    () => ExtendedRequest(session, Buffer.from([0xd0, 0x05, 0x00])),
+    'truncated auto-shot requests must not crash the session'
+);
+assert.strictEqual(session.actor.autoSoulshots.has(1835), false, 'unrelated extended requests must not alter auto-shot state');
+
+const bssBackpack = new Backpack({ paperdoll: Array.from({ length: 16 }, () => ({})), items: [] });
+bssBackpack.items = [
+    item(3, { selfId: 238, kind: 'Weapon.Blunt', equipped: true, slot: 7, spiritshot: 1, rank: 'b' }),
+    item(4, { selfId: 3950, kind: 'Other.Shot', amount: 3 })
+];
+const bssSession = {
+    actor: {
+        backpack: bssBackpack,
+        isDead: () => false,
+        fetchId: () => 2000002,
+        fetchLocX: () => 100,
+        fetchLocY: () => 200,
+        fetchLocZ: () => -300
+    },
+    dataSendToMe() {},
+    dataSendToMeAndOthers() {}
+};
+const bssPacket = Buffer.alloc(11);
+bssPacket[0] = 0xd0;
+bssPacket.writeInt16LE(5, 1);
+bssPacket.writeInt32LE(3950, 3);
+bssPacket.writeInt32LE(1, 7);
+ExtendedRequest(bssSession, bssPacket);
+assert.strictEqual(bssBackpack.fetchAutoSpiritshotKind(bssSession.actor), 'blessedSpiritshot', 'Blessed Spiritshot should participate in the C4 auto-shot toggle');
+assert.strictEqual(bssBackpack.fetchItemFromSelfId(3950).fetchAmount(), 2, 'enabling Blessed Spiritshot should consume the weapon cost immediately');
+assert.strictEqual(bssSession.actor.blessedSpiritshotLoaded, true, 'Blessed Spiritshot auto-charge should retain its damage modifier');
+
+const attack = new Attack();
+let consumeCalls = 0;
+const combatActor = {
+    soulshotLoaded: false,
+    backpack: {
+        isAutoShotEnabled: () => false,
+        consumeSoulshot() { consumeCalls += 1; }
+    }
+};
+attack.chargeShotForSkill({ actor: combatActor }, combatActor, false);
+assert.strictEqual(consumeCalls, 0, 'ordinary combat must not consume shots until explicitly enabled');
+combatActor.backpack.isAutoShotEnabled = () => true;
+combatActor.backpack.consumeSoulshot = (ignoredSession, callback) => {
+    consumeCalls += 1;
+    callback(false);
+};
+attack.chargeShotForSkill({ actor: combatActor }, combatActor, false);
+assert.strictEqual(consumeCalls, 1, 'enabled hotbar shots should be eligible for automatic reload');
+attack.destructor();
+
+console.log('Auto soulshot toggle checks passed');

--- a/tests/test_skill_damage_formulas.js
+++ b/tests/test_skill_damage_formulas.js
@@ -21,7 +21,9 @@ function actor() {
         fetchCollectiveAtkSpd: () => 333,
         fetchCollectiveCastSpd: () => 666,
         backpack: {
-            fetchTotalWeaponPAtkRnd: () => 0
+            fetchTotalWeaponPAtkRnd: () => 0,
+            isAutoShotEnabled: () => false,
+            fetchAutoSpiritshotKind: () => null
         }
     };
 }
@@ -153,6 +155,12 @@ attack.chargeShotForSkill({
     actor: physicalChargeActor,
     dataSendToMeAndOthers() {}
 }, physicalChargeActor, false);
+assert.strictEqual(soulshotConsumed, false, 'physical skill should not charge soulshot before the hotbar toggle is enabled');
+physicalChargeActor.backpack.isAutoShotEnabled = () => true;
+attack.chargeShotForSkill({
+    actor: physicalChargeActor,
+    dataSendToMeAndOthers() {}
+}, physicalChargeActor, false);
 assert.strictEqual(soulshotConsumed, true, 'physical skill should try to charge soulshot');
 assert.strictEqual(spiritshotConsumed, false, 'physical skill should not try to charge spiritshot');
 assert.strictEqual(physicalChargeActor.soulshotLoaded, true, 'physical skill should load soulshot on successful consume');
@@ -169,6 +177,7 @@ magicChargeActor.backpack.consumeSpiritshot = (session, callback) => {
     spiritshotConsumed = true;
     callback(true, { skillId: 2157 });
 };
+magicChargeActor.backpack.fetchAutoSpiritshotKind = () => 'spiritshot';
 attack.chargeShotForSkill({
     actor: magicChargeActor,
     dataSendToMeAndOthers(packet) { chargePackets.push(packet); }


### PR DESCRIPTION
## What changed

- Added C4 hotbar auto-use toggles for Soulshots, Spiritshots, and Blessed Spiritshots.
- Added the `0xD0 / 0x05` request route and `ExAutoSoulShot` response used by the C4 client.
- Auto-use now charges the first compatible shot immediately, then reloads it during combat or spell use.
- Added support for Blessed Spiritshot auto-charging and its damage modifier.

## Why

Shots previously auto-consumed without an explicit player toggle. Mapping every `0xD0` extended request directly to the auto-shot parser also caused a crash when the client sent another extended request after login.

## Validation

- `npm run check`
- `node scripts/run-tests.js`
