### PR TITLE
Fix NPC combat damage fidelity

### DIFF
--- a/src/GameServer/Actor/Attack.js
+++ b/src/GameServer/Actor/Attack.js
@@ -216,6 +216,15 @@ class Attack {
                 else if (outcome.missed) {
                     ConsoleText.transmit(session, ConsoleText.caption.missedHit);
                 }
+                else if (outcome.resisted) {
+                    const targetSession = target?.session || (this.isNpcCombatant(actor) ? session : null);
+                    if (targetSession?.dataSendToMe) {
+                        ConsoleText.transmit(targetSession, ConsoleText.caption.magicResisted, [{
+                            kind: ConsoleText.kind.text,
+                            value: actor.fetchName?.() || 'The monster'
+                        }]);
+                    }
+                }
             });
             this.clearLoadedShot(actor, magicSkill);
             actor.state.setCasts(false);
@@ -257,32 +266,26 @@ class Attack {
                 ? session.followPlayerSession
                 : session;
             const party = PartyAwareness.partyActors(leaderSession)
-                .filter((target) => this.isValidSkillTarget(target, skill));
+                .filter((target) => this.isValidSkillTarget(target, skill, actor));
             return party.length > 0 ? party : [primary];
         }
 
         if (sourceTarget === 'aura' && radius > 0 && primary === actor && skill.fetchTargetKind?.() === 'enemy') {
-            const World = invoke('GameServer/World/World');
-            const nearby = typeof World.fetchNpcsInRadius === 'function'
-                ? World.fetchNpcsInRadius(actor.fetchLocX(), actor.fetchLocY(), radius)
-                : [];
-            return nearby.filter((target) => this.isValidSkillTarget(target, skill) && this.distance2d(actor, target) <= radius);
+            return this.fetchSkillTargetsInRadius(actor, actor.fetchLocX(), actor.fetchLocY(), radius)
+                .filter((target) => this.isValidSkillTarget(target, skill, actor) && this.distance2d(actor, target) <= radius);
         }
 
         if (
             !sourceTarget ||
             radius <= 0 ||
             !['enemy', 'corpse_mob'].includes(skill.fetchTargetKind?.()) ||
-            !this.isNpcAreaPrimary(primary, skill)
+            !this.isAreaPrimary(actor, primary, skill)
         ) {
             return [primary];
         }
 
         const center = sourceTarget === 'area' ? primary : actor;
-        const World = invoke('GameServer/World/World');
-        const nearby = typeof World.fetchNpcsInRadius === 'function'
-            ? World.fetchNpcsInRadius(center.fetchLocX(), center.fetchLocY(), radius)
-            : [];
+        const nearby = this.fetchSkillTargetsInRadius(actor, center.fetchLocX(), center.fetchLocY(), radius);
         const targets = [primary, ...nearby];
         const seen = new Set();
 
@@ -291,22 +294,33 @@ class Attack {
             if (!id || seen.has(id)) return false;
             seen.add(id);
 
-            if (!this.isValidSkillTarget(target, skill)) return false;
+            if (!this.isValidSkillTarget(target, skill, actor)) return false;
             if (this.distance2d(center, target) > radius) return false;
             if (sourceTarget === 'front_area' && !this.isFacing(actor, target, 120)) return false;
             return true;
         });
     }
 
-    isNpcAreaPrimary(target, skill) {
+    fetchSkillTargetsInRadius(actor, locX, locY, radius) {
+        const World = invoke('GameServer/World/World');
+        if (this.isNpcCombatant(actor)) {
+            return (World.user?.sessions || []).map((session) => session?.actor).filter(Boolean);
+        }
+
+        return typeof World.fetchNpcsInRadius === 'function'
+            ? World.fetchNpcsInRadius(locX, locY, radius)
+            : [];
+    }
+
+    isAreaPrimary(actor, target, skill) {
         if (skill.fetchTargetKind?.() === 'corpse_mob') {
             return target?.fetchAttackable?.() === true && target?.isDead?.() === true;
         }
 
-        return target?.fetchAttackable?.() === true;
+        return this.isValidSkillTarget(target, skill, actor);
     }
 
-    isValidSkillTarget(target, skill) {
+    isValidSkillTarget(target, skill, actor = null) {
         if (!target) return false;
         const targetKind = skill.fetchTargetKind?.();
 
@@ -315,6 +329,9 @@ class Attack {
         }
 
         if (targetKind === 'enemy') {
+            if (this.isNpcCombatant(actor)) {
+                return target !== actor && !target.fetchKind && target.state?.fetchDead?.() !== true && target.isDead?.() !== true;
+            }
             return target.fetchAttackable?.() === true && target.state?.fetchDead?.() !== true && target.isDead?.() !== true;
         }
 
@@ -325,6 +342,10 @@ class Attack {
         const dx = (Number(src?.fetchLocX?.()) || 0) - (Number(dst?.fetchLocX?.()) || 0);
         const dy = (Number(src?.fetchLocY?.()) || 0) - (Number(dst?.fetchLocY?.()) || 0);
         return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    isNpcCombatant(actor) {
+        return !!(actor?.fetchKind && actor.fetchIsSummon?.() !== true);
     }
 
     chargeShotForSkill(session, actor, magicSkill, skill = null) {
@@ -397,6 +418,24 @@ class Attack {
     }
 
     prepareSkillDamage(actor, creature, skill, magicSkill, rng = Math.random, magicAtkOverride = null) {
+        if (magicSkill) {
+            const usedSpiritshot = !!actor.spiritshotLoaded;
+            const usedBlessedSpiritshot = usedSpiritshot && !!actor.blessedSpiritshotLoaded;
+            const semantic = skill.fetchSemantic?.() || {};
+            const vulnModifier = traitVulnerabilityModifier(creature, semantic.trait);
+            const power = semantic.skillType === C4SkillRules.DEATH_LINK
+                ? Formulas.calcDeathLinkPower(skill.fetchPower(), actor.fetchHp?.(), actor.fetchMaxHp?.())
+                : skill.fetchPower();
+            const damage = Math.round(Formulas.calcMagicDamage(
+                magicAtkOverride ?? actor.fetchCollectiveMAtk(),
+                power,
+                creature.fetchCollectiveMDef(),
+                { spiritshot: usedSpiritshot, blessedSpiritshot: usedBlessedSpiritshot }
+            ) * vulnModifier);
+            this.clearLoadedShot(actor, magicSkill);
+            return damage;
+        }
+
         const shield = Formulas.rollShieldUse({
             shieldRate: this.fetchShieldRate(creature),
             dex: creature.fetchDex ? creature.fetchDex() : 0,
@@ -407,25 +446,6 @@ class Attack {
         if (shield === Formulas.SHIELD_DEFENSE_PERFECT_BLOCK) {
             this.clearLoadedShot(actor, magicSkill);
             return 1;
-        }
-
-        if (magicSkill) {
-            const usedSpiritshot = !!actor.spiritshotLoaded;
-            const usedBlessedSpiritshot = usedSpiritshot && !!actor.blessedSpiritshotLoaded;
-            const shieldMDef = shield === Formulas.SHIELD_DEFENSE_SUCCEED ? this.fetchShieldPDef(creature) : 0;
-            const semantic = skill.fetchSemantic?.() || {};
-            const vulnModifier = traitVulnerabilityModifier(creature, semantic.trait);
-            const power = semantic.skillType === C4SkillRules.DEATH_LINK
-                ? Formulas.calcDeathLinkPower(skill.fetchPower(), actor.fetchHp?.(), actor.fetchMaxHp?.())
-                : skill.fetchPower();
-            const damage = Math.round(Formulas.calcMagicDamage(
-                magicAtkOverride ?? actor.fetchCollectiveMAtk(),
-                power,
-                creature.fetchCollectiveMDef() + shieldMDef,
-                { spiritshot: usedSpiritshot, blessedSpiritshot: usedBlessedSpiritshot }
-            ) * vulnModifier);
-            this.clearLoadedShot(actor, magicSkill);
-            return damage;
         }
 
         const usedSoulshot = !!actor.soulshotLoaded;

--- a/src/GameServer/ConsoleText.js
+++ b/src/GameServer/ConsoleText.js
@@ -17,6 +17,7 @@ const ConsoleText = {
         earnedExpAndSp    :  95,
         levelUp           :  96,
         incorrectDest     : 144,
+        magicResisted     : 159,
         waitForResponse   : 164,
         insufficientSp    : 278,
         insufficientAdena : 279,
@@ -27,6 +28,7 @@ const ConsoleText = {
     },
 
     kind: {
+        text   : 0,
         number : 1,
         npc    : 2,
         item   : 3,

--- a/src/GameServer/Network/Response/ConsoleText.js
+++ b/src/GameServer/Network/Response/ConsoleText.js
@@ -8,9 +8,13 @@ function consoleText(textId, params) {
         .writeD(utils.size(params))
 
     params.forEach((param) => {
-        packet
-            .writeD(param.kind)
-            .writeD(param.value);
+        packet.writeD(param.kind);
+        if (param.kind === 0) {
+            packet.writeS(String(param.value ?? ''));
+        }
+        else {
+            packet.writeD(param.value);
+        }
     });
 
     return packet.fetchBuffer();

--- a/src/GameServer/Npc/Npc.js
+++ b/src/GameServer/Npc/Npc.js
@@ -8,6 +8,7 @@ const GeodataEngine  = invoke('GameServer/Geodata/GeodataEngine');
 const Attack         = invoke('GameServer/Actor/Attack');
 const ManorData      = invoke('GameServer/Manor/ManorData');
 const NpcSkills      = invoke('GameServer/Npc/NpcSkills');
+const EffectStats    = invoke('GameServer/Effects/EffectStats');
 const AttackHelper   = new Attack();
 
 class Npc extends NpcModel {
@@ -149,6 +150,20 @@ class Npc extends NpcModel {
         );
     }
 
+    fetchCollectiveAccur() {
+        // NPC templates carry the base accuracy bonus.  As in the C4 stat
+        // calculator, add DEX and level before using it in the hit formula.
+        return Formulas.calcAccur(this.fetchLevel(), this.fetchDex(), this.fetchAccur())
+            + EffectStats.add(this, 'pAccuracyCombatAdd');
+    }
+
+    fetchCollectiveEvasion() {
+        // NPC templates have no authored evasion value, but they still use
+        // the standard DEX/level evasion calculation and active effects.
+        return Formulas.calcEvasion(this.fetchLevel(), this.fetchDex(), this.fetchEvasion())
+            + EffectStats.add(this, 'pEvasionRateAdd');
+    }
+
     fetchCombatStopCoords(actor, attackRange = this.fetchCombatAttackRange(actor)) {
         return this.automation.actionStopCoords(this, actor, attackRange);
     }
@@ -208,7 +223,7 @@ class Npc extends NpcModel {
     castSkill(session, actor, skill) {
         AttackHelper.remoteHit({
             actor: this,
-            dataSendToMe() {},
+            dataSendToMe: (packet) => session.dataSendToMe?.(packet),
             dataSendToMeAndOthers: (packet) => session.dataSendToMeAndOthers(packet, this)
         }, actor, skill);
     }
@@ -248,6 +263,9 @@ class Npc extends NpcModel {
 
             if (hitLanded) {
                 this.hit(session, dst, hit.damage);
+            }
+            else {
+                ConsoleText.transmit(session, ConsoleText.caption.missedHit);
             }
 
         }, speed * 0.644);

--- a/tests/test_npc_combat_range.js
+++ b/tests/test_npc_combat_range.js
@@ -5,6 +5,8 @@ require('../src/Global');
 const Attack = invoke('GameServer/Actor/Attack');
 const Npc = invoke('GameServer/Npc/Npc');
 const SkillModel = invoke('GameServer/Model/Skill');
+const Formulas = invoke('GameServer/Formulas');
+const ConsoleText = invoke('GameServer/ConsoleText');
 
 function npcWithRange(atkRadius, selfId = 900000) {
     return new Npc(900000, {
@@ -15,7 +17,7 @@ function npcWithRange(atkRadius, selfId = 900000) {
         level: 1,
         hostile: true,
         str: 1,
-        dex: 1,
+        dex: 30,
         con: 1,
         int: 1,
         wit: 1,
@@ -25,7 +27,7 @@ function npcWithRange(atkRadius, selfId = 900000) {
         pDef: 1,
         mAtk: 1,
         mDef: 1,
-        accur: 1,
+        accur: 4.75,
         atkSpd: 253,
         castSpd: 333,
         atkRadius,
@@ -63,6 +65,8 @@ function actorAt(x) {
         setHp(value) { this.hp = value; },
         fetchCollectivePDef: () => 100,
         fetchCollectiveMDef: () => 100,
+        fetchCollectiveEvasion: () => 34,
+        fetchLevel: () => 1,
         fetchDex: () => 30,
         fetchHead: () => 0,
         statusUpdateVitals() {},
@@ -101,6 +105,21 @@ assert.strictEqual(rangedNpc.isTargetInAttackRange(target), true, 'ranged NPC sh
 assert.notStrictEqual(rangedNpc.fetchLocX(), target.fetchLocX(), 'ranged NPC must not snap onto the player');
 
 const meleeNpc = npcWithRange(40);
+assert.strictEqual(
+    Math.round(meleeNpc.fetchCollectiveAccur()),
+    39,
+    'NPC accuracy should include its base accuracy, DEX, and level'
+);
+assert.strictEqual(
+    Math.round(meleeNpc.fetchCollectiveEvasion()),
+    34,
+    'NPC evasion should include its DEX and level like other creatures'
+);
+assert.strictEqual(
+    Formulas.calcHitChance(meleeNpc, target, () => 0.85),
+    true,
+    'a low-level NPC should not be pinned to the 20% minimum hit chance against a low-level player'
+);
 assert.deepStrictEqual(
     meleeNpc.fetchCombatStopCoords(target),
     { locX: 960, locY: 0, locZ: 0 },
@@ -126,6 +145,10 @@ assert.deepStrictEqual(
 casterNpc.setLocXYZ(castStop);
 const session = {
     packets: [],
+    clientPackets: [],
+    dataSendToMe(packet) {
+        this.clientPackets.push(packet);
+    },
     dataSendToMeAndOthers(packet) {
         this.packets.push(packet);
     }
@@ -139,6 +162,12 @@ assert.strictEqual(castPacket.readInt32LE(25), castStop.locX, 'MagicSkillUse sho
 assert.strictEqual(session.packets.some((packet) => packet[0] === 0x05), false, 'spellcasting path should not emit an immediate melee attack');
 casterNpc.state.setCasts(false);
 AttackHelperCleanup(casterNpc);
+
+const originalCalcHitChance = Formulas.calcHitChance;
+Formulas.calcHitChance = () => false;
+meleeNpc.setCollectiveAtkSpd(999999);
+meleeNpc.meleeHit(session, meleeNpc, target);
+Formulas.calcHitChance = originalCalcHitChance;
 
 const npcPhysicalSkill = new SkillModel({
     selfId: 4032,
@@ -161,10 +190,20 @@ assert.doesNotThrow(
     'physical NPC skills should not require a player backpack'
 );
 
-console.log('NPC combat range checks passed');
-
 function AttackHelperCleanup(npc) {
     npc.abortCombatState({
         dataSendToMeAndOthers() {}
     });
 }
+
+setTimeout(() => {
+    assert(
+        session.clientPackets.some((packet) => packet[0] === 0x64 && packet.readInt32LE(1) === ConsoleText.caption.actorHit),
+        'NPC skill damage should forward its hit system message to the targeted player'
+    );
+    assert(
+        session.clientPackets.some((packet) => packet[0] === 0x64 && packet.readInt32LE(1) === ConsoleText.caption.missedHit),
+        'NPC melee misses should send the evasion system message to the targeted player'
+    );
+    console.log('NPC combat range checks passed');
+}, 25);

--- a/tests/test_skill_area_runtime.js
+++ b/tests/test_skill_area_runtime.js
@@ -88,6 +88,34 @@ function npc(id, x, y, dead = false) {
     };
 }
 
+function player(id, x, y, level = 70) {
+    return {
+        hp: 1000,
+        fetchId: () => id,
+        fetchName: () => `Player${id}`,
+        fetchLevel: () => level,
+        fetchLocX: () => x,
+        fetchLocY: () => y,
+        fetchLocZ: () => 0,
+        fetchHead: () => 0,
+        fetchCollectiveMDef: () => 50,
+        fetchCollectivePDef: () => 100,
+        fetchDex: () => 30,
+        fetchHp() { return this.hp; },
+        setHp(value) { this.hp = value; },
+        statusUpdateVitals() {},
+        automation: {
+            replenishVitals() {}
+        },
+        state: {
+            fetchDead: () => false,
+            fetchSeated: () => false,
+            fetchCombats: () => false,
+            setCombats() {}
+        }
+    };
+}
+
 function session(caster) {
     return {
         actor: caster,
@@ -174,5 +202,53 @@ assert.deepStrictEqual(
     [caster.fetchId(), primary.fetchId(), nearby.fetchId()],
     'area damage should send vitals updates for every affected visible NPC, not only the selected primary target'
 );
+
+const npcCaster = actor();
+npcCaster.fetchId = () => 1004999;
+npcCaster.fetchName = () => 'Area Monster';
+npcCaster.fetchKind = () => 'Monster';
+const playerPrimary = player(2004999, 100, 0);
+const playerNearby = player(2005000, 240, 0);
+const playerOutside = player(2005001, 500, 0);
+const npcSession = session(npcCaster);
+const playerPrimarySession = session(playerPrimary);
+const playerNearbySession = session(playerNearby);
+const playerOutsideSession = session(playerOutside);
+playerPrimary.session = playerPrimarySession;
+playerNearby.session = playerNearbySession;
+playerOutside.session = playerOutsideSession;
+
+World.user = { sessions: [playerPrimarySession, playerNearbySession, playerOutsideSession] };
+Math.random = () => 0;
+try {
+    attack.remoteHit(npcSession, playerPrimary, flameStrike());
+} finally {
+    World.user = originalWorldUser;
+    Math.random = originalRandom;
+}
+
+assert.strictEqual(playerPrimary.fetchHp(), 967, 'NPC TARGET_AREA skill should damage its selected player target');
+assert.strictEqual(playerNearby.fetchHp(), 967, 'NPC TARGET_AREA skill should damage nearby players');
+assert.strictEqual(playerOutside.fetchHp(), 1000, 'NPC TARGET_AREA skill should not damage players outside sourced radius');
+const npcLaunched = npcSession.packets.find((packet) => packet?.[0] === 0x76);
+assert(npcLaunched, 'NPC area spell should broadcast MagicSkillLaunched');
+assert.strictEqual(npcLaunched.readInt32LE(13), 2, 'NPC area spell should include each affected player in MagicSkillLaunched');
+
+const resistedPlayer = player(2005002, 100, 0, 100);
+const resistedPlayerSession = session(resistedPlayer);
+resistedPlayer.session = resistedPlayerSession;
+World.user = { sessions: [resistedPlayerSession] };
+Math.random = () => 0.99;
+try {
+    attack.remoteHit(npcSession, resistedPlayer, flameStrike());
+} finally {
+    World.user = originalWorldUser;
+    Math.random = originalRandom;
+}
+
+assert.strictEqual(resistedPlayer.fetchHp(), 1000, 'resisted NPC magic should not deal damage');
+const resistedMessage = resistedPlayerSession.packets.find((packet) => packet?.[0] === 0x64 && packet.readInt32LE(1) === 159);
+assert(resistedMessage, 'a player should receive the C4 magic-resisted system message for an NPC spell');
+assert.strictEqual(resistedMessage.readInt32LE(9), 0, 'magic-resisted system message should carry the monster name as text');
 
 console.log('Skill area runtime checks passed');

--- a/tests/test_skill_damage_formulas.js
+++ b/tests/test_skill_damage_formulas.js
@@ -70,6 +70,22 @@ const castDamage = attack.prepareSkillDamage(magicActor, target(), skill({ spell
 assert.strictEqual(castDamage, 257, 'magic skill damage should follow C4 magic formula with spiritshot');
 assert.strictEqual(magicActor.spiritshotLoaded, false, 'magic skill should clear used spiritshot charge');
 
+const shieldedMagicTarget = target();
+shieldedMagicTarget.fetchHead = () => 0;
+shieldedMagicTarget.backpack = {
+    fetchTotalShieldRate: () => 100,
+    fetchTotalShieldPDef: () => 100
+};
+const shieldedMagicActor = actor();
+shieldedMagicActor.fetchLocX = () => 1;
+shieldedMagicActor.fetchLocY = () => 0;
+const shieldedMagicDamage = attack.prepareSkillDamage(shieldedMagicActor, shieldedMagicTarget, skill({ spell: true, power: 10 }), true, () => 0.99);
+assert.strictEqual(
+    shieldedMagicDamage,
+    magicNoShot,
+    'magic skill damage should ignore shield P.Def and shield block rolls'
+);
+
 const blessedMagicActor = actor();
 blessedMagicActor.spiritshotLoaded = true;
 blessedMagicActor.blessedSpiritshotLoaded = true;


### PR DESCRIPTION
## What changed

This PR makes monster combat feel more consistent and closer to the intended C4 behaviour.

Mobs now use their level and DEX when calculating accuracy and evasion, so low-level monsters are no longer stuck missing most of their attacks. Melee misses, successful hits, and resisted magic also provide the player with the appropriate system feedback.

The damage pipeline has also been corrected: shields no longer reduce magical damage, while physical attacks still use shield defence as expected. Area spells cast by monsters can now hit nearby players instead of affecting only the selected target.

## Why

Several parts of the NPC combat path were using player-oriented assumptions or incomplete target selection. This led to frequent unexplained misses, missing combat messages, shield mitigation on magic, and monster AoE skills behaving like single-target spells.

## Player impact

Combat should now be easier to read and more predictable:

- monsters land hits at a reasonable rate;
- magical damage is not incorrectly blocked by a shield;
- nearby players are affected by monster AoE skills;
- the client reports when an NPC spell is resisted.

## Validation

- `npm run check`
- `npm test`