### PR TITLE
Add third class progression

### DIFF
--- a/config/default.ini
+++ b/config/default.ini
@@ -21,7 +21,7 @@ pvp = false
 
 [General]
 protocol = 656
-maxLevel = 75
+maxLevel = 80
 progressionPreset = x1
 expRate = 1.0
 adenaRate = 1.0

--- a/data/Html/7070.html
+++ b/data/Html/7070.html
@@ -1,6 +1,6 @@
 <html><body>
     High Priest Sylvain:<br>
-    The gods watch over all who seek to master their destiny. I am Sylvain, High Priest of Gludio. If you have reached Level 20 or Level 40, I can guide you through the Class Transfer ritual to unlock new power.<br>
+    The gods watch over all who seek to master their destiny. I am Sylvain, High Priest of Gludio. If you have reached Level 20, 40, or 76, I can guide you through the Class Transfer ritual to unlock new power.<br>
     Please select your race:<br>
     <a action="bypass -h html Gatekeeper/7070-human">Humans</a><br1>
     <a action="bypass -h html Gatekeeper/7070-elven">Elves</a><br1>

--- a/data/Html/Gatekeeper/7070-darkelven.html
+++ b/data/Html/Gatekeeper/7070-darkelven.html
@@ -19,5 +19,10 @@
     <a action="bypass -h change-class 41 Phantom Summoner">Phantom Summoner</a><br>
     From Shillien Oracle:<br1>
     <a action="bypass -h change-class 43 Shillien Elder">Shillien Elder</a><br><br>
+    <b>3rd Class Transfer (Level 76+)</b><br>
+    <a action="bypass -h change-class 106 Shillien Templar">Shillien Templar</a> | <a action="bypass -h change-class 107 Spectral Dancer">Spectral Dancer</a><br>
+    <a action="bypass -h change-class 108 Ghost Hunter">Ghost Hunter</a> | <a action="bypass -h change-class 109 Ghost Sentinel">Ghost Sentinel</a><br>
+    <a action="bypass -h change-class 110 Storm Screamer">Storm Screamer</a> | <a action="bypass -h change-class 111 Spectral Master">Spectral Master</a><br>
+    <a action="bypass -h change-class 112 Shillien Saint">Shillien Saint</a><br><br>
     <a action="bypass -h html 7070">Back</a>
 </body></html>

--- a/data/Html/Gatekeeper/7070-elven.html
+++ b/data/Html/Gatekeeper/7070-elven.html
@@ -19,5 +19,10 @@
     <a action="bypass -h change-class 28 Elemental Summoner">Elemental Summoner</a><br>
     From Elven Oracle:<br1>
     <a action="bypass -h change-class 30 Elven Elder">Elven Elder</a><br><br>
+    <b>3rd Class Transfer (Level 76+)</b><br>
+    <a action="bypass -h change-class 99 Eva's Templar">Eva's Templar</a> | <a action="bypass -h change-class 100 Sword Muse">Sword Muse</a><br>
+    <a action="bypass -h change-class 101 Wind Rider">Wind Rider</a> | <a action="bypass -h change-class 102 Moonlight Sentinel">Moonlight Sentinel</a><br>
+    <a action="bypass -h change-class 103 Mystic Muse">Mystic Muse</a> | <a action="bypass -h change-class 104 Elemental Master">Elemental Master</a><br>
+    <a action="bypass -h change-class 105 Eva's Saint">Eva's Saint</a><br><br>
     <a action="bypass -h html 7070">Back</a>
 </body></html>

--- a/data/Html/Gatekeeper/7070-human.html
+++ b/data/Html/Gatekeeper/7070-human.html
@@ -25,5 +25,11 @@
     From Cleric:<br1>
     <a action="bypass -h change-class 16 Bishop">Bishop</a> | 
     <a action="bypass -h change-class 17 Prophet">Prophet</a><br><br>
+    <b>3rd Class Transfer (Level 76+)</b><br>
+    <a action="bypass -h change-class 88 Duelist">Duelist</a> | <a action="bypass -h change-class 89 Dreadnought">Dreadnought</a><br>
+    <a action="bypass -h change-class 90 Phoenix Knight">Phoenix Knight</a> | <a action="bypass -h change-class 91 Hell Knight">Hell Knight</a><br>
+    <a action="bypass -h change-class 93 Adventurer">Adventurer</a> | <a action="bypass -h change-class 92 Sagittarius">Sagittarius</a><br>
+    <a action="bypass -h change-class 94 Archmage">Archmage</a> | <a action="bypass -h change-class 95 Soultaker">Soultaker</a> | <a action="bypass -h change-class 96 Arcana Lord">Arcana Lord</a><br>
+    <a action="bypass -h change-class 97 Cardinal">Cardinal</a> | <a action="bypass -h change-class 98 Hierophant">Hierophant</a><br><br>
     <a action="bypass -h html 7070">Back</a>
 </body></html>

--- a/data/Html/Gatekeeper/7070-orcdwarf.html
+++ b/data/Html/Gatekeeper/7070-orcdwarf.html
@@ -21,5 +21,9 @@
     <a action="bypass -h change-class 55 Bounty Hunter">Bounty Hunter</a><br>
     From Artisan:<br1>
     <a action="bypass -h change-class 57 Warsmith">Warsmith</a><br><br>
+    <b>3rd Class Transfer (Level 76+)</b><br>
+    <a action="bypass -h change-class 113 Titan">Titan</a> | <a action="bypass -h change-class 114 Grand Khavatari">Grand Khavatari</a><br>
+    <a action="bypass -h change-class 115 Dominator">Dominator</a> | <a action="bypass -h change-class 116 Doomcryer">Doomcryer</a><br>
+    <a action="bypass -h change-class 117 Fortune Seeker">Fortune Seeker</a> | <a action="bypass -h change-class 118 Maestro">Maestro</a><br><br>
     <a action="bypass -h html 7070">Back</a>
 </body></html>

--- a/database/sql/database.sql
+++ b/database/sql/database.sql
@@ -20,7 +20,7 @@ CREATE TABLE `characters`(
     `maxHp`       float       NOT NULL,
     `mp`          float       NOT NULL DEFAULT 25,
     `maxMp`       float       NOT NULL,
-    `exp`         int(20)     NOT NULL DEFAULT 0,
+    `exp`         bigint      NOT NULL DEFAULT 0,
     `sp`          int(10)     NOT NULL DEFAULT 0,
     `pk`          int(10)     NOT NULL DEFAULT 0,
     `pvp`         int(10)     NOT NULL DEFAULT 0,

--- a/src/Database.js
+++ b/src/Database.js
@@ -2,6 +2,24 @@ const SQL = require('like-sql'), builder = new SQL();
 
 let conn;
 
+function normalizeRowNumbers(row) {
+    return Object.fromEntries(
+        Object.entries(row).map(([key, value]) => [key, typeof value === 'bigint' ? Number(value) : value])
+    );
+}
+
+function migrateCharacterExperience(optn) {
+    return conn.query(
+        'SELECT DATA_TYPE AS dataType FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?',
+        [optn.databaseName, 'characters', 'exp']
+    ).then((rows) => {
+        if (rows[0]?.dataType === 'bigint') return null;
+        return conn.query('ALTER TABLE `characters` MODIFY COLUMN `exp` BIGINT NOT NULL DEFAULT 0');
+    }).catch((error) => {
+        utils.infoWarn('DB', 'failed to migrate characters.exp to BIGINT: %s', error.message);
+    });
+}
+
 const Database = {
     init: (callback) => {
         const optn = options.default.Database;
@@ -16,13 +34,15 @@ const Database = {
         }).then((instance) => {
             utils.infoSuccess('DB', 'connected');
             conn = instance;
-            conn.query('ALTER TABLE `items` ADD COLUMN `petData` TEXT NULL')
+            Promise.all([
+                conn.query('ALTER TABLE `items` ADD COLUMN `petData` TEXT NULL')
                 .catch((error) => {
                     if (error?.errno !== 1060) {
                         utils.infoWarn('DB', 'failed to add items.petData: %s', error.message);
                     }
-                })
-                .finally(callback);
+                }),
+                migrateCharacterExperience(optn)
+            ]).finally(callback);
 
         }).catch(error => {
             utils.infoFail('DB', 'failed(%d) -> %s', error.errno, error.text);
@@ -54,20 +74,20 @@ const Database = {
     fetchCharacters: (username) => {
         return Database.execute(
             builder.select('characters', ['*'], 'username = ?', username)
-        );
+        ).then((rows) => rows.map(normalizeRowNumbers));
     },
 
     fetchClanCharacters() {
         return Database.execute(
             builder.select('characters', ['*'], 'clanId != 0')
-        );
+        ).then((rows) => rows.map(normalizeRowNumbers));
     },
 
     // Checks if acharacter `Name` exists
     fetchCharacterName: (name) => {
         return Database.execute(
             builder.selectOne('characters', ['*'], 'name = ?', name)
-        );
+        ).then((rows) => rows.map(normalizeRowNumbers));
     },
 
     // Stores a new `Character` in database with provided details

--- a/src/GameServer/Actor/Generics/ExperienceReward.js
+++ b/src/GameServer/Actor/Generics/ExperienceReward.js
@@ -4,6 +4,19 @@ const ConsoleText    = invoke('GameServer/ConsoleText');
 const Database       = invoke('Database');
 const ProgressionRates = invoke('GameServer/ProgressionRates');
 
+function resolveLevel(totalExp, maxLevel, experience) {
+    const availableLevels = Math.min(Math.max(1, Number(maxLevel) || 1), experience.length);
+
+    for (let i = 0; i < availableLevels; i++) {
+        const isFinalLevel = i === availableLevels - 1;
+        if (totalExp >= experience[i] && (isFinalLevel || totalExp < experience[i + 1])) {
+            return i + 1;
+        }
+    }
+
+    return null;
+}
+
 function experienceReward(session, actor, exp, sp) {
     const optn = options.default.General;
     const rates = ProgressionRates.profile();
@@ -17,13 +30,9 @@ function experienceReward(session, actor, exp, sp) {
     actor.setExpSp(totalExp, totalSp);
     ConsoleText.transmit(session, ConsoleText.caption.earnedExpAndSp, [{ kind: ConsoleText.kind.number, value: exp }, { kind: ConsoleText.kind.number, value: sp }]);
 
-    for (let i = 0; i < optn.maxLevel; i++) {
-        if (totalExp >= DataCache.experience[i] && totalExp < DataCache.experience[i + 1]) {
-            if (i + 1 > actor.fetchLevel()) { // Leveled up
-                invoke(path.actor).levelUp(session, actor, i + 1);
-                break;
-            }
-        }
+    const resolvedLevel = resolveLevel(totalExp, optn.maxLevel, DataCache.experience);
+    if (resolvedLevel && resolvedLevel > actor.fetchLevel()) {
+        invoke(path.actor).levelUp(session, actor, resolvedLevel);
     }
 
     // Update stats
@@ -34,3 +43,4 @@ function experienceReward(session, actor, exp, sp) {
 }
 
 module.exports = experienceReward;
+module.exports.resolveLevel = resolveLevel;

--- a/src/GameServer/ClassProgression.js
+++ b/src/GameServer/ClassProgression.js
@@ -1,0 +1,54 @@
+const thirdClasses = {
+    88: { parentClassId: 2, name: 'Duelist', cp: { baseCpMax: 2755.6, lvlCpAdd: 56.77, lvlCpMod: 0.22 } },
+    89: { parentClassId: 3, name: 'Dreadnought', cp: { baseCpMax: 2619.3, lvlCpAdd: 55.78, lvlCpMod: 0.22 } },
+    90: { parentClassId: 5, name: 'Phoenix Knight', cp: { baseCpMax: 1730.3, lvlCpAdd: 35.86, lvlCpMod: 0.22 } },
+    91: { parentClassId: 6, name: 'Hell Knight', cp: { baseCpMax: 1730.3, lvlCpAdd: 35.86, lvlCpMod: 0.22 } },
+    92: { parentClassId: 9, name: 'Sagittarius', cp: { baseCpMax: 1910.9, lvlCpAdd: 39.51, lvlCpMod: 0.22 } },
+    93: { parentClassId: 8, name: 'Adventurer', cp: { baseCpMax: 1049.4, lvlCpAdd: 21.25, lvlCpMod: 0.22 } },
+    94: { parentClassId: 12, name: 'Archmage', cp: { baseCpMax: 1440, lvlCpAdd: 29.05, lvlCpMod: 0.22 } },
+    95: { parentClassId: 13, name: 'Soultaker', cp: { baseCpMax: 1440, lvlCpAdd: 29.05, lvlCpMod: 0.22 } },
+    96: { parentClassId: 14, name: 'Arcana Lord', cp: { baseCpMax: 1823.5, lvlCpAdd: 37.85, lvlCpMod: 0.22 } },
+    97: { parentClassId: 16, name: 'Cardinal', cp: { baseCpMax: 2227.8, lvlCpAdd: 44.16, lvlCpMod: 0.22 } },
+    98: { parentClassId: 17, name: 'Hierophant', cp: { baseCpMax: 1671, lvlCpAdd: 34.03, lvlCpMod: 0.22 } },
+    99: { parentClassId: 20, name: "Eva's Templar", cp: { baseCpMax: 1917.6, lvlCpAdd: 39.84, lvlCpMod: 0.22 } },
+    100: { parentClassId: 21, name: 'Sword Muse', cp: { baseCpMax: 1651.1, lvlCpAdd: 34.86, lvlCpMod: 0.22 } },
+    101: { parentClassId: 23, name: 'Wind Rider', cp: { baseCpMax: 1174.3, lvlCpAdd: 23.9, lvlCpMod: 0.22 } },
+    102: { parentClassId: 24, name: 'Moonlight Sentinel', cp: { baseCpMax: 1521, lvlCpAdd: 31.54, lvlCpMod: 0.22 } },
+    103: { parentClassId: 27, name: 'Mystic Muse', cp: { baseCpMax: 1506.5, lvlCpAdd: 30.71, lvlCpMod: 0.22 } },
+    104: { parentClassId: 28, name: 'Elemental Master', cp: { baseCpMax: 1871.5, lvlCpAdd: 38.84, lvlCpMod: 0.22 } },
+    105: { parentClassId: 30, name: "Eva's Saint", cp: { baseCpMax: 1711, lvlCpAdd: 34.86, lvlCpMod: 0.22 } },
+    106: { parentClassId: 33, name: 'Shillien Templar', cp: { baseCpMax: 2024.4, lvlCpAdd: 41.83, lvlCpMod: 0.22 } },
+    107: { parentClassId: 34, name: 'Spectral Dancer', cp: { baseCpMax: 1766.6, lvlCpAdd: 37.35, lvlCpMod: 0.22 } },
+    108: { parentClassId: 36, name: 'Ghost Hunter', cp: { baseCpMax: 1245.5, lvlCpAdd: 25.23, lvlCpMod: 0.22 } },
+    109: { parentClassId: 37, name: 'Ghost Sentinel', cp: { baseCpMax: 1610, lvlCpAdd: 33.2, lvlCpMod: 0.22 } },
+    110: { parentClassId: 40, name: 'Storm Screamer', cp: { baseCpMax: 1519.5, lvlCpAdd: 30.71, lvlCpMod: 0.22 } },
+    111: { parentClassId: 41, name: 'Spectral Master', cp: { baseCpMax: 1918.9, lvlCpAdd: 39.84, lvlCpMod: 0.22 } },
+    112: { parentClassId: 43, name: 'Shillien Saint', cp: { baseCpMax: 1723.9, lvlCpAdd: 34.86, lvlCpMod: 0.22 } },
+    113: { parentClassId: 46, name: 'Titan', cp: { baseCpMax: 2413, lvlCpAdd: 51.03, lvlCpMod: 0.22 } },
+    114: { parentClassId: 48, name: 'Grand Khavatari', cp: { baseCpMax: 1646.6, lvlCpAdd: 34.76, lvlCpMod: 0.22 } },
+    115: { parentClassId: 51, name: 'Dominator', cp: { baseCpMax: 2687.9, lvlCpAdd: 54.35, lvlCpMod: 0.22 } },
+    116: { parentClassId: 52, name: 'Doomcryer', cp: { baseCpMax: 1679.9, lvlCpAdd: 33.93, lvlCpMod: 0.22 } },
+    117: { parentClassId: 55, name: 'Fortune Seeker', cp: { baseCpMax: 2413, lvlCpAdd: 51.03, lvlCpMod: 0.22 } },
+    118: { parentClassId: 57, name: 'Maestro', cp: { baseCpMax: 2634.5, lvlCpAdd: 55.68, lvlCpMod: 0.22 } }
+};
+
+function getThirdClass(classId) {
+    return thirdClasses[Number(classId)] || null;
+}
+
+function expandTemplates(templates) {
+    Object.entries(thirdClasses).forEach(([classId, thirdClass]) => {
+        if (templates.some((template) => template.classId === Number(classId))) return;
+
+        const parent = templates.find((template) => template.classId === thirdClass.parentClassId);
+        if (!parent) throw new Error(`third-class parent template ${thirdClass.parentClassId} is missing`);
+
+        templates.push({
+            ...structuredClone(parent),
+            classId: Number(classId),
+            template: { ...parent.template, class: thirdClass.name }
+        });
+    });
+}
+
+module.exports = { thirdClasses, getThirdClass, expandTemplates };

--- a/src/GameServer/DataCache.js
+++ b/src/GameServer/DataCache.js
@@ -1,10 +1,12 @@
 const validateSchema = require('jsonschema').validate;
+const ClassProgression = invoke('GameServer/ClassProgression');
 
 const DataCache = {
     init: () => {
         const path = '../data/';
 
         DataCache.classTemplates  = validateModel(path + 'Templates/templates');
+        ClassProgression.expandTemplates(DataCache.classTemplates);
         DataCache.newbieItems     = validateModel(path + 'Templates/Items/items');
         DataCache.newbieShortcuts = validateModel(path + 'Templates/Shortcuts/shortcuts');
         DataCache.newbieSpawns    = validateModel(path + 'Templates/Spawns/spawns');

--- a/src/GameServer/Formulas.js
+++ b/src/GameServer/Formulas.js
@@ -70,6 +70,8 @@ const Formulas = {
     })(),
 
     getParentClassId(classId) {
+        const thirdClass = invoke('GameServer/ClassProgression').getThirdClass(classId);
+        if (thirdClass) return this.getParentClassId(thirdClass.parentClassId);
         if (classId >= 0 && classId <= 9) return 0;
         if (classId >= 10 && classId <= 17) return 10;
         if (classId >= 18 && classId <= 24) return 18;
@@ -152,6 +154,10 @@ const Formulas = {
             56: { classBaseLevel: 20, baseCpMax: 276.8, lvlCpAdd: 26.3, lvlCpMod: 0.22 },
             57: { classBaseLevel: 40, baseCpMax: 850.4, lvlCpAdd: 43.58, lvlCpMod: 0.22 }
         };
+
+        Object.entries(invoke('GameServer/ClassProgression').thirdClasses).forEach(([classId, thirdClass]) => {
+            table[classId] = { classBaseLevel: 76, ...thirdClass.cp };
+        });
 
         return (level, classId, con) => {
             const data = table[classId] || table[0];

--- a/src/GameServer/Model/Actor.js
+++ b/src/GameServer/Model/Actor.js
@@ -1,4 +1,5 @@
 const CreatureModel = invoke('GameServer/Model/Creature');
+const Formulas = invoke('GameServer/Formulas');
 
 class ActorModel extends CreatureModel {
 
@@ -249,7 +250,7 @@ class ActorModel extends CreatureModel {
     // Abstract
 
     isSpellcaster() {
-        return [10, 25, 38, 49].includes(this.fetchClassId()) ? 1 : 0;
+        return [10, 25, 38, 49].includes(Formulas.getParentClassId(this.fetchClassId())) ? 1 : 0;
     }
 
     fillupCp() {

--- a/src/GameServer/World/Generics/NpcBypasses/ChangeClass.js
+++ b/src/GameServer/World/Generics/NpcBypasses/ChangeClass.js
@@ -1,6 +1,7 @@
 const Database = invoke('Database');
 const CalculateStats = invoke('GameServer/Actor/Generics/CalculateStats');
 const ServerResponse = invoke('GameServer/Network/Response');
+const ClassProgression = invoke('GameServer/ClassProgression');
 
 function html(session, body) {
     session.dataSendToMe(ServerResponse.npcHtml(7070, body));
@@ -71,6 +72,8 @@ module.exports = async function(session, parts) {
         56: [57]
     };
 
+    const thirdClass = ClassProgression.getThirdClass(targetClassId);
+
     let isAllowed = false;
     let requiredLevel = 20;
 
@@ -80,6 +83,9 @@ module.exports = async function(session, parts) {
     } else if (secondProfMap[currentClassId] && secondProfMap[currentClassId].includes(targetClassId)) {
         isAllowed = true;
         requiredLevel = 40;
+    } else if (thirdClass?.parentClassId === currentClassId) {
+        isAllowed = true;
+        requiredLevel = 76;
     }
 
     if (!isAllowed) {

--- a/src/Packet/Send.js
+++ b/src/Packet/Send.js
@@ -11,12 +11,13 @@ class SendPacket {
 
     write(value, size) {
         const data = Buffer.alloc(size);
+        const numericValue = typeof value === 'bigint' ? Number(value) : value;
 
         switch (size) {
-            case 1: data.writeUInt8   (value); break;
-            case 2: data.writeInt16LE (value); break;
-            case 4: data.writeInt32LE (value); break;
-            case 8: data.writeDoubleLE(value); break;
+            case 1: data.writeUInt8   (numericValue); break;
+            case 2: data.writeInt16LE (numericValue); break;
+            case 4: data.writeInt32LE (numericValue > 0x7fffffff ? numericValue - 0x100000000 : numericValue); break;
+            case 8: data.writeDoubleLE(numericValue); break;
         }
 
         this.append(data);

--- a/tests/test_admin_tools.js
+++ b/tests/test_admin_tools.js
@@ -84,8 +84,8 @@ assert.strictEqual(adminShopRows.get(1467).amount, 0, 'admin S-grade Soulshot st
 assert.strictEqual(adminShopRows.get(1835).price, 0, 'admin supply prices should be free');
 
 assert.strictEqual(AdminSetLevel.normalizeLevel('1'), 1, 'admin level should accept level 1');
-assert.strictEqual(AdminSetLevel.normalizeLevel('75'), 75, 'admin level should accept the configured max level');
-assert.strictEqual(AdminSetLevel.normalizeLevel('999'), 75, 'admin level should clamp to max level');
+assert.strictEqual(AdminSetLevel.normalizeLevel('80'), 80, 'admin level should accept the configured max level');
+assert.strictEqual(AdminSetLevel.normalizeLevel('999'), 80, 'admin level should clamp to max level');
 assert.strictEqual(AdminSetLevel.normalizeLevel('0'), 1, 'admin level should clamp to level 1');
 assert.strictEqual(AdminSetLevel.normalizeLevel('abc'), null, 'admin level should reject non-numeric input');
 assert.strictEqual(AdminSetLevel.expForLevel(1), DataCache.experience[0], 'level 1 exp should use the first threshold');

--- a/tests/test_change_class.js
+++ b/tests/test_change_class.js
@@ -9,6 +9,11 @@ const ChangeClass = invoke('GameServer/World/Generics/NpcBypasses/ChangeClass');
 
 DataCache.init();
 
+const thirdClassTrees = DataCache.skillTree.filter((tree) => tree.classId >= 88 && tree.classId <= 118);
+assert.strictEqual(thirdClassTrees.length, 31, 'all C4 third-class skill trees must be present');
+assert.strictEqual(DataCache.classTemplates.filter((template) => template.classId >= 88 && template.classId <= 118).length, 31, 'all C4 third classes must have login templates');
+assert.ok(thirdClassTrees.every((tree) => tree.skills.every((skill) => DataCache.skills.some((definition) => definition.selfId === skill.selfId))), 'every third-class tree skill must have a loaded definition');
+
 let storedSkills = [{ selfId: 194, level: 1, passive: true }];
 Database.updateCharacterClassId = (id, classId) => {
     Database.lastClassUpdate = { id, classId };
@@ -98,6 +103,14 @@ function createSession({ level = 20, classId = 0 } = {}) {
     assert.ok(incompleteDataSession.actor.skillset.fetchSkills().some((skill) => skill.fetchSelfId() === 312), 'newly defined target-class skills must be persisted and sent to the client');
     assert.ok(incompleteDataSession.packets.some((packet) => packet[0] === 0x58), 'incomplete skill data must still finish with SkillsList');
     assert.ok(incompleteDataSession.packets.some((packet) => packet[0] === 0x04), 'incomplete skill data must still finish with UserInfo');
+
+    const thirdClassSession = createSession({ level: 76, classId: 2 });
+    await ChangeClass(thirdClassSession, ['change-class', '88', 'Duelist']);
+
+    assert.strictEqual(thirdClassSession.actor.fetchClassId(), 88, 'third class transfer should update the live actor class id');
+    assert.strictEqual(DataCache.classTemplates.find((template) => template.classId === 88)?.template.class, 'Duelist', 'third class must have a template for the next login');
+    assert.ok(thirdClassSession.actor.skillset.fetchSkills().some((skill) => skill.fetchSelfId() === 329), 'third class skills should be awarded at level 76');
+    assert.strictEqual(createSession({ level: 76, classId: 94 }).actor.isSpellcaster(), 1, 'third-class mages must retain caster MP and armor calculations');
 
     console.log('Class change checks passed');
 })().catch((err) => {

--- a/tests/test_progression_rates.js
+++ b/tests/test_progression_rates.js
@@ -3,7 +3,16 @@ const assert = require('assert');
 require('../src/Global');
 
 const ProgressionRates = invoke('GameServer/ProgressionRates');
+const DataCache = invoke('GameServer/DataCache');
+const ExperienceReward = invoke('GameServer/Actor/Generics/ExperienceReward');
+const SendPacket = invoke('Packet/Send');
 const originalRate = process.env.L2NODE_PROGRESSION_RATE;
+
+DataCache.init();
+assert.strictEqual(options.default.General.maxLevel, 80, 'C4 progression must allow the third-class cap of level 80');
+assert.strictEqual(ExperienceReward.resolveLevel(DataCache.experience.at(-1), options.default.General.maxLevel, DataCache.experience), 80, 'the final experience threshold must award level 80');
+const level80Packet = new SendPacket(0x04).writeD(4200000000n).fetchBuffer(false);
+assert.strictEqual(level80Packet.readUInt32LE(1), 4200000000, 'C4 packets must serialize the level-80 experience threshold as an unsigned D value');
 
 process.env.L2NODE_PROGRESSION_RATE = 'x10';
 let profile = ProgressionRates.profile();


### PR DESCRIPTION
## What changed

- Added all C4 third-class transfers to Sylvain's class-change menu at level 76.
- Added runtime templates and class progression data for all 31 third classes.
- Raised the progression cap to level 80 and added correct level-80 XP handling.
- Added third-class CP data and correct spellcaster recognition for advanced mage classes.

## Stability fixes

- Migrates character XP storage to `BIGINT` for the level-80 threshold.
- Normalizes database numeric values returned as JavaScript `bigint`.
- Serializes high XP values safely in C4 packets, preventing startup/login crashes after the migration.

## Validation

- `npm run check`
- `npm test`
- Live server startup against the migrated database, including bot spawning and reachable auth/game ports
