### PR TITLE
Apply deep blue drop rules

### DIFF
--- a/src/GameServer/Npc/Generics/ReceivedHit.js
+++ b/src/GameServer/Npc/Generics/ReceivedHit.js
@@ -5,6 +5,22 @@ function receivedHit(session, actor, npc, hit, options = {}) {
 
     BotSocialMemory.recordCombatHelp(session, npc, `hit ${npc.fetchName()} for ${hit}`);
 
+    const attackerLevel = Number(actor?.fetchLevel?.());
+    const actingPlayerLevel = Number(session?.actor?.fetchLevel?.());
+    const levels = [attackerLevel, actingPlayerLevel]
+        .filter((level) => Number.isFinite(level) && level > 0);
+    if (levels.length > 0) {
+        const dropState = npc.model ?? npc;
+        dropState.dropAttackerLevels ??= [];
+        levels.forEach((level) => {
+            if (!dropState.dropAttackerLevels.includes(level)) {
+                dropState.dropAttackerLevels.push(level);
+            }
+        });
+        // Lisvus starts with the killer's acting player, not the summon itself.
+        dropState.dropLastAttackerLevel = actingPlayerLevel || attackerLevel;
+    }
+
     if (options.wakeSleep !== false) {
         EffectRestrictions.wakeOnDamage(npc, session);
     }

--- a/src/GameServer/Npc/SpoilSweep.js
+++ b/src/GameServer/Npc/SpoilSweep.js
@@ -25,9 +25,15 @@ function hasSpoils(npc) {
 
 function rollSpoils(npc) {
     const awarded = [];
+    const dropState = npc.model ?? npc;
+    const rewardContext = {
+        npcLevel: npc.fetchLevel?.() ?? npc.model?.level,
+        killerLevel: dropState.dropLastAttackerLevel,
+        attackerLevels: dropState.dropAttackerLevels ?? []
+    };
 
     fetchSpoilGroups(npc).forEach((group) => {
-        const groupRoll = ProgressionRates.rollGroup(group.overall, ProgressionRates.groupRate(group, 'spoil'));
+        const groupRoll = ProgressionRates.rewardGroupRoll(group, 'spoil', rewardContext);
         if (!groupRoll.hit) {
             return;
         }

--- a/src/GameServer/ProgressionRates.js
+++ b/src/GameServer/ProgressionRates.js
@@ -4,6 +4,12 @@ const PRESETS = {
     x50: { label: 'x50', multiplier: 50 }
 };
 
+const DEEP_BLUE_LEVEL_GAP = 9;
+const DEEP_BLUE_PENALTY_PER_LEVEL = 9;
+const DEEP_BLUE_CHANCE_DIVISOR = 3;
+// L2DropData.MAX_CHANCE is 1,000,000 in Lisvus, whose post-rounding floor is 1.
+const MIN_DEEP_BLUE_CHANCE = 0.0001;
+
 function numberOr(value, fallback) {
     if (value === undefined || value === null || value === '') return fallback;
     const parsed = Number(value);
@@ -42,14 +48,66 @@ function groupRate(group, kind = 'drop') {
     return kind === 'spoil' ? current.spoil : current.drop;
 }
 
-function rollGroup(overall, rate, rng = Math.random) {
+function rollGroup(overall, rate, rng = Math.random, minimumChance = 0) {
     const scaled = Math.max(0, Number(overall) || 0) * numberOr(rate, 1);
-    const chance = Math.min(100, scaled);
+    const chance = Math.min(100, Math.max(Math.max(0, Number(minimumChance) || 0), scaled));
 
     return {
         hit: chance > 0 && rng() * 100 <= chance,
-        amountMultiplier: Math.max(1, scaled / 100)
+        amountMultiplier: amountMultiplier(overall, rate)
     };
+}
+
+function amountMultiplier(overall, rate) {
+    const scaled = Math.max(0, Number(overall) || 0) * numberOr(rate, 1);
+    return Math.max(1, scaled / 100);
+}
+
+function deepBlueRule({ npcLevel, killerLevel, attackerLevels = [] } = {}) {
+    const levels = [killerLevel, ...attackerLevels]
+        .map((level) => Number(level))
+        .filter((level) => Number.isFinite(level) && level > 0);
+    const highestLevel = levels.length > 0 ? Math.max(...levels) : 0;
+    const normalizedNpcLevel = Number(npcLevel);
+    const levelGap = Number.isFinite(normalizedNpcLevel) && normalizedNpcLevel > 0
+        ? highestLevel - normalizedNpcLevel
+        : 0;
+
+    if (levelGap < DEEP_BLUE_LEVEL_GAP) {
+        return { active: false, highestLevel, levelGap, penaltyPercent: 0, chanceMultiplier: 1, minimumChance: 0 };
+    }
+
+    const penaltyPercent = (levelGap - (DEEP_BLUE_LEVEL_GAP - 1)) * DEEP_BLUE_PENALTY_PER_LEVEL;
+    return {
+        active: true,
+        highestLevel,
+        levelGap,
+        penaltyPercent,
+        chanceMultiplier: Math.max(0, (100 - penaltyPercent) / 100) / DEEP_BLUE_CHANCE_DIVISOR,
+        minimumChance: MIN_DEEP_BLUE_CHANCE
+    };
+}
+
+function rewardGroupRoll(group, kind = 'drop', context = {}, rng = Math.random) {
+    const current = profile();
+    const rule = deepBlueRule(context);
+    const baseRate = groupRate(group, kind);
+    let rate = baseRate;
+
+    if (rule.active) {
+        rate *= rule.chanceMultiplier;
+        // Lisvus divides deep-blue Adena by RateDropItems before applying RateDropAdena.
+        // This keeps a shared high-rate preset from cancelling the retail penalty.
+        if ((group.items || []).some((item) => Number(item.selfId) === 57)) {
+            rate = current.drop > 0 ? rate / current.drop : 0;
+        }
+    }
+
+    const roll = rollGroup(group.overall, rate, rng, rule.minimumChance);
+    // Lisvus applies the Deep Blue modifier to categorized normal-drop chance,
+    // but still calculates a selected item's high-rate quantity from its base rate.
+    const amountRate = rule.active && kind === 'drop' ? baseRate : rate;
+    return { ...roll, amountMultiplier: amountMultiplier(group.overall, amountRate), rule };
 }
 
 function scaleAmount(amount, amountMultiplier, rng = Math.random) {
@@ -66,5 +124,7 @@ module.exports = {
     profile,
     groupRate,
     rollGroup,
+    deepBlueRule,
+    rewardGroupRoll,
     scaleAmount
 };

--- a/src/GameServer/World/Generics/NpcRewards.js
+++ b/src/GameServer/World/Generics/NpcRewards.js
@@ -51,9 +51,15 @@ function spawnGroundDrop(world, session, npc, selfId, amount) {
 function npcRewards(session, npc) {
     DataCache.fetchNpcRewardsFromSelfId(npc.fetchSelfId(), (result) => {
         const rewards = result.rewards ?? [];
+        const dropState = npc.model ?? npc;
+        const rewardContext = {
+            npcLevel: npc.fetchLevel?.() ?? npc.model?.level,
+            killerLevel: dropState.dropLastAttackerLevel ?? session?.actor?.fetchLevel?.(),
+            attackerLevels: dropState.dropAttackerLevels ?? []
+        };
 
         rewards.forEach((reward) => {
-            const groupRoll = ProgressionRates.rollGroup(reward.overall, ProgressionRates.groupRate(reward, 'drop'));
+            const groupRoll = ProgressionRates.rewardGroupRoll(reward, 'drop', rewardContext);
             if (groupRoll.hit) {
                 let number = Math.random() * 100;
                 let rewardPartition = 0;

--- a/tests/test_progression_rates.js
+++ b/tests/test_progression_rates.js
@@ -31,6 +31,33 @@ assert.strictEqual(rareHit.amountMultiplier, 1);
 const rareMiss = ProgressionRates.rollGroup(0.5, profile.drop, () => 0.051);
 assert.strictEqual(rareMiss.hit, false);
 
+const noDeepBlue = ProgressionRates.deepBlueRule({ npcLevel: 20, killerLevel: 28, attackerLevels: [27] });
+assert.strictEqual(noDeepBlue.active, false);
+assert.strictEqual(noDeepBlue.chanceMultiplier, 1);
+
+const deepBlue = ProgressionRates.deepBlueRule({ npcLevel: 20, killerLevel: 29, attackerLevels: [25] });
+assert.strictEqual(deepBlue.active, true);
+assert.strictEqual(deepBlue.penaltyPercent, 9);
+assert.strictEqual(deepBlue.chanceMultiplier, 0.91 / 3);
+
+const highContributor = ProgressionRates.deepBlueRule({ npcLevel: 20, killerLevel: 20, attackerLevels: [30] });
+assert.strictEqual(highContributor.levelGap, 10);
+assert.strictEqual(highContributor.penaltyPercent, 18);
+
+process.env.L2NODE_PROGRESSION_RATE = 'x10';
+const deepBlueAdena = ProgressionRates.rewardGroupRoll(adenaGroup, 'drop', { npcLevel: 20, killerLevel: 29 }, () => 0.2);
+assert.strictEqual(deepBlueAdena.rule.active, true);
+assert.strictEqual(deepBlueAdena.amountMultiplier, 7);
+assert.strictEqual(deepBlueAdena.hit, true);
+
+const deepBlueItem = ProgressionRates.rewardGroupRoll({ overall: 100, items: [{ selfId: 1000 }] }, 'drop', { npcLevel: 20, killerLevel: 29 }, () => 0.31);
+assert.strictEqual(deepBlueItem.hit, true);
+assert.strictEqual(deepBlueItem.amountMultiplier, 10);
+
+const summonOwner = ProgressionRates.deepBlueRule({ npcLevel: 20, killerLevel: 40, attackerLevels: [10] });
+assert.strictEqual(summonOwner.highestLevel, 40);
+assert.strictEqual(summonOwner.active, true);
+
 const originalDropChanceRate = options.default.General.dropChanceRate;
 options.default.General.dropChanceRate = 0;
 profile = ProgressionRates.profile();


### PR DESCRIPTION
## Summary
- apply Lisvus-style Deep Blue penalties when a higher-level character kills a lower-level NPC
- use the highest contributing attacker level and include summon owners as acting players
- apply the rule to normal drops and spoil, while preserving normal high-rate item quantities
- preserve the Adena rate interaction and cover the threshold and high-rate cases with regression tests

## Root cause
NPC reward rolls ignored the level relationship between the killer and the NPC, so over-level farming received full drop chances.

## Validation
- npm run check
- npm test