### PR TITLE
Fix town respawns

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -48,6 +48,7 @@ const tests = [
     'tests/test_pathfinder_astar.js',
     'tests/test_player_ranged_combat.js',
     'tests/test_progression_rates.js',
+    'tests/test_restart_point_revive.js',
     'tests/test_private_tell_routing.js',
     'tests/test_shot_consumption.js',
     'tests/test_skill_area_semantics.js',
@@ -56,6 +57,7 @@ const tests = [
     'tests/test_skill_semantics.js',
     'tests/test_skill_damage_formulas.js',
     'tests/test_town_pathfinder.js',
+    'tests/test_town_respawn.js',
     'tests/test_toggle_skills.js',
     'tests/test_ui_test_window.js'
 ];

--- a/src/GameServer/Actor/Generics/Revive.js
+++ b/src/GameServer/Actor/Generics/Revive.js
@@ -1,13 +1,26 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 
-function revive(session, actor) {
+function revive(session, actor, { delayMs = 2500, restoreFullVitals = false } = {}) {
+    if (restoreFullVitals) {
+        actor.automation.stopReplenish();
+        actor.fillupVitals();
+    } else {
+        actor.automation.replenishVitals(actor);
+    }
+
+    if (delayMs <= 0) {
+        actor.state.setDead(false);
+        session.dataSendToMeAndOthers(ServerResponse.revive(actor.fetchId()), actor);
+        session.dataSendToMeAndOthers(ServerResponse.socialAction(actor.fetchId(), 9), actor);
+        return;
+    }
+
     session.dataSendToMeAndOthers(ServerResponse.revive(actor.fetchId()), actor);
-    actor.automation.replenishVitals(actor);
 
     setTimeout(() => {
         actor.state.setDead(false);
         session.dataSendToMeAndOthers(ServerResponse.socialAction(actor.fetchId(), 9), actor); // SWAG stand-up
-    }, 2500);
+    }, delayMs);
 }
 
 module.exports = revive;

--- a/src/GameServer/Actor/Generics/TeleportTo.js
+++ b/src/GameServer/Actor/Generics/TeleportTo.js
@@ -20,8 +20,7 @@ function teleportTo(session, actor, coords) {
 
     // Turns out to be a viable solution
     setTimeout(() => {
-        Generics.updatePosition(session, actor, coords);
-        Generics.updateEnvironment(session, actor); // Force update position, in case we Teleport to the same Location
+        Generics.updatePosition(session, actor, coords, { immediateNpcInfo: true, forceRefresh: true });
 
         // Wake up bot AI after teleportation is complete and position updated
         if (session.aiActive) {

--- a/src/GameServer/Actor/Generics/UpdateEnvironment.js
+++ b/src/GameServer/Actor/Generics/UpdateEnvironment.js
@@ -3,13 +3,19 @@ const World          = invoke('GameServer/World/World');
 const SpeckMath      = invoke('GameServer/SpeckMath');
 const BotAI          = invoke('GameServer/Bot/BotAI');
 
-function updateEnvironment(session, actor) {
+function updateEnvironment(session, actor, { immediateNpcInfo = false, forceRefresh = false } = {}) {
     const actorArea = new SpeckMath.Circle(actor.fetchLocX(), actor.fetchLocY(), 6000);
     const npcs = World.fetchNpcsInRadius(actor.fetchLocX(), actor.fetchLocY(), 6000).filter((ob) => ob.state.fetchDead() === false) ?? [];
 
-    if (new SpeckMath.Point(actor.previousXY?.locX ?? 0, actor.previousXY?.locY ?? 0).distance(new SpeckMath.Point(actor.fetchLocX(), actor.fetchLocY())) >= 1000) {
-        npcs.forEach((npc) => { // Gives a sense of random NPC Animation to the actor
-            setTimeout( () => { session.dataSendToMe(ServerResponse.npcInfo(npc)); }, utils.randomNumber(2000));
+    if (forceRefresh || new SpeckMath.Point(actor.previousXY?.locX ?? 0, actor.previousXY?.locY ?? 0).distance(new SpeckMath.Point(actor.fetchLocX(), actor.fetchLocY())) >= 1000) {
+        npcs.forEach((npc) => {
+            const sendNpcInfo = () => session.dataSendToMe(ServerResponse.npcInfo(npc));
+            if (immediateNpcInfo) {
+                sendNpcInfo();
+            } else {
+                // Gives a sense of random NPC Animation to the actor.
+                setTimeout(sendNpcInfo, utils.randomNumber(2000));
+            }
         });
 
         World.fetchVisibleUsers(session, actor).forEach((user) => {

--- a/src/GameServer/Actor/Generics/UpdatePosition.js
+++ b/src/GameServer/Actor/Generics/UpdatePosition.js
@@ -1,7 +1,7 @@
 const Database = invoke('Database');
 const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
 
-function updatePosition(session, actor, coords) {
+function updatePosition(session, actor, coords, environmentOptions) {
     const Generics = invoke(path.actor);
 
     // NOTE: Do NOT snap Z to geodata here. UpdatePosition is called both after
@@ -15,7 +15,7 @@ function updatePosition(session, actor, coords) {
     Database.updateCharacterLocation(actor.fetchId(), coords);
 
     // Update Online users, NPCs, underwater locations
-    Generics.updateEnvironment(session, actor);
+    Generics.updateEnvironment(session, actor, environmentOptions);
     Generics.underwaterCheck  (session, actor);
 
     // Reschedule actions based on updated position

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -6,6 +6,7 @@ const BotCombatUtility = invoke('GameServer/Bot/AI/BotCombatUtility');
 const PopulationService = invoke('GameServer/Bot/Population/PopulationService');
 const BotEquipmentUpgrade = invoke('GameServer/Bot/AI/BotEquipmentUpgrade');
 const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
+const TownRespawn = invoke('GameServer/World/TownRespawn');
 
 const CHAT_PHRASES = {
     foundTarget: [
@@ -34,19 +35,6 @@ const CHAT_PHRASES = {
     ]
 };
 
-const TOWNS = [
-    { name: "Talking Island", x: -84318, y: 244579, z: -3730 },
-    { name: "Elven Village", x: 45475, y: 48359, z: -3060 },
-    { name: "Dark Elven Village", x: 12111, y: 16686, z: -4582 },
-    { name: "Dwarven Village", x: 115632, y: -177996, z: -905 },
-    { name: "Orc Village", x: -45032, y: -113598, z: -192 },
-    { name: "Gludin", x: -80752, y: 149776, z: -3044 },
-    { name: "Gludio", x: -12736, y: 122816, z: -3114 },
-    { name: "Dion", x: 15631, y: 142885, z: -2704 },
-    { name: "Giran", x: 83396, y: 147904, z: -3404 },
-    { name: "Oren", x: 82960, y: 53177, z: -1497 }
-];
-
 function getRandomPhrase(category, ...args) {
     const list = CHAT_PHRASES[category];
     const phrase = list[Math.floor(Math.random() * list.length)];
@@ -58,24 +46,8 @@ function newbieSpawnCoords(classId) {
     return DataCache.newbieSpawns.find(ob => ob.classId === classId)?.spawns ?? [{ locX: -84318, locY: 244579, locZ: -3730 }];
 }
 
-function closestTown(locX, locY) {
-    let closest = TOWNS[0];
-    let minDist = Infinity;
-    TOWNS.forEach(town => {
-        const dx = town.x - locX;
-        const dy = town.y - locY;
-        const dist = Math.sqrt(dx * dx + dy * dy);
-        if (dist < minDist) {
-            minDist = dist;
-            closest = town;
-        }
-    });
-    return closest;
-}
-
 function townRespawnCoords(bot) {
-    const town = closestTown(bot.fetchLocX(), bot.fetchLocY());
-    return { locX: town.x, locY: town.y, locZ: town.z };
+    return TownRespawn.getRespawnCoords(bot.fetchLocX(), bot.fetchLocY());
 }
 
 function isRealPlayerSession(session) {
@@ -209,7 +181,8 @@ const BotAI = {
     },
 
     getClosestTown(locX, locY) {
-        return closestTown(locX, locY);
+        const town = TownRespawn.getClosestTown(locX, locY);
+        return { name: town.name, x: town.locX, y: town.locY, z: town.locZ };
     },
 
     getDeathRespawnTarget(session, bot, wasCompanion = false) {
@@ -362,8 +335,9 @@ const BotAI = {
 
             // Revive after 12 seconds of death
             if (Date.now() - session.deathTimerStart > 12000) {
-                Generics.revive(session, bot);
-                bot.fillupVitals(); // Restore full HP/MP
+                // TeleportTo rejects actors that are still marked dead, so bot
+                // respawns must complete before applying the new town location.
+                Generics.revive(session, bot, { delayMs: 0, restoreFullVitals: true });
                 session.deathTimerStart = undefined;
                 session.currentTargetId = undefined;
                 session.incomingThreatId = undefined;

--- a/src/GameServer/Network/Request/RestartPoint.js
+++ b/src/GameServer/Network/Request/RestartPoint.js
@@ -1,4 +1,5 @@
 const ReceivePacket = invoke('Packet/Receive');
+const ServerResponse = invoke('GameServer/Network/Response');
 
 function restartPoint(session, buffer) {
     const packet = new ReceivePacket(buffer);
@@ -12,24 +13,22 @@ function restartPoint(session, buffer) {
 }
 
 function consume(session, data) {
-    session.actor.revive();
+    const actor = session.actor;
+    if (!actor || !actor.state?.fetchDead?.() || !actor.isDead()) {
+        return;
+    }
 
-    // Teleport resurrected players to a randomized newbie spawn coordinate of their class
-    const DataCache = invoke('GameServer/DataCache');
-    const classId = session.actor.fetchClassId();
-    const spawns = DataCache.newbieSpawns.find(ob => ob.classId === classId)?.spawns ?? [{ locX: -84318, locY: 244579, locZ: -3730 }];
-    const randomSpawn = spawns[Math.floor(Math.random() * spawns.length)];
+    const TownRespawn = invoke('GameServer/World/TownRespawn');
+    const townRespawn = TownRespawn.getRespawnCoords(actor.fetchLocX(), actor.fetchLocY());
+    const Generics = invoke(path.actor);
 
-    const targetCoord = {
-        locX: randomSpawn.locX + (Math.random() - 0.5) * 600,
-        locY: randomSpawn.locY + (Math.random() - 0.5) * 600,
-        locZ: randomSpawn.locZ
-    };
+    // Town restart is a complete respawn, unlike a gradual resurrection skill.
+    // Make the actor alive before TeleportTo checks HP/dead state.
+    Generics.revive(session, actor, { delayMs: 0, restoreFullVitals: true });
+    session.dataSendToMe(ServerResponse.userInfo(actor));
 
-    setTimeout(() => {
-        const TeleportTo = invoke('GameServer/Actor/Generics/TeleportTo');
-        TeleportTo(session, session.actor, targetCoord);
-    }, 2800);
+    Generics.teleportTo(session, actor, townRespawn);
 }
 
 module.exports = restartPoint;
+module.exports.consume = consume;

--- a/src/GameServer/World/TownRespawn.js
+++ b/src/GameServer/World/TownRespawn.js
@@ -1,0 +1,101 @@
+// Based on the C4 L2J mapRegions/restartPoints data. Restart regions are
+// deliberately geographical, not a straight-line nearest-city calculation.
+const TOWNS = {
+    aden_town: { name: 'Aden', locX: 146737, locY: 25807, locZ: -2008 },
+    de_village: { name: 'Dark Elven Village', locX: 9670, locY: 15537, locZ: -4576 },
+    dion_town: { name: 'Dion', locX: 15631, locY: 142885, locZ: -2704 },
+    dwarven_village: { name: 'Dwarven Village', locX: 115072, locY: -178176, locZ: -880 },
+    elven_village: { name: 'Elven Village', locX: 46926, locY: 51511, locZ: -2976 },
+    floran_village: { name: 'Floran Village', locX: 19025, locY: 145245, locZ: -3107 },
+    giran_town: { name: 'Giran', locX: 83396, locY: 147904, locZ: -3400 },
+    gludin_village: { name: 'Gludin', locX: -80752, locY: 149776, locZ: -3040 },
+    gludio_town: { name: 'Gludio', locX: -12736, locY: 122816, locZ: -3112 },
+    goddard_town: { name: 'Goddard', locX: 147966, locY: -55228, locZ: -2728 },
+    hunters_village: { name: "Hunter's Village", locX: 117129, locY: 76917, locZ: -2688 },
+    innadril_town: { name: 'Heine', locX: 111386, locY: 219413, locZ: -3544 },
+    orc_village: { name: 'Orc Village', locX: -45264, locY: -112512, locZ: -256 },
+    oren_town: { name: 'Oren', locX: 82992, locY: 53171, locZ: -1496 },
+    rune_town: { name: 'Rune', locX: 43824, locY: -47664, locZ: -792 },
+    ti_village: { name: 'Talking Island', locX: -84108, locY: 244604, locZ: -3728 }
+};
+
+// Keep the destination close to the gatekeeper without placing the actor in
+// the NPC collision model. This is deliberately fixed rather than randomized.
+const GATEKEEPER_RESPAWN_OFFSET = { locX: 50, locY: 0 };
+
+const REGION_GROUPS = {
+    aden_town: ['23_18', '24_17', '24_18', '25_17', '25_18', '25_19', '24_19'],
+    de_village: ['20_18', '19_18', '19_19', '18_19', '18_18', '18_20', '17_19'],
+    dion_town: ['18_10', '20_21', '20_22', '21_21', '21_22'],
+    dwarven_village: ['23_10', '23_11', '23_12', '24_10', '24_11', '24_12', '25_10', '25_11', '25_12'],
+    elven_village: ['21_19', '21_20', '20_19', '20_20'],
+    floran_village: ['20_23'],
+    giran_town: ['21_23', '22_21', '22_22', '23_21', '23_22', '24_21', '25_21', '20_24', '21_24', '21_25'],
+    gludin_village: ['16_20', '16_21', '16_22', '17_20', '17_21', '17_22', '17_23', '18_22', '18_23', '18_24', '19_24'],
+    gludio_town: ['19_20', '18_21', '19_21', '19_22', '19_23', '19_26', '20_26'],
+    goddard_town: ['23_16', '24_14', '24_15', '24_16', '25_14', '25_15', '25_16', '26_14'],
+    hunters_village: ['20_10', '23_20', '23_19', '24_20', '25_20'],
+    innadril_town: ['22_23', '22_24', '22_25', '23_23', '23_24', '23_25', '24_23'],
+    orc_village: ['18_14', '19_13', '19_14', '19_15', '19_16', '20_13', '20_14', '20_15', '16_10'],
+    oren_town: ['19_10', '21_18', '22_20', '22_19', '22_18', '22_17', '23_17'],
+    rune_town: ['21_15', '21_16', '21_17', '22_15', '22_16', '23_15', '16_11', '17_10', '17_11', '19_17', '20_16', '20_17', '19_16', '15_10', '15_11', '15_12'],
+    ti_village: ['15_23', '15_24', '15_25', '16_23', '16_24', '16_25', '17_24', '17_25', '18_25']
+};
+
+const RESPAWN_ZONES = [
+    { group: 'oren_town', points: [[117258, -17696], [111573, -6727], [104357, -204], [98363, -186], [98372, -24720]] },
+    { group: 'goddard_town', points: [[97820, -33007], [130600, -33101], [131029, -19205], [114478, -17118], [113183, -18971], [97723, -24594]] },
+    { group: 'aden_town', points: [[130704, -21362], [130886, -209], [112747, -173], [108637, -3399], [115372, -13695]] }
+];
+
+const CELL_TO_GROUP = Object.fromEntries(
+    Object.entries(REGION_GROUPS).flatMap(([group, cells]) => cells.map((cell) => [cell, group]))
+);
+
+function isInsidePolygon(locX, locY, points) {
+    let inside = false;
+    for (let index = 0, previous = points.length - 1; index < points.length; previous = index++) {
+        const [x, y] = points[index];
+        const [previousX, previousY] = points[previous];
+        const crosses = (y > locY) !== (previousY > locY);
+        if (crosses && locX < ((previousX - x) * (locY - y)) / (previousY - y) + x) {
+            inside = !inside;
+        }
+    }
+    return inside;
+}
+
+function getRegionGroup(locX, locY) {
+    const zone = RESPAWN_ZONES.find((candidate) => isInsidePolygon(locX, locY, candidate.points));
+    if (zone) return zone.group;
+
+    const mapX = (locX >> 15) + 20;
+    const mapY = (locY >> 15) + 18;
+    return CELL_TO_GROUP[`${mapX}_${mapY}`];
+}
+
+function getClosestTown(locX, locY) {
+    const regionalTown = TOWNS[getRegionGroup(locX, locY)];
+    if (regionalTown) return regionalTown;
+
+    return Object.values(TOWNS).reduce((closest, town) => {
+        const closestDistance = (closest.locX - locX) ** 2 + (closest.locY - locY) ** 2;
+        const townDistance = (town.locX - locX) ** 2 + (town.locY - locY) ** 2;
+        return townDistance < closestDistance ? town : closest;
+    });
+}
+
+function getRespawnCoords(locX, locY) {
+    const town = getClosestTown(locX, locY);
+    return {
+        locX: town.locX + GATEKEEPER_RESPAWN_OFFSET.locX,
+        locY: town.locY + GATEKEEPER_RESPAWN_OFFSET.locY,
+        locZ: town.locZ
+    };
+}
+
+module.exports = {
+    getClosestTown,
+    getRegionGroup,
+    getRespawnCoords
+};

--- a/tests/test_bot_death_respawn.js
+++ b/tests/test_bot_death_respawn.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 require('../src/Global');
 
 const BotAI = invoke('GameServer/Bot/BotAI');
+const revive = invoke('GameServer/Actor/Generics/Revive');
 
 function botAt(loc) {
     return {
@@ -22,7 +23,7 @@ const huntingSession = {
 
 assert.deepStrictEqual(
     BotAI.getDeathRespawnTarget(huntingSession, botAt(huntingSpot), false),
-    { locX: 45475, locY: 48359, locZ: -3060 },
+    { locX: 46976, locY: 51511, locZ: -2976 },
     'solo hunting death should restart at the nearest town instead of the active hunting spot'
 );
 
@@ -59,5 +60,30 @@ assert.strictEqual(deadSession.lastDecision, undefined, 'death should clear stal
 assert.strictEqual(deadSession.lastTargetEvaluation, undefined, 'death should clear stale target scoring');
 assert.strictEqual(deadSession.lastCombatDecision, undefined, 'death should clear stale combat choices');
 assert.strictEqual(deadSession.lastPvpDecision, undefined, 'death should clear stale PvP choices');
+
+const respawningBot = {
+    hp: 0,
+    mp: 0,
+    fetchId: () => 200001,
+    fillupVitals() {
+        this.hp = 100;
+        this.mp = 100;
+    },
+    automation: {
+        stopReplenish() {},
+        replenishVitals() { throw new Error('bot town respawn must not wait for gradual regeneration'); }
+    },
+    state: {
+        dead: true,
+        setDead(value) { this.dead = value; }
+    }
+};
+const respawnPackets = [];
+revive({
+    dataSendToMeAndOthers(packet) { respawnPackets.push(packet); }
+}, respawningBot, { delayMs: 0, restoreFullVitals: true });
+assert.strictEqual(respawningBot.state.dead, false, 'bot must be alive before its immediate town teleport');
+assert.strictEqual(respawningBot.hp, 100, 'bot town respawn should restore HP before teleport validation');
+assert.strictEqual(respawnPackets.length, 2, 'bot town respawn should send revive and stand-up packets synchronously');
 
 console.log('Bot death respawn checks passed');

--- a/tests/test_restart_point_revive.js
+++ b/tests/test_restart_point_revive.js
@@ -1,0 +1,40 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const revive = invoke('GameServer/Actor/Generics/Revive');
+
+const packets = [];
+const actor = {
+    hp: 0,
+    mp: 0,
+    fetchId: () => 42,
+    fillupVitals() {
+        this.hp = 100;
+        this.mp = 100;
+    },
+    automation: {
+        stopReplenishCalled: false,
+        stopReplenish() { this.stopReplenishCalled = true; },
+        replenishVitals() { throw new Error('town restart must not wait for gradual regeneration'); }
+    },
+    state: {
+        dead: true,
+        setDead(value) { this.dead = value; }
+    }
+};
+const session = {
+    dataSendToMeAndOthers(packet) { packets.push(packet); }
+};
+
+revive(session, actor, { delayMs: 0, restoreFullVitals: true });
+
+assert.strictEqual(actor.state.dead, false, 'town restart should immediately clear the dead state');
+assert.strictEqual(actor.hp, 100, 'town restart should restore HP before teleport validation');
+assert.strictEqual(actor.mp, 100, 'town restart should restore MP before teleport validation');
+assert.strictEqual(actor.automation.stopReplenishCalled, true, 'town restart should stop stale regeneration timers');
+assert.strictEqual(packets.length, 2, 'town restart should send revive and stand-up packets immediately');
+assert.strictEqual(packets[0][0], 0x07, 'first packet should be Revive');
+assert.strictEqual(packets[1][0], 0x2d, 'second packet should be SocialAction stand-up');
+
+console.log('Restart point revive checks passed');

--- a/tests/test_town_pathfinder.js
+++ b/tests/test_town_pathfinder.js
@@ -56,7 +56,7 @@ assert(distance(dionEntry, dionCenter) < distance(dionField, dionCenter));
 
 const gludinTown = BotAI.getClosestTown(-82000, 151000);
 assert.strictEqual(gludinTown.name, 'Gludin');
-assert.strictEqual(gludinTown.z, -3044);
+assert.strictEqual(gludinTown.z, -3040);
 
 const talkingIslandExitSteps = routeUntilTarget(talkingIslandCenter, talkingIslandField);
 assert.deepStrictEqual(

--- a/tests/test_town_respawn.js
+++ b/tests/test_town_respawn.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const TownRespawn = invoke('GameServer/World/TownRespawn');
+const BotAI = invoke('GameServer/Bot/BotAI');
+
+assert.deepStrictEqual(
+    TownRespawn.getRespawnCoords(76000, 144000),
+    { locX: 83446, locY: 147904, locZ: -3400 },
+    'a player who dies near Giran should respawn beside the Giran gatekeeper'
+);
+
+assert.deepStrictEqual(
+    TownRespawn.getRespawnCoords(-82000, 151000),
+    { locX: -80702, locY: 149776, locZ: -3040 },
+    'a player who dies near Gludin should respawn beside the Gludin gatekeeper'
+);
+
+assert.deepStrictEqual(
+    TownRespawn.getRespawnCoords(166612, 20436),
+    { locX: 146787, locY: 25807, locZ: -2008 },
+    'Cemetery belongs to the Aden restart region, not Oren'
+);
+
+assert.deepStrictEqual(
+    TownRespawn.getRespawnCoords(146828, -12859),
+    { locX: 146787, locY: 25807, locZ: -2008 },
+    'Blazing Swamp belongs to the Aden restart region, not Oren'
+);
+
+assert.strictEqual(
+    BotAI.getClosestTown(76000, 144000).name,
+    'Giran',
+    'bots should use the same nearest-town source as player respawns'
+);
+
+console.log('Town respawn regression checks passed');


### PR DESCRIPTION
## Summary

- respawn players and bots in the appropriate town region instead of a starter location
- place the respawn point next to, rather than inside, the town gatekeeper
- complete town respawns before teleporting so dead-state validation cannot cancel the move
- refresh the destination environment immediately after teleporting

## Root cause

Restart Point always selected a random newbie spawn and attempted the teleport before delayed revival had cleared the dead state. Bot death recovery had the same revive-to-teleport ordering issue.

## Validation

- `npm run check`
- `npm test`
- `tests/test_town_respawn.js`
- `tests/test_bot_death_respawn.js`
