### PR TITLE
Fix control effect runtime and visuals

### DIFF
--- a/src/GameServer/Actor/Generics/ReceivedHit.js
+++ b/src/GameServer/Actor/Generics/ReceivedHit.js
@@ -50,13 +50,15 @@ function applyCombatPointShield(session, actor, hit) {
     return damage - cpDamage;
 }
 
-function receivedHit(session, actor, hit) {
+function receivedHit(session, actor, hit, options = {}) {
     const Generics = invoke(path.actor);
     const EffectRestrictions = invoke('GameServer/Effects/EffectRestrictions');
     const victimSession = actor?.session;
     const hpDamage = applyCombatPointShield(session, actor, hit);
 
-    EffectRestrictions.wakeOnDamage(actor);
+    if (options.wakeSleep !== false) {
+        EffectRestrictions.wakeOnDamage(actor, victimSession || session);
+    }
     actor.setHp(Math.max(0, actor.fetchHp() - hpDamage)); // HP bar would disappear if less than zero
     actor.statusUpdateVitals(actor);
 

--- a/src/GameServer/Effects/EffectRestrictions.js
+++ b/src/GameServer/Effects/EffectRestrictions.js
@@ -29,10 +29,28 @@ function reject(session) {
     }
 }
 
+function stopMovement(session, actor) {
+    if (session?.moveTimer) {
+        clearInterval(session.moveTimer);
+        session.moveTimer = null;
+    }
+    if (!actor?.fetchId) return false;
+    actor.state?.setTowards?.(false);
+    const packet = ServerResponse.stopMove(actor.fetchId(), {
+        locX: actor.fetchLocX?.() || 0,
+        locY: actor.fetchLocY?.() || 0,
+        locZ: actor.fetchLocZ?.() || 0,
+        head: actor.fetchHead?.() || 0
+    });
+    session?.dataSendToMeAndOthers?.(packet, actor);
+    return true;
+}
+
 function interruptOnApply(session, actor, effect, source = session?.actor) {
     if (!actor || !effect || effect.type !== 'debuff') return;
     const impairments = EffectStore.impairments(actor);
-    if (!(impairments.disabled || impairments.rooted)) return;
+    const confused = EffectStore.hasDebuff(actor, 'confusion');
+    if (!(impairments.disabled || impairments.rooted || confused)) return;
 
     actor.automation?.abortAll?.(actor);
     actor.attack?.clearTimers?.();
@@ -46,13 +64,62 @@ function interruptOnApply(session, actor, effect, source = session?.actor) {
             actor.abortCombatState(safeSession);
         }
     }
-    if (session?.moveTimer) {
-        clearInterval(session.moveTimer);
-        session.moveTimer = null;
-    }
+    stopMovement(session, actor);
     if (impairments.afraid) {
         startFear(session, actor, source, effect);
     }
+    if (confused) {
+        startConfusion(session, actor, effect);
+    }
+}
+
+// Lisvus EffectConfusion / EffectConfuseMob: immediately, then once per
+// effect period, pick a known character in a 600 radius and attack it. The
+// ConfuseMob variant limits the candidates to attackable NPCs.
+function startConfusion(session, actor, effect) {
+    if (!actor?.fetchId || !effect?.key || !EffectStore.hasDebuff(actor, 'confusion')) return false;
+    const timers = actor.effectTimers || (actor.effectTimers = {});
+    if (timers[effect.key]) clearInterval(timers[effect.key]);
+
+    const act = () => {
+        if (!EffectStore.hasDebuff(actor, 'confusion')) {
+            stopConfusion(actor, effect.key);
+            return;
+        }
+        const targets = confusionTargets(actor, effect.confusionMobOnly);
+        if (!targets.length) return;
+        const target = targets[Math.floor(Math.random() * targets.length)];
+        // Npc.enterCombatState deliberately ignores a second start while the
+        // mob has an active combat loop. Confusion must replace that target.
+        actor.abortCombatState?.(session);
+        actor.enterCombatState?.(session, target);
+    };
+
+    act();
+    timers[effect.key] = setInterval(act, 6000);
+    timers[effect.key].unref?.();
+    return true;
+}
+
+function stopConfusion(actor, key = 'confusion') {
+    if (!actor?.effectTimers?.[key]) return false;
+    clearInterval(actor.effectTimers[key]);
+    delete actor.effectTimers[key];
+    return true;
+}
+
+function confusionTargets(actor, attackableOnly) {
+    const World = invoke('GameServer/World/World');
+    const npcs = World.npc?.spawns || [];
+    const users = attackableOnly ? [] : (World.user?.sessions || []).map((session) => session.actor).filter(Boolean);
+    return [...npcs, ...users].filter((candidate) => {
+        if (!candidate || candidate === actor || candidate.state?.fetchDead?.()) return false;
+        if (attackableOnly && candidate.fetchAttackable?.() !== true) return false;
+        const dx = (candidate.fetchLocX?.() || 0) - (actor.fetchLocX?.() || 0);
+        const dy = (candidate.fetchLocY?.() || 0) - (actor.fetchLocY?.() || 0);
+        const dz = (candidate.fetchLocZ?.() || 0) - (actor.fetchLocZ?.() || 0);
+        return Math.hypot(dx, dy, dz) <= 600;
+    });
 }
 
 function startFear(session, actor, source, effect) {
@@ -150,15 +217,13 @@ function fearMoveStep(session, actor, source) {
     }
 }
 
-function wakeOnDamage(actor) {
+function wakeOnDamage(actor, session = actor?.session) {
     if (!actor) return false;
     const removed = EffectStore.remove(actor, 'sleep');
     if (!removed) return false;
 
-    const packet = ServerResponse.abnormalStatusUpdate.fromActor(actor);
-    if (actor.session?.dataSendToMe) {
-        actor.session.dataSendToMe(packet);
-    }
+    const EffectTicker = invoke('GameServer/Effects/EffectTicker');
+    EffectTicker.refreshEffects(session, actor);
     return true;
 }
 
@@ -168,8 +233,11 @@ module.exports = {
     canCast,
     canUseBasicAction,
     reject,
+    stopMovement,
     interruptOnApply,
     startFear,
     stopFear,
+    startConfusion,
+    stopConfusion,
     wakeOnDamage
 };

--- a/src/GameServer/Effects/EffectStore.js
+++ b/src/GameServer/Effects/EffectStore.js
@@ -1,5 +1,18 @@
 const DEFAULT_EFFECT_LEVEL = 1;
 
+// C4 abnormal-effect bits used by CharInfo/NpcInfo. MagicEffectIcons is only
+// sent to the affected player, so nearby clients need this mask to render
+// persistent control effects on another creature.
+const ABNORMAL_MASKS = {
+    bleed: 0x0001,
+    poison: 0x0002,
+    stun: 0x0040,
+    sleep: 0x0080,
+    silence: 0x0100,
+    root: 0x0200,
+    paralyze: 0x0400
+};
+
 function now() {
     return Date.now();
 }
@@ -33,6 +46,7 @@ function normalize(effect = {}) {
         manaDot: effect.manaDot || null,
         manaHot: effect.manaHot || null,
         hot: effect.hot || null,
+        confusionMobOnly: effect.confusionMobOnly === true,
         expiresAt
     };
 }
@@ -145,6 +159,14 @@ function impairments(actor) {
     };
 }
 
+function abnormalMask(actor) {
+    return activeDebuffs(actor).reduce((mask, effect) => {
+        const key = effect.key || effect.category;
+        const category = effect.category || effect.key;
+        return mask | (ABNORMAL_MASKS[key] || ABNORMAL_MASKS[category] || 0);
+    }, 0);
+}
+
 module.exports = {
     apply,
     remove,
@@ -156,5 +178,6 @@ module.exports = {
     activeDebuffs,
     hasDebuff,
     impairments,
+    abnormalMask,
     prune
 };

--- a/src/GameServer/Effects/EffectTicker.js
+++ b/src/GameServer/Effects/EffectTicker.js
@@ -46,6 +46,16 @@ function refreshEffects(session, target) {
         session.dataSendToMe(packet);
     }
 
+    if (target?.session?.dataSendToMe && target?.backpack?.fetchPaperdollSelfId) {
+        target.session.dataSendToMe(ServerResponse.userInfo(target));
+    }
+
+    if (target?.fetchKind && session?.dataSendToMeAndOthers) {
+        session.dataSendToMeAndOthers(ServerResponse.npcInfo(target), target);
+    } else if (target?.session?.dataSendToOthers && target?.backpack?.fetchPaperdollSelfId) {
+        target.session.dataSendToOthers(ServerResponse.charInfo(target), target);
+    }
+
     try {
         const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
         if (target?.session) PartyCompanionService.updateActorEffects(target.session);
@@ -72,6 +82,9 @@ function scheduleExpiry(session, target, effect) {
         clearRuntime(target, effect.key);
         if (target.activeBuffs?.[effect.key] && target.activeBuffs[effect.key] <= Date.now()) {
             delete target.activeBuffs[effect.key];
+        }
+        if (Object.keys(effect.stats || {}).length > 0) {
+            refreshStats(target.session || session, target);
         }
         refreshEffects(session, target);
     }, Math.max(1, delay + 25));
@@ -205,9 +218,10 @@ function applyManaHot(session, source, target, effect) {
 function applyDamage(session, source, target, damage) {
     if (session && source && target?.fetchId && source !== target) {
         if (target.fetchId() >= 2000000) {
-            invoke(path.actor).receivedHit(session, target, damage);
+            invoke(path.actor).receivedHit(session, target, damage, { wakeSleep: true });
         } else {
-            invoke(path.npc).receivedHit(session, source, target, damage);
+            // Lisvus keeps an attackable NPC asleep when it takes DOT damage.
+            invoke(path.npc).receivedHit(session, source, target, damage, { wakeSleep: false });
         }
         return;
     }
@@ -225,6 +239,11 @@ function applyManaDamage(target, damage) {
 }
 
 function refreshStats(session, target) {
+    if (target?.session) {
+        try {
+            invoke(path.actor).calculateStats(target?.session || session, target);
+        } catch (_) {}
+    }
     if (target?.statusUpdateVitals) {
         target.statusUpdateVitals(target);
     }
@@ -261,5 +280,6 @@ module.exports = {
     applyManaHot,
     applyHot,
     scheduleExpiry,
+    refreshEffects,
     clear
 };

--- a/src/GameServer/Formulas.js
+++ b/src/GameServer/Formulas.js
@@ -357,12 +357,16 @@ const Formulas = {
         return Math.max(1, Math.min(99, 100 - (failRate / 100)));
     },
 
-    // Adapted from aCis calcSkillSuccess; C4SkillEffects supplies sourced trait-resist modifiers.
+    // Lisvus C4 Formulas.calcSkillSuccess. C4SkillEffects supplies the
+    // sourced trait-resist modifier because the local effect model keeps it
+    // separately from an L2Character stat calculator.
     calcSkillEffectSuccessRate({
         baseChance = 80,
         magic = false,
         mAtk = 0,
         mDef = 1,
+        soulshot = false,
+        spiritshot = false,
         blessedSpiritshot = false,
         attackerLevel = 1,
         targetLevel = 1,
@@ -370,21 +374,45 @@ const Formulas = {
         levelDepend = 0,
         resistModifier = 1
     } = {}) {
-        let mAtkModifier = 1;
+        let rate = Number(baseChance) || 0;
+        const resolvedLevelDepend = Number(levelDepend) || 2;
+
         if (magic) {
-            const boostedMAtk = (Number(mAtk) || 0) * (blessedSpiritshot ? 4 : 1);
-            mAtkModifier = (utils.sqrt(boostedMAtk) / Math.max(1, Number(mDef) || 1)) * 11;
+            rate *= Math.pow(
+                Math.max(0, Number(mAtk) || 0) / Math.max(1, Number(mDef) || 1),
+                0.2
+            );
         }
 
-        let levelModifier = 1;
-        if (Number(levelDepend) !== 0) {
-            const effectiveMagicLevel = Number(magicLevel) > 0 ? Number(magicLevel) : (Number(attackerLevel) || 1);
-            const delta = effectiveMagicLevel + Number(levelDepend) - (Number(targetLevel) || 1);
-            levelModifier = 1 + ((delta < 0 ? 0.01 : 0.005) * delta);
+        const shotModifier = blessedSpiritshot ? 200 : (spiritshot || soulshot ? 150 : 100);
+        if (shotModifier !== 100) {
+            rate = rate > (10000 / (100 + shotModifier))
+                ? 100 - (((100 - rate) * 100) / shotModifier)
+                : (rate * shotModifier) / 100;
         }
 
-        const chance = (Number(baseChance) || 0) * mAtkModifier * Math.max(0, levelModifier) * Math.max(0, Number(resistModifier) || 0);
-        return Math.max(1, Math.min(chance, 99));
+        if (resolvedLevelDepend > 0) {
+            let attackerLevelModifier = Number(attackerLevel) || 1;
+            let targetLevelModifier = Number(targetLevel) || 1;
+            if (attackerLevelModifier >= 70) attackerLevelModifier = ((attackerLevelModifier - 69) * 2) + 70;
+            if (targetLevelModifier >= 70) targetLevelModifier = ((targetLevelModifier - 69) * 2) + 70;
+
+            const resolvedMagicLevel = Number(magicLevel) || 0;
+            const delta = resolvedMagicLevel === 0
+                ? attackerLevelModifier - targetLevelModifier
+                : ((resolvedMagicLevel + attackerLevelModifier) / 2) - targetLevelModifier;
+            let levelModifier;
+            if ((delta + 3) < 0) {
+                levelModifier = delta <= -20 ? 0.05 : 1 - ((-1) * (delta / 20));
+                if (levelModifier >= 1) levelModifier = 0.05;
+            } else {
+                levelModifier = 1 + ((delta + 3) / 75);
+            }
+            rate *= Math.abs(levelModifier);
+        }
+
+        rate = Math.max(1, Math.min(rate, 99));
+        return rate * Math.max(0, Number(resistModifier) || 0);
     },
 
     calcRemoteHit(mAtk, power, mDef) {

--- a/src/GameServer/Network/Request/ValidatePosition.js
+++ b/src/GameServer/Network/Request/ValidatePosition.js
@@ -1,4 +1,5 @@
 const ReceivePacket = invoke('Packet/Receive');
+const EffectRestrictions = invoke('GameServer/Effects/EffectRestrictions');
 
 function validatePosition(session, buffer) {
     const packet = new ReceivePacket(buffer);
@@ -10,7 +11,7 @@ function validatePosition(session, buffer) {
         .readD()  // Head
         .readD(); // Vehicle Id
 
-    consume(session, {
+    return consume(session, {
         locX: packet.data[0],
         locY: packet.data[1],
         locZ: packet.data[2],
@@ -19,7 +20,13 @@ function validatePosition(session, buffer) {
 }
 
 function consume(session, data) {
+    if (!EffectRestrictions.canMove(session.actor)) {
+        EffectRestrictions.stopMovement(session, session.actor);
+        EffectRestrictions.reject(session);
+        return false;
+    }
     session.actor.updatePosition(data);
+    return true;
 }
 
 module.exports = validatePosition;

--- a/src/GameServer/Network/Response/CharInfo.js
+++ b/src/GameServer/Network/Response/CharInfo.js
@@ -1,5 +1,6 @@
 const SendPacket = invoke('Packet/Send');
 const Pledge = invoke('GameServer/Network/Response/PledgeHelpers');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
 
 function charInfo(actor) {
     const packet = new SendPacket(0x03);
@@ -78,7 +79,7 @@ function charInfo(actor) {
 
     packet
         .writeC(0x00)  // Party matching
-        .writeD(0x00)  // Abnormal effect
+        .writeD(EffectStore.abnormalMask(actor))  // Abnormal effect
         .writeC(0x00)  // Recommendations left
         .writeH(0x00)  // Recommendations won
         .writeD(actor.fetchMountNpcId?.() || 0)  // Mount NPC ID

--- a/src/GameServer/Network/Response/NpcInfo.js
+++ b/src/GameServer/Network/Response/NpcInfo.js
@@ -1,4 +1,5 @@
 const SendPacket = invoke('Packet/Send');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
 
 function npcInfo(npc) {
     const packet = new SendPacket(0x16);
@@ -39,7 +40,7 @@ function npcInfo(npc) {
         .writeD(0x00)  // ?
         .writeD(0x00)  // Pvp?
         .writeD(0x00)  // Pk?
-        .writeD(0x00)  // Abnormal effect
+        .writeD(EffectStore.abnormalMask(npc))  // Abnormal effect
         .writeD(0x00)  // Clan Id
         .writeD(0x00)  // Clan crest
         .writeD(0x00)  // Ally Id

--- a/src/GameServer/Network/Response/UserInfo.js
+++ b/src/GameServer/Network/Response/UserInfo.js
@@ -1,6 +1,7 @@
 const SendPacket = invoke('Packet/Send');
 const Pledge = invoke('GameServer/Network/Response/PledgeHelpers');
 const ClanService = invoke('GameServer/Clan/ClanService');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
 
 function userInfo(actor) {
     const packet = new SendPacket(0x04);
@@ -92,7 +93,7 @@ function userInfo(actor) {
 
     packet
         .writeC(0x00)  // Find Party Members = 0x01
-        .writeD(0x00)  // Is invisible?
+        .writeD(EffectStore.abnormalMask(actor))  // Abnormal effect
         .writeC(0x00)  // ?
         .writeD(Pledge.privileges(actor))  // Clan Privileges
         .writeD(0x00)  // ?

--- a/src/GameServer/Npc/Generics/ReceivedHit.js
+++ b/src/GameServer/Npc/Generics/ReceivedHit.js
@@ -1,11 +1,13 @@
-function receivedHit(session, actor, npc, hit) {
+function receivedHit(session, actor, npc, hit, options = {}) {
     const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
     const EffectRestrictions = invoke('GameServer/Effects/EffectRestrictions');
     const SocialAggro = invoke('GameServer/Npc/SocialAggro');
 
     BotSocialMemory.recordCombatHelp(session, npc, `hit ${npc.fetchName()} for ${hit}`);
 
-    EffectRestrictions.wakeOnDamage(npc);
+    if (options.wakeSleep !== false) {
+        EffectRestrictions.wakeOnDamage(npc, session);
+    }
     npc.setHp(Math.max(0, npc.fetchHp() - hit)); // HP bar would disappear if less than zero
     npc.broadcastVitals();
 

--- a/src/GameServer/Npc/Npc.js
+++ b/src/GameServer/Npc/Npc.js
@@ -9,6 +9,7 @@ const Attack         = invoke('GameServer/Actor/Attack');
 const ManorData      = invoke('GameServer/Manor/ManorData');
 const NpcSkills      = invoke('GameServer/Npc/NpcSkills');
 const EffectStats    = invoke('GameServer/Effects/EffectStats');
+const EffectRestrictions = invoke('GameServer/Effects/EffectRestrictions');
 const AttackHelper   = new Attack();
 
 class Npc extends NpcModel {
@@ -40,7 +41,9 @@ class Npc extends NpcModel {
         // TODO: Move this into actual GameServer timer
         this.timer = {
             combat: undefined,
-            combatStart: undefined
+            combatStart: undefined,
+            hit: undefined,
+            hitEnd: undefined
         };
         this.skillReuseUntil = new Map();
     }
@@ -96,7 +99,7 @@ class Npc extends NpcModel {
                     return;
                 }
 
-                if (this.state.isBlocked()) {
+                if (this.state.isBlocked() || !EffectRestrictions.canAttack(this)) {
                     return;
                 }
 
@@ -121,6 +124,9 @@ class Npc extends NpcModel {
                 const actionRange = combatSkill ? this.fetchSkillCastRange(combatSkill, actor) : this.fetchCombatAttackRange(actor);
 
                 this.automation.scheduleAction(session, this, actor, actionRange, () => {
+                    if (!EffectRestrictions.canAttack(this)) {
+                        return;
+                    }
                     this.setLocXYZ(this.fetchCombatStopCoords(actor, actionRange));
 
                     if (combatSkill && this.isTargetInAttackRange(actor, actionRange)) {
@@ -164,6 +170,42 @@ class Npc extends NpcModel {
             + EffectStats.add(this, 'pEvasionRateAdd');
     }
 
+    // Lisvus NpcStat inherits CharStat, so NPCs evaluate the same stat
+    // functions as players while effects are active. NPC templates already
+    // provide this project's base combat values; apply only the active effect
+    // modifiers here instead of running the player-only class calculator.
+    fetchCollectivePAtk() {
+        return effectAdjusted(super.fetchCollectivePAtk(), this, 'pAtk');
+    }
+
+    fetchCollectiveMAtk() {
+        return effectAdjusted(super.fetchCollectiveMAtk(), this, 'mAtk');
+    }
+
+    fetchCollectivePDef() {
+        return effectAdjusted(super.fetchCollectivePDef(), this, 'pDef');
+    }
+
+    fetchCollectiveMDef() {
+        return effectAdjusted(super.fetchCollectiveMDef(), this, 'mDef');
+    }
+
+    fetchCollectiveAtkSpd() {
+        return effectAdjusted(super.fetchCollectiveAtkSpd(), this, 'pAtkSpd');
+    }
+
+    fetchCollectiveCastSpd() {
+        return effectAdjusted(super.fetchCollectiveCastSpd(), this, 'castSpd');
+    }
+
+    fetchCollectiveWalkSpd() {
+        return effectAdjusted(super.fetchCollectiveWalkSpd(), this, 'walkSpd', { speed: true });
+    }
+
+    fetchCollectiveRunSpd() {
+        return effectAdjusted(super.fetchCollectiveRunSpd(), this, 'runSpd', { speed: true });
+    }
+
     fetchCombatStopCoords(actor, attackRange = this.fetchCombatAttackRange(actor)) {
         return this.automation.actionStopCoords(this, actor, attackRange);
     }
@@ -191,6 +233,7 @@ class Npc extends NpcModel {
     }
 
     selectCombatSkill(actor) {
+        if (!EffectRestrictions.canCast(this)) return null;
         return this.fetchCombatSkills().find((skill) => {
             if (skill.fetchTargetKind() !== 'enemy') return false;
             if (this.fetchMp() < skill.fetchConsumedMp()) return false;
@@ -221,7 +264,8 @@ class Npc extends NpcModel {
     }
 
     castSkill(session, actor, skill) {
-        AttackHelper.remoteHit({
+        if (!EffectRestrictions.canCast(this)) return;
+        this.attack.remoteHit({
             actor: this,
             dataSendToMe: (packet) => session.dataSendToMe?.(packet),
             dataSendToMeAndOthers: (packet) => session.dataSendToMeAndOthers(packet, this)
@@ -233,6 +277,10 @@ class Npc extends NpcModel {
         this.timer.combatStart = undefined;
         clearInterval(this.timer.combat);
         this.timer.combat = undefined;
+        clearTimeout(this.timer.hit);
+        this.timer.hit = undefined;
+        clearTimeout(this.timer.hitEnd);
+        this.timer.hitEnd = undefined;
 
         this.clearDestId();
         this.state.setCombatEnded();
@@ -245,7 +293,7 @@ class Npc extends NpcModel {
     }
 
     meleeHit(session, src, dst) {
-        if (this.checkParticipants(session, src, dst)) {
+        if (!EffectRestrictions.canAttack(src) || this.checkParticipants(session, src, dst)) {
             return;
         }
 
@@ -256,8 +304,10 @@ class Npc extends NpcModel {
         session.dataSendToMeAndOthers(ServerResponse.attack(src, dst.fetchId(), hit), this);
         src.state.setHits(true);
 
-        setTimeout(() => {
-            if (this.checkParticipants(session, src, dst)) {
+        clearTimeout(this.timer.hit);
+        this.timer.hit = setTimeout(() => {
+            this.timer.hit = undefined;
+            if (!EffectRestrictions.canAttack(src) || this.checkParticipants(session, src, dst)) {
                 return;
             }
 
@@ -270,7 +320,9 @@ class Npc extends NpcModel {
 
         }, speed * 0.644);
 
-        setTimeout(() => {
+        clearTimeout(this.timer.hitEnd);
+        this.timer.hitEnd = setTimeout(() => {
+            this.timer.hitEnd = undefined;
             this.state.setHits(false);
 
         }, speed); // Until end of combat move
@@ -415,6 +467,15 @@ class Npc extends NpcModel {
         }
         return items;
     }
+}
+
+function effectAdjusted(base, actor, stat, { speed = false } = {}) {
+    const add = EffectStats.add(actor, `${stat}Add`);
+    const multiplier = EffectStats.multiplier(actor, `${stat}Mul`);
+    const adjusted = speed
+        ? (Number(base) + add) * multiplier
+        : (Number(base) * multiplier) + add;
+    return Math.max(1, Math.round(adjusted));
 }
 
 module.exports = Npc;

--- a/src/GameServer/Skills/C4SkillEffects.js
+++ b/src/GameServer/Skills/C4SkillEffects.js
@@ -137,7 +137,7 @@ function execute(session, actor, target, skill, context = {}) {
         return result;
     }
 
-    if (magicSkill && isOffensive(semantic) && !rollMagicSuccess(actor, target, skill, semantic, rng)) {
+    if (magicSkill && isOffensive(semantic) && !usesEffectSuccessFormula(semantic) && !rollMagicSuccess(actor, target, skill, semantic, rng)) {
         clearLoadedShot(context.attack, actor, magicSkill);
         result.resisted = true;
         return result;
@@ -589,6 +589,7 @@ function applyEffect(session, target, skill, semantic, source = session?.actor) 
         manaDot: manaDotFromSkill(skill, semantic),
         manaHot: manaHotFromSkill(skill, semantic),
         hot: hotFromSkill(skill, semantic),
+        confusionMobOnly: semantic.confusionMobOnly,
         durationMs
     });
 
@@ -616,6 +617,9 @@ function applyEffect(session, target, skill, semantic, source = session?.actor) 
 
     EffectTicker.scheduleExpiry(session, target, effect);
     EffectRestrictions.interruptOnApply(target?.session || session, target, effect, source);
+    if (hasStats(effect)) {
+        refreshStats(target?.session || session, target);
+    }
     refreshEffects(session, target);
     return effect;
 }
@@ -630,6 +634,9 @@ function applyCleanse(session, target, semantic) {
         removed.push(...EffectStore.removeByCategory(target, entry.category, entry.maxLevel ?? Infinity));
     });
     if (removed.length) {
+        if (removed.some(hasStats)) {
+            refreshStats(target?.session || session, target);
+        }
         refreshEffects(session, target);
     }
     return removed;
@@ -648,6 +655,9 @@ function applyCancel(session, target, semantic, rng) {
         }
     });
     if (removed.length) {
+        if (removed.some(hasStats)) {
+            refreshStats(target?.session || session, target);
+        }
         refreshEffects(session, target);
     }
     return removed;
@@ -730,17 +740,27 @@ function rollMagicSuccess(actor, target, skill, semantic, rng) {
 }
 
 function resistEffect(actor, target, skill, semantic, magicSkill, rng) {
+    const effectTrait = semantic.effectTrait || semantic.trait;
+    // Lisvus calcSkillSuccess defaults unset lvlDepend to 1 for PARALYZE
+    // and FEAR, and to 2 for every other effect type.
+    const levelDepend = semantic.levelDepend || (
+        semantic.effect === 'paralyze' || semantic.effect === 'fear' || effectTrait === 'paralyze' || effectTrait === 'fear'
+            ? 1
+            : 2
+    );
     const chance = Formulas.calcSkillEffectSuccessRate({
         baseChance: semantic.baseLandRate,
         magic: magicSkill,
         mAtk: actor.fetchCollectiveMAtk?.(),
         mDef: target.fetchCollectiveMDef?.(),
+        soulshot: !!actor.soulshotLoaded,
+        spiritshot: !!actor.spiritshotLoaded,
         blessedSpiritshot: !!actor.blessedSpiritshotLoaded,
         attackerLevel: actor.fetchLevel?.(),
         targetLevel: target.fetchLevel?.(),
         magicLevel: semantic.magicLevel,
-        levelDepend: semantic.levelDepend,
-        resistModifier: traitResistModifier(target, semantic.effectTrait || semantic.trait)
+        levelDepend,
+        resistModifier: traitResistModifier(target, effectTrait)
     });
     return !(chance >= rng() * 100);
 }
@@ -779,6 +799,14 @@ function applyLethal(target, semantic, rng, result) {
 
 function isOffensive(semantic) {
     return semantic.target !== 'self' && semantic.effectType !== 'buff';
+}
+
+function usesEffectSuccessFormula(semantic) {
+    return semantic.skillType === C4SkillRules.EFFECT
+        || semantic.skillType === C4SkillRules.DAMAGE_EFFECT
+        || semantic.skillType === C4SkillRules.CANCEL
+        || semantic.skillType === C4SkillRules.AGGRO_REMOVE
+        || semantic.skillType === C4SkillRules.AGGRO_REDUCE_CHAR;
 }
 
 function isAttackableNpc(target) {
@@ -849,12 +877,39 @@ function refreshEffects(session, target) {
         session.dataSendToMe(packet);
     }
 
+    if (target?.session?.dataSendToMe && target?.backpack?.fetchPaperdollSelfId) {
+        target.session.dataSendToMe(ServerResponse.userInfo(target));
+    }
+
+    // MagicEffectIcons has no object id and is only valid for the receiver's
+    // own effect bar. For NPCs, C4 renders persistent abnormal states from the
+    // abnormal-effect mask embedded in NpcInfo instead.
+    if (target?.fetchKind && session?.dataSendToMeAndOthers) {
+        session.dataSendToMeAndOthers(ServerResponse.npcInfo(target), target);
+    } else if (target?.session?.dataSendToOthers && target?.backpack?.fetchPaperdollSelfId) {
+        target.session.dataSendToOthers(ServerResponse.charInfo(target), target);
+    }
+
     try {
         const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
         if (target?.session) PartyCompanionService.updateActorEffects(target.session);
     } catch (err) {
         utils.infoWarn('SkillEffects', 'party effect refresh failed: %s', err.message);
     }
+}
+
+function refreshStats(session, target) {
+    if (!target) return;
+    if (target?.session) {
+        try {
+            invoke(path.actor).calculateStats(target?.session || session, target);
+        } catch (_) {}
+    }
+    target.statusUpdateVitals?.(target);
+}
+
+function hasStats(effect) {
+    return Object.keys(effect?.stats || {}).length > 0;
 }
 
 module.exports = {

--- a/src/GameServer/Skills/C4SkillRules.js
+++ b/src/GameServer/Skills/C4SkillRules.js
@@ -297,7 +297,7 @@ const RULES = {
     1157: { skillType: MANA_HEAL, trait: 'mana', target: 'self', ssBoost: 0, manaPowerByLevel: [22, 35, 47, 53, 61] },
     1159: { skillType: DEATH_LINK, trait: 'dark', target: 'enemy', ssBoost: 1, baseLandRate: 92 },
     1160: { skillType: EFFECT, trait: 'slow', effect: 'slow', effectType: 'debuff', target: 'enemy', baseLandRate: 80, statsByLevel: { runSpdMul: [0.7, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5] } },
-    1163: { skillType: EFFECT, trait: 'confusion', effect: 'confusion', effectType: 'debuff', target: 'enemy', baseLandRate: 80, mobOnly: true },
+    1163: { skillType: EFFECT, trait: 'confusion', effect: 'confusion', effectType: 'debuff', target: 'enemy', baseLandRate: 80, mobOnly: true, confusionMobOnly: true },
     1164: { skillType: EFFECT, trait: 'debuff', effect: 'curse_weakness', effectType: 'debuff', target: 'enemy', baseLandRate: 80, statsByLevel: { pAtkMul: [0.83, 0.8, 0.8, 0.8, 0.8, 0.77, 0.77, 0.77, 0.77, 0.77, 0.77, 0.77, 0.77, 0.77, 0.77, 0.77, 0.77, 0.77, 0.77] } },
     1167: { skillType: EFFECT, trait: 'poison', effect: 'poison', effectType: 'debuff', target: 'enemy', sourceTarget: 'area', radius: 200, baseLandRateByLevel: [3, 4, 5, 6, 7, 8], magicLevelByLevel: [25, 35, 48, 56, 64, 74], castRange: 500, effectRange: 1000, dot: { count: 10, intervalMs: 3000, damageByLevel: [18, 24, 31, 38, 44, 48] } },
     1168: { skillType: EFFECT, trait: 'poison', effect: 'poison', effectType: 'debuff', target: 'enemy', baseLandRateByLevel: [1, 3, 4, 5, 6, 7, 8], dot: { count: 10, intervalMs: 3000, damageByLevel: [8, 18, 24, 31, 38, 44, 48] } },
@@ -726,6 +726,7 @@ function resolve(skill = {}) {
         dispellable: rule.dispellable,
         nextActionAttack: rule.nextActionAttack || false,
         mobOnly: rule.mobOnly || inferred.mobOnly || false,
+        confusionMobOnly: rule.confusionMobOnly || false,
         undeadOnly: rule.undeadOnly || inferred.undeadOnly || false,
         maxCancelled: rule.maxCancelled ?? inferred.maxCancelled
     };

--- a/tests/test_c4_protocol_packets.js
+++ b/tests/test_c4_protocol_packets.js
@@ -207,6 +207,8 @@ assert.strictEqual(userInfo[0], 0x04);
 assert.deepStrictEqual(actor.paperdollIdSlots, Array.from({ length: 16 }, (_, i) => i));
 assert.deepStrictEqual(actor.paperdollSelfIdSlots, Array.from({ length: 16 }, (_, i) => i));
 assert.ok(userInfo.includes(0xff), 'C4 UserInfo should include trailing name-color bytes');
+actor.effects = { stun: { key: 'stun', id: 100, type: 'debuff', expiresAt: Date.now() + 10000 } };
+assert.ok(ServerResponse.userInfo(actor).includes(0x40), 'C4 UserInfo should expose the stun abnormal-effect mask');
 
 const charInfo = ServerResponse.charInfo(actor);
 assert.strictEqual(charInfo[0], 0x03);

--- a/tests/test_effect_restrictions.js
+++ b/tests/test_effect_restrictions.js
@@ -4,10 +4,17 @@ require('../src/Global');
 
 const EffectStore = invoke('GameServer/Effects/EffectStore');
 const EffectRestrictions = invoke('GameServer/Effects/EffectRestrictions');
+const validatePosition = invoke('GameServer/Network/Request/ValidatePosition');
+const World = invoke('GameServer/World/World');
 
 function actor() {
     return {
         effects: {},
+        fetchId: () => 2000001,
+        fetchLocX: () => 10,
+        fetchLocY: () => 20,
+        fetchLocZ: () => 30,
+        fetchHead: () => 40,
         aborted: false,
         combatAborted: false,
         queue: false,
@@ -76,15 +83,22 @@ EffectRestrictions.interruptOnApply(stunnedSession, stunned, stunEffect);
 assert.strictEqual(EffectRestrictions.canMove(stunned), false, 'Stun should block movement');
 assert.strictEqual(EffectRestrictions.canAttack(stunned), false, 'Stun should block attacks');
 assert.strictEqual(EffectRestrictions.canCast(stunned), false, 'Stun should block casting');
+assert.strictEqual(EffectStore.abnormalMask(stunned), 0x0040, 'Stun should expose the C4 abnormal-effect mask');
 assert.strictEqual(stunned.aborted, true, 'Control debuff should abort current movement/action');
 assert.strictEqual(stunned.attack.timersCleared, true, 'Control debuff should clear active attack timers');
 assert.strictEqual(stunned.state.hits, false, 'Control debuff should clear active hit state');
 assert.strictEqual(stunned.state.casts, false, 'Control debuff should clear active cast state');
 assert.strictEqual(stunned.combatAborted, true, 'Control debuff should abort NPC-style combat loops when available');
 assert.strictEqual(stunnedSession.moveTimer, null, 'Control debuff should clear active move timer');
+assert(stunnedSession.packets.some((packet) => packet[0] === 0x47), 'Control debuff should send StopMove to halt an in-flight client move');
+
+stunnedSession.actor = stunned;
+const validatedWhileStunned = validatePosition(stunnedSession, Buffer.alloc(21));
+assert.strictEqual(validatedWhileStunned, false, 'ValidatePosition must not bypass an active control debuff');
 
 const sleeping = actor();
 EffectStore.apply(sleeping, { key: 'sleep', id: 1069, type: 'debuff', durationMs: 10000 });
+assert.strictEqual(EffectStore.abnormalMask(sleeping), 0x0080, 'Sleep should expose the C4 abnormal-effect mask');
 EffectRestrictions.wakeOnDamage(sleeping);
 assert.strictEqual(EffectStore.hasDebuff(sleeping, 'sleep'), false, 'Damage should wake a sleeping target');
 
@@ -92,6 +106,28 @@ const stunnedByDamage = actor();
 EffectStore.apply(stunnedByDamage, { key: 'stun', id: 100, type: 'debuff', durationMs: 10000 });
 EffectRestrictions.wakeOnDamage(stunnedByDamage);
 assert.strictEqual(EffectStore.hasDebuff(stunnedByDamage, 'stun'), true, 'Damage should not remove non-sleep control debuffs');
+
+const confusedMob = actor();
+confusedMob.fetchAttackable = () => true;
+confusedMob.state.fetchCombats = () => true;
+confusedMob.abortCombatState = () => { confusedMob.confusionCombatAborted = true; };
+confusedMob.enterCombatState = (_session, target) => { confusedMob.confusionTarget = target; };
+const confusionTarget = {
+    fetchAttackable: () => true,
+    fetchLocX: () => 100,
+    fetchLocY: () => 100,
+    fetchLocZ: () => 0
+};
+World.npc = { spawns: [confusedMob, confusionTarget] };
+World.user = { sessions: [] };
+const confusionEffect = EffectStore.apply(confusedMob, {
+    key: 'confusion', id: 2, type: 'debuff', durationMs: 10000, confusionMobOnly: true
+});
+EffectRestrictions.interruptOnApply(session(), confusedMob, confusionEffect);
+assert.strictEqual(confusedMob.confusionCombatAborted, true, 'ConfuseMob should replace an NPC combat loop before retargeting');
+assert.strictEqual(confusedMob.confusionTarget, confusionTarget, 'ConfuseMob should make an NPC attack a nearby attackable NPC');
+EffectRestrictions.stopConfusion(confusedMob);
+EffectStore.remove(confusedMob, 'confusion');
 
 const fearTarget = {
     ...actor(),

--- a/tests/test_npc_combat_range.js
+++ b/tests/test_npc_combat_range.js
@@ -7,6 +7,7 @@ const Npc = invoke('GameServer/Npc/Npc');
 const SkillModel = invoke('GameServer/Model/Skill');
 const Formulas = invoke('GameServer/Formulas');
 const ConsoleText = invoke('GameServer/ConsoleText');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
 
 function npcWithRange(atkRadius, selfId = 900000) {
     return new Npc(900000, {
@@ -22,11 +23,11 @@ function npcWithRange(atkRadius, selfId = 900000) {
         int: 1,
         wit: 1,
         men: 1,
-        pAtk: 1,
+        pAtk: 100,
         pAtkRnd: 0,
-        pDef: 1,
-        mAtk: 1,
-        mDef: 1,
+        pDef: 100,
+        mAtk: 100,
+        mDef: 100,
         accur: 4.75,
         atkSpd: 253,
         castSpd: 333,
@@ -105,6 +106,23 @@ assert.strictEqual(rangedNpc.isTargetInAttackRange(target), true, 'ranged NPC sh
 assert.notStrictEqual(rangedNpc.fetchLocX(), target.fetchLocX(), 'ranged NPC must not snap onto the player');
 
 const meleeNpc = npcWithRange(40);
+EffectStore.apply(meleeNpc, {
+    key: 'npc_debuff_regression',
+    id: 9999,
+    type: 'debuff',
+    durationMs: 10000,
+    stats: { pAtkMul: 0.8, pDefMul: 0.77, pAtkSpdMul: 0.77, runSpdMul: 0.7 }
+});
+assert.strictEqual(meleeNpc.fetchCollectivePAtk(), 80, 'NPC P.Atk should apply active effect modifiers');
+assert.strictEqual(meleeNpc.fetchCollectivePDef(), 77, 'NPC P.Def should apply active effect modifiers');
+assert.strictEqual(meleeNpc.fetchCollectiveAtkSpd(), 195, 'NPC attack speed should apply active effect modifiers');
+assert.strictEqual(meleeNpc.fetchCollectiveRunSpd(), 84, 'NPC run speed should apply active effect modifiers');
+EffectStore.remove(meleeNpc, 'npc_debuff_regression');
+EffectStore.apply(meleeNpc, { key: 'stun', id: 100, type: 'debuff', durationMs: 10000 });
+const stunnedNpcSession = { packets: [], dataSendToMeAndOthers(packet) { this.packets.push(packet); } };
+meleeNpc.meleeHit(stunnedNpcSession, meleeNpc, target);
+assert.strictEqual(stunnedNpcSession.packets.some((packet) => packet[0] === 0x05), false, 'A stunned NPC must not start a melee attack');
+EffectStore.remove(meleeNpc, 'stun');
 assert.strictEqual(
     Math.round(meleeNpc.fetchCollectiveAccur()),
     39,


### PR DESCRIPTION
## Summary
- make control effects enforce movement, attacks, casts, and active NPC combat actions
- synchronize C4 abnormal-effect masks through UserInfo, CharInfo, and NpcInfo
- apply source-backed effect success, resistance, level, and shot calculations
- make NPC stat debuffs and Confusion runtime behavior take effect

## Root cause
Effects were stored and displayed inconsistently, while NPC combat and pending actions could bypass their runtime restrictions. The affected player's UserInfo packet also omitted the abnormal-effect mask.

## Validation
- node tests/test_c4_protocol_packets.js
- node tests/test_effect_restrictions.js
- node tests/test_effect_ticker.js
- node tests/test_npc_combat_range.js
- node tests/test_skill_semantics.js
- node scripts/check-syntax.js