### PR TITLE
Add native city merchant sales

### DIFF
--- a/data/Html/7001.html
+++ b/data/Html/7001.html
@@ -2,6 +2,6 @@
 Trader Lector:<br>
 Welcome! I deal in weapons suitable for young adventurers like you. What can I do for you today?<br>
 <a action="bypass -h buy-shop npc">Buy Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7001-quest">Quest</a>
 </body></html>

--- a/data/Html/7002.html
+++ b/data/Html/7002.html
@@ -2,6 +2,6 @@
 Trader Jackson:<br>
 Need sturdier armor or a dependable shield? You came to the right place. Have a look at my inventory!<br>
 <a action="bypass -h buy-shop npc">Buy Armor and Shields</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7002-quest">Quest</a>
 </body></html>

--- a/data/Html/7003.html
+++ b/data/Html/7003.html
@@ -2,6 +2,6 @@
 Trader Silvia:<br>
 Greetings. I sell magical accessories and spellbooks for new mystics. What are you looking for?<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry and Spellbooks</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7003-quest">Quest</a>
 </body></html>

--- a/data/Html/7004.html
+++ b/data/Html/7004.html
@@ -2,6 +2,6 @@
 Trader Katerina:<br>
 Greetings! Make sure you are well-stocked on Soulshots and Healing Potions before heading out to fight monsters.<br>
 <a action="bypass -h buy-shop npc">Buy Consumables (Soulshots, Potions, Scrolls)</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7004-quest">Quest</a>
 </body></html>

--- a/data/Html/7060.html
+++ b/data/Html/7060.html
@@ -2,6 +2,6 @@
 Trader Sabrin:<br>
 Welcome. I sell weapons for Dion adventurers, from blades and bows to mystic arms.<br>
 <a action="bypass -h buy-shop npc">Buy Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7060-quest">Quest</a>
 </body></html>

--- a/data/Html/7061.html
+++ b/data/Html/7061.html
@@ -2,6 +2,6 @@
 Trader Casey:<br>
 Welcome. I carry armor, robes, shields, gloves, boots, and helmets for travelers around Dion.<br>
 <a action="bypass -h buy-shop npc">Buy Armor and Shields</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7061-quest">Quest</a>
 </body></html>

--- a/data/Html/7062.html
+++ b/data/Html/7062.html
@@ -2,6 +2,6 @@
 Trader Sonia:<br>
 Greetings. I trade magical accessories, spellbooks, amulets, and blueprints for the people of Dion.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry and Spellbooks</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7062-quest">Quest</a>
 </body></html>

--- a/data/Html/7063.html
+++ b/data/Html/7063.html
@@ -2,6 +2,6 @@
 Trader Lara:<br>
 Welcome. I sell travel goods, shots, scrolls, dyes, and other supplies for Dion customers.<br>
 <a action="bypass -h buy-shop npc">Buy Consumables and Dyes</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7063-quest">Quest</a>
 </body></html>

--- a/data/Html/7078.html
+++ b/data/Html/7078.html
@@ -2,6 +2,6 @@
 Grocer Pano:<br>
 Welcome. I sell travel goods, shots, scrolls, ropes, gemstones, and other Floran supplies.<br>
 <a action="bypass -h buy-shop npc">Buy Goods</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7078-quest">Quest</a>
 </body></html>

--- a/data/Html/7081.html
+++ b/data/Html/7081.html
@@ -2,6 +2,6 @@
 Grocer Helvetia:<br>
 Welcome. I sell groceries and dyes for Giran adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Goods and Dyes</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7081-quest">Quest</a>
 </body></html>

--- a/data/Html/7082.html
+++ b/data/Html/7082.html
@@ -2,6 +2,6 @@
 Grocer Denkus:<br>
 Welcome. I sell jewelry and spellbooks for Giran adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry and Spellbooks</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7082-quest">Quest</a>
 </body></html>

--- a/data/Html/7084.html
+++ b/data/Html/7084.html
@@ -2,6 +2,6 @@
 Weapons Trader Graham:<br>
 Welcome. I sell weapons for Giran adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7084-quest">Quest</a>
 </body></html>

--- a/data/Html/7085.html
+++ b/data/Html/7085.html
@@ -2,6 +2,6 @@
 Weapons Trader Stanford:<br>
 Welcome. I sell mystic weapons for Giran adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Mystic Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7085-quest">Quest</a>
 </body></html>

--- a/data/Html/7087.html
+++ b/data/Html/7087.html
@@ -2,6 +2,6 @@
 Armor Trader Peta:<br>
 Welcome. I sell robes, shields, gloves, boots, and helmets for Giran adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Robes and Armor Parts</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7087-quest">Quest</a>
 </body></html>

--- a/data/Html/7088.html
+++ b/data/Html/7088.html
@@ -2,6 +2,6 @@
 Armor Trader Radia:<br>
 Welcome. I sell armor for Giran adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Armor</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7088-quest">Quest</a>
 </body></html>

--- a/data/Html/7090.html
+++ b/data/Html/7090.html
@@ -2,6 +2,6 @@
 Jeweler Sandra:<br>
 Welcome. I sell jewelry for Giran adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7090-quest">Quest</a>
 </body></html>

--- a/data/Html/7091.html
+++ b/data/Html/7091.html
@@ -2,6 +2,6 @@
 Jeweler Ellie:<br>
 Welcome. I sell jewelry for Giran adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7091-quest">Quest</a>
 </body></html>

--- a/data/Html/7093.html
+++ b/data/Html/7093.html
@@ -2,6 +2,6 @@
 Magic Trader Groot:<br>
 Welcome. I sell dyes for Giran adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Dyes</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7093-quest">Quest</a>
 </body></html>

--- a/data/Html/7094.html
+++ b/data/Html/7094.html
@@ -2,6 +2,6 @@
 Magic Trader Gentler:<br>
 Welcome. I sell spellbooks, mystic weapons, and mystic armor for Giran adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Spellbooks, Mystic Weapons, and Armor</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7094-quest">Quest</a>
 </body></html>

--- a/data/Html/7097.html
+++ b/data/Html/7097.html
@@ -2,6 +2,6 @@
 Trader Galladucci:<br>
 Welcome to the luxury shop. I exchange fine weapons for crystals.<br>
 <a action="bypass -h exchange-shop npc">Exchange Luxury Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7097-quest">Quest</a>
 </body></html>

--- a/data/Html/7098.html
+++ b/data/Html/7098.html
@@ -2,6 +2,6 @@
 Trader Alexandria:<br>
 Welcome to the luxury shop. I exchange armor, shields, and jewelry for crystals.<br>
 <a action="bypass -h exchange-shop npc">Exchange Luxury Armor and Jewelry</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7098-quest">Quest</a>
 </body></html>

--- a/data/Html/7135.html
+++ b/data/Html/7135.html
@@ -2,6 +2,6 @@
 Trader Iria:<br>
 Welcome to the Dark Elven armory. We forge dark steel blades, bows, and mystic weapons suited for assassins and spellcasters alike. What is your desire?<br>
 <a action="bypass -h buy-shop npc">Buy Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7135-quest">Quest</a>
 </body></html>

--- a/data/Html/7136.html
+++ b/data/Html/7136.html
@@ -2,6 +2,6 @@
 Trader Payne:<br>
 Greetings, traveler. I deal in robust armor and shields. Choose your protection wisely before facing your foes!<br>
 <a action="bypass -h buy-shop npc">Buy Armor and Shields</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7136-quest">Quest</a>
 </body></html>

--- a/data/Html/7137.html
+++ b/data/Html/7137.html
@@ -2,6 +2,6 @@
 Trader Vollodos:<br>
 Welcome to the dark market. I supply critical traveling gear: No-Grade Soulshots, potions to heal your wounds, and scrolls to escape dangerous dungeons. Do you need a restock?<br>
 <a action="bypass -h buy-shop npc">Buy Consumables (Soulshots, Potions, Scrolls)</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7137-quest">Quest</a>
 </body></html>

--- a/data/Html/7138.html
+++ b/data/Html/7138.html
@@ -2,6 +2,6 @@
 Trader Minaless:<br>
 Greetings. I keep magical accessories and spellbooks for those who follow Shilen's path.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry and Spellbooks</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7138-quest">Quest</a>
 </body></html>

--- a/data/Html/7147.html
+++ b/data/Html/7147.html
@@ -2,6 +2,6 @@
 Trader Unoren:<br>
 Welcome to the Elven weapons forge. I sell fine bows, daggers, and mystic weapons suited for the grace of the Elven race. Can I help you?<br>
 <a action="bypass -h buy-shop npc">Buy Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7147-quest">Quest</a>
 </body></html>

--- a/data/Html/7148.html
+++ b/data/Html/7148.html
@@ -2,6 +2,6 @@
 Trader Ariel:<br>
 Greetings, traveler. I carry light armor, tunics, shields, gloves, boots, and helmets for young Elven adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Armor and Shields</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7148-quest">Quest</a>
 </body></html>

--- a/data/Html/7149.html
+++ b/data/Html/7149.html
@@ -2,6 +2,6 @@
 Trader Creamees:<br>
 Welcome. I sell magical accessories and spellbooks for young mystics of the Elven forest.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry and Spellbooks</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7149-quest">Quest</a>
 </body></html>

--- a/data/Html/7150.html
+++ b/data/Html/7150.html
@@ -2,6 +2,6 @@
 Trader Herbiel:<br>
 Hello, traveler! If you are heading out to hunt, make sure your weapon is loaded with Soulshots. Potions and scrolls of escape are also highly recommended!<br>
 <a action="bypass -h buy-shop npc">Buy Consumables (Soulshots, Potions, Scrolls)</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7150-quest">Quest</a>
 </body></html>

--- a/data/Html/7178.html
+++ b/data/Html/7178.html
@@ -2,6 +2,6 @@
 Trader Zenkin:<br>
 Welcome. I sell armor and robes for Oren adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Armor and Robes</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7178-quest">Quest</a>
 </body></html>

--- a/data/Html/7179.html
+++ b/data/Html/7179.html
@@ -2,6 +2,6 @@
 Trader Raudia:<br>
 Welcome. I sell weapons and mystic weapons for Oren adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Weapons and Mystic Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7179-quest">Quest</a>
 </body></html>

--- a/data/Html/7180.html
+++ b/data/Html/7180.html
@@ -2,6 +2,6 @@
 Trader Sara:<br>
 Welcome. I sell groceries and dyes for Oren adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Goods and Dyes</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7180-quest">Quest</a>
 </body></html>

--- a/data/Html/7181.html
+++ b/data/Html/7181.html
@@ -2,6 +2,6 @@
 Trader Galibredo:<br>
 Welcome. I sell jewelry and spellbooks for Oren adventurers.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry and Spellbooks</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7181-quest">Quest</a>
 </body></html>

--- a/data/Html/7207.html
+++ b/data/Html/7207.html
@@ -2,6 +2,6 @@
 Trader Arodin:<br>
 Welcome. I sell weapons for adventurers heading out from Gludin, from blades and bows to mystic arms.<br>
 <a action="bypass -h buy-shop npc">Buy Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7207-quest">Quest</a>
 </body></html>

--- a/data/Html/7208.html
+++ b/data/Html/7208.html
@@ -2,6 +2,6 @@
 Trader Damion:<br>
 Greetings. I keep armor, robes, shields, gloves, boots, and helmets for travelers around Gludin.<br>
 <a action="bypass -h buy-shop npc">Buy Armor and Shields</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7208-quest">Quest</a>
 </body></html>

--- a/data/Html/7209.html
+++ b/data/Html/7209.html
@@ -2,6 +2,6 @@
 Trader Colleen:<br>
 Welcome. I trade in dyes for warriors and mystics who want to shape their abilities.<br>
 <a action="bypass -h buy-shop npc">Buy Dyes</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7209-quest">Quest</a>
 </body></html>

--- a/data/Html/7230.html
+++ b/data/Html/7230.html
@@ -2,6 +2,6 @@
 Trader Edroc:<br>
 Welcome. I carry armor, robes, shields, gloves, boots, and helmets for hunters who need reliable protection.<br>
 <a action="bypass -h buy-shop npc">Buy Armor and Shields</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7230-quest">Quest</a>
 </body></html>

--- a/data/Html/7231.html
+++ b/data/Html/7231.html
@@ -2,6 +2,6 @@
 Trader Garette:<br>
 Greetings. I trade magical accessories, spellbooks, amulets, and blueprints for adventurers around Hunter Village.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry and Spellbooks</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7231-quest">Quest</a>
 </body></html>

--- a/data/Html/7235.html
+++ b/data/Html/7235.html
@@ -2,6 +2,6 @@
 Trader Monellia:<br>
 Greetings, warrior. I sell magic defense jewelry - rings, necklaces, and earrings designed to shield you from the spells of other tribes. What can I offer you?<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry (Magic Defense)</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7235-quest">Quest</a>
 </body></html>

--- a/data/Html/7253.html
+++ b/data/Html/7253.html
@@ -2,6 +2,6 @@
 Trader Simplon:<br>
 Welcome. I sell armor, robes, shields, gloves, boots, and helmets for travelers around Gludio.<br>
 <a action="bypass -h buy-shop npc">Buy Armor and Shields</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7253-quest">Quest</a>
 </body></html>

--- a/data/Html/7254.html
+++ b/data/Html/7254.html
@@ -2,6 +2,6 @@
 Trader Harmony:<br>
 Greetings. I keep travel goods, shots, scrolls, dyes, and other supplies for adventurers leaving Gludio.<br>
 <a action="bypass -h buy-shop npc">Buy Consumables and Dyes</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7254-quest">Quest</a>
 </body></html>

--- a/data/Html/7294.html
+++ b/data/Html/7294.html
@@ -2,6 +2,6 @@
 Trader Varan:<br>
 Greetings. I trade magical accessories, spellbooks, amulets, and blueprints for the people of Gludio.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry and Spellbooks</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7294-quest">Quest</a>
 </body></html>

--- a/data/Html/7301.html
+++ b/data/Html/7301.html
@@ -2,6 +2,6 @@
 Trader Hally:<br>
 Hello. I sell travel goods, shots, scrolls, dyes, and other supplies for Hunter Village customers.<br>
 <a action="bypass -h buy-shop npc">Buy Consumables and Dyes</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7301-quest">Quest</a>
 </body></html>

--- a/data/Html/7313.html
+++ b/data/Html/7313.html
@@ -2,6 +2,6 @@
 Trader Asha:<br>
 Welcome. I sell spellbooks, amulets, and blueprints for young mystics in Gludin.<br>
 <a action="bypass -h buy-shop npc">Buy Spellbooks and Amulets</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7313-quest">Quest</a>
 </body></html>

--- a/data/Html/7314.html
+++ b/data/Html/7314.html
@@ -2,6 +2,6 @@
 Trader Nestle:<br>
 Greetings. I trade magical accessories, spellbooks, amulets, and blueprints for Gludin's travelers.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry and Spellbooks</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7314-quest">Quest</a>
 </body></html>

--- a/data/Html/7315.html
+++ b/data/Html/7315.html
@@ -2,6 +2,6 @@
 Trader Poesia:<br>
 Hello. I sell travel goods, shots, scrolls, and other supplies for Gludin customers.<br>
 <a action="bypass -h buy-shop npc">Buy Goods</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7315-quest">Quest</a>
 </body></html>

--- a/data/Html/7321.html
+++ b/data/Html/7321.html
@@ -2,6 +2,6 @@
 Trader Sydnia:<br>
 Welcome. I sell weapons for adventurers in Gludio, from blades and bows to mystic arms.<br>
 <a action="bypass -h buy-shop npc">Buy Weapons and Mystic Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7321-quest">Quest</a>
 </body></html>

--- a/data/Html/7436.html
+++ b/data/Html/7436.html
@@ -2,6 +2,6 @@
 Trader Sarien:<br>
 Welcome. I sell travel goods, shots, scrolls, ropes, gemstones, and other supplies near the Wastelands.<br>
 <a action="bypass -h buy-shop npc">Buy Goods</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7436-quest">Quest</a>
 </body></html>

--- a/data/Html/7437.html
+++ b/data/Html/7437.html
@@ -2,6 +2,6 @@
 Trader Rolento:<br>
 Hello. I sell travel goods, shots, scrolls, ropes, gemstones, and other supplies near the Wastelands.<br>
 <a action="bypass -h buy-shop npc">Buy Goods</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7437-quest">Quest</a>
 </body></html>

--- a/data/Html/7516.html
+++ b/data/Html/7516.html
@@ -2,6 +2,6 @@
 Trader Reep:<br>
 Welcome. I sell weapons for dwarven adventurers, from blades and bows to mystic arms.<br>
 <a action="bypass -h buy-shop npc">Buy Weapons and Mystic Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7516-quest">Quest</a>
 </body></html>

--- a/data/Html/7517.html
+++ b/data/Html/7517.html
@@ -2,6 +2,6 @@
 Trader Shari:<br>
 Greetings. I sell armor, robes, shields, gloves, boots, and helmets for Dwarven Village customers.<br>
 <a action="bypass -h buy-shop npc">Buy Armor and Robes</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7517-quest">Quest</a>
 </body></html>

--- a/data/Html/7518.html
+++ b/data/Html/7518.html
@@ -2,6 +2,6 @@
 Trader Garita:<br>
 Hello. I trade magical accessories for young adventurers in Dwarven Village.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7518-quest">Quest</a>
 </body></html>

--- a/data/Html/7519.html
+++ b/data/Html/7519.html
@@ -2,6 +2,6 @@
 Trader Mion:<br>
 Welcome to the Dwarven general store. I sell travel goods, shots, scrolls, spellbooks, amulets, and blueprints.<br>
 <a action="bypass -h buy-shop npc">Buy Goods and Spellbooks</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7519-quest">Quest</a>
 </body></html>

--- a/data/Html/7558.html
+++ b/data/Html/7558.html
@@ -2,6 +2,6 @@
 Trader Jakal:<br>
 Welcome, brave Orc. I deal in weapons for warriors and mystic arms for shamans who must prove their strength.<br>
 <a action="bypass -h buy-shop npc">Buy Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html noquest">Quest</a>
 </body></html>

--- a/data/Html/7559.html
+++ b/data/Html/7559.html
@@ -2,6 +2,6 @@
 Trader Kunai:<br>
 Greetings. I supply armor, robes, shields, gloves, boots, and helmets for young Orcs of the Dudamara tribe.<br>
 <a action="bypass -h buy-shop npc">Buy Armor and Robes</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html noquest">Quest</a>
 </body></html>

--- a/data/Html/7560.html
+++ b/data/Html/7560.html
@@ -2,6 +2,6 @@
 Trader Uska:<br>
 May Paagrio bless you. I trade in protective jewelry and sacred amulets for Orc warriors and shamans.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry and Amulets</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html noquest">Quest</a>
 </body></html>

--- a/data/Html/7561.html
+++ b/data/Html/7561.html
@@ -2,6 +2,6 @@
 Trader Papuma:<br>
 Welcome. I offer travel goods, shots, potions, and scrolls for those leaving the Orc Village.<br>
 <a action="bypass -h buy-shop npc">Buy Consumables</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html noquest">Quest</a>
 </body></html>

--- a/data/Html/7684.html
+++ b/data/Html/7684.html
@@ -2,6 +2,6 @@
 Trader Viktor:<br>
 Welcome. I sell weapons for Hunter Village adventurers, from blades and bows to mystic arms.<br>
 <a action="bypass -h buy-shop npc">Buy Weapons and Mystic Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7684-quest">Quest</a>
 </body></html>

--- a/data/Html/7731.html
+++ b/data/Html/7731.html
@@ -2,6 +2,6 @@
 Pet manager Martin:<br>
 Welcome. I sell equipment and food for wolves, hatchlings and striders.<br>
 <a action="bypass -h buy-shop npc">Buy Pet Gear and Food</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7731-quest">Quest</a>
 </body></html>

--- a/data/Html/7827.html
+++ b/data/Html/7827.html
@@ -2,6 +2,6 @@
 Pet Manager Lundy:<br>
 Welcome. I sell equipment and food for wolves, hatchlings and striders.<br>
 <a action="bypass -h buy-shop npc">Buy Pet Gear and Food</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7827-quest">Quest</a>
 </body></html>

--- a/data/Html/7828.html
+++ b/data/Html/7828.html
@@ -2,6 +2,6 @@
 Pet Manager Waters:<br>
 Welcome. I sell equipment and food for wolves, hatchlings and striders.<br>
 <a action="bypass -h buy-shop npc">Buy Pet Gear and Food</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7828-quest">Quest</a>
 </body></html>

--- a/data/Html/7829.html
+++ b/data/Html/7829.html
@@ -2,6 +2,6 @@
 Pet Manager Cooper:<br>
 Welcome. I sell equipment and food for wolves, hatchlings and striders.<br>
 <a action="bypass -h buy-shop npc">Buy Pet Gear and Food</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7829-quest">Quest</a>
 </body></html>

--- a/data/Html/7830.html
+++ b/data/Html/7830.html
@@ -2,6 +2,6 @@
 Pet Manager Joey:<br>
 Welcome. I sell equipment and food for wolves, hatchlings and striders.<br>
 <a action="bypass -h buy-shop npc">Buy Pet Gear and Food</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7830-quest">Quest</a>
 </body></html>

--- a/data/Html/7831.html
+++ b/data/Html/7831.html
@@ -2,6 +2,6 @@
 Pet Manager Nelson:<br>
 Welcome. I sell equipment and food for wolves, hatchlings and striders.<br>
 <a action="bypass -h buy-shop npc">Buy Pet Gear and Food</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7831-quest">Quest</a>
 </body></html>

--- a/data/Html/7834.html
+++ b/data/Html/7834.html
@@ -2,6 +2,6 @@
 Magic Trader Cema:<br>
 Greetings. I trade mystic weapons, robes, armor parts, arrows, and field supplies.<br>
 <a action="bypass -h buy-shop npc">Buy Mystic Weapons, Armor, and Goods</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7834-quest">Quest</a>
 </body></html>

--- a/data/Html/7837.html
+++ b/data/Html/7837.html
@@ -2,6 +2,6 @@
 Trader Woodrow:<br>
 Welcome. I sell weapons for adventurers headed beyond Aden.<br>
 <a action="bypass -h buy-shop npc">Buy Weapons and Mystic Weapons</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7837-quest">Quest</a>
 </body></html>

--- a/data/Html/7838.html
+++ b/data/Html/7838.html
@@ -2,6 +2,6 @@
 Trader Woodley:<br>
 Welcome. I sell armor and robes made for Aden's travelers.<br>
 <a action="bypass -h buy-shop npc">Buy Armor and Robes</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7838-quest">Quest</a>
 </body></html>

--- a/data/Html/7839.html
+++ b/data/Html/7839.html
@@ -2,6 +2,6 @@
 Trader Holly:<br>
 Welcome. I sell supplies, scrolls, arrows and magic materials.<br>
 <a action="bypass -h buy-shop npc">Buy Goods</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7839-quest">Quest</a>
 </body></html>

--- a/data/Html/7840.html
+++ b/data/Html/7840.html
@@ -2,6 +2,6 @@
 Trader Lorenzo:<br>
 Welcome. I keep spellbooks for the mystics of Aden.<br>
 <a action="bypass -h buy-shop npc">Buy Spellbooks</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7840-quest">Quest</a>
 </body></html>

--- a/data/Html/7841.html
+++ b/data/Html/7841.html
@@ -2,6 +2,6 @@
 Trader Carson:<br>
 Welcome. I sell jewelry and dyes.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry and Dyes</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7841-quest">Quest</a>
 </body></html>

--- a/data/Html/7842.html
+++ b/data/Html/7842.html
@@ -2,6 +2,6 @@
 Trader Alexis:<br>
 Welcome. I sell jewelry and spellbooks.<br>
 <a action="bypass -h buy-shop npc">Buy Jewelry and Spellbooks</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7842-quest">Quest</a>
 </body></html>

--- a/data/Html/7869.html
+++ b/data/Html/7869.html
@@ -2,6 +2,6 @@
 Pet Manager Lemper:<br>
 Welcome. I sell equipment and food for wolves, hatchlings and striders.<br>
 <a action="bypass -h buy-shop npc">Buy Pet Gear and Food</a><br>
-<a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>
+<a action="bypass -h sell-shop">Sell items</a><br>
 <a action="bypass -h html 7869-quest">Quest</a>
 </body></html>

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -45,6 +45,7 @@ const tests = [
     'tests/test_npc_combat_range.js',
     'tests/test_npc_interaction_completion.js',
     'tests/test_npc_shop_stock.js',
+    'tests/test_npc_sell_shop.js',
     'tests/test_npc_social_aggro.js',
     'tests/test_npc_respawn.js',
     'tests/test_party_companion_rest_follow.js',

--- a/src/GameServer/Network/Request/Sell.js
+++ b/src/GameServer/Network/Request/Sell.js
@@ -2,6 +2,7 @@ const ReceivePacket = invoke('Packet/Receive');
 const ServerResponse = invoke('GameServer/Network/Response');
 const TradeService   = invoke('GameServer/Bot/TradeService');
 const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
+const Database       = invoke('Database');
 
 function merchantSellRows(actor, store) {
     return actor.backpack.fetchItems()
@@ -19,6 +20,16 @@ function merchantSellRows(actor, store) {
         .filter((row) => row && row.amount > 0);
 }
 
+function npcSellRows(actor) {
+    return actor.backpack.fetchItems()
+        .filter((item) => !item.fetchEquipped() && item.fetchSelfId() !== 57)
+        .map((item) => ({
+            item,
+            amount: item.fetchAmount(),
+            price: Math.max(1, Math.floor(item.fetchPrice() * 0.5))
+        }));
+}
+
 function sell(session, buffer) {
     const packet = new ReceivePacket(buffer);
 
@@ -32,15 +43,17 @@ function sell(session, buffer) {
     for (let i = 0; i < count; i++) {
         packet
             .readD()
+            .readD()
             .readD();
 
         list.push({
-            objectId: packet.data[2 + (i * 2)],
-            amount: packet.data[3 + (i * 2)]
+            objectId: packet.data[2 + (i * 3)],
+            selfId: packet.data[3 + (i * 3)],
+            amount: packet.data[4 + (i * 3)]
         });
     }
 
-    consume(session, list);
+    return consume(session, list);
 }
 
 async function consume(session, list) {
@@ -48,15 +61,14 @@ async function consume(session, list) {
     const store = trade && trade.store;
 
     if (!store || store.storeType !== 3) {
-        session.dataSendToMe(ServerResponse.actionFailed());
-        return;
+        return sellToNpcShop(session, list);
     }
 
     try {
         const sold = [];
         for (const line of list) {
             const item = session.actor.backpack.fetchItems().find((ob) => ob.fetchId() === line.objectId);
-            if (!item || item.fetchEquipped() || item.fetchSelfId() === 57) continue;
+            if (!item || item.fetchEquipped() || item.fetchSelfId() === 57 || item.fetchSelfId() !== line.selfId || line.amount <= 0) continue;
 
             sold.push(await TradeService.sellToStore(session.actor, store, item.fetchSelfId(), line.amount));
         }
@@ -74,6 +86,74 @@ async function consume(session, list) {
         ));
     } catch (err) {
         utils.infoWarn('Sell', 'merchant sell error: %s', err.message || err);
+        session.dataSendToMe(ServerResponse.actionFailed());
+    }
+}
+
+async function sellToNpcShop(session, list) {
+    const shop = session.activeNpcSellShop;
+    if (!shop) {
+        session.dataSendToMe(ServerResponse.actionFailed());
+        return;
+    }
+
+    try {
+        const sold = [];
+        for (const line of list) {
+            const item = session.actor.backpack.fetchItems().find((ob) => ob.fetchId() === line.objectId);
+            const offered = shop.items.get(line.objectId);
+            const amount = Number(line.amount);
+            if (!item || !offered || item.fetchEquipped() || item.fetchSelfId() === 57 ||
+                item.fetchSelfId() !== line.selfId || item.fetchSelfId() !== offered.selfId ||
+                !Number.isSafeInteger(amount) || amount < 1 || amount > item.fetchAmount()) continue;
+
+            const payout = offered.price * amount;
+            if (!Number.isSafeInteger(payout) || payout < 0) continue;
+
+            if (amount === item.fetchAmount()) {
+                await Database.deleteItem(session.actor.fetchId(), item.fetchId());
+                session.actor.backpack.items = session.actor.backpack.items.filter((ob) => ob.fetchId() !== item.fetchId());
+            } else {
+                await Database.updateItemAmount(session.actor.fetchId(), item.fetchId(), item.fetchAmount() - amount);
+                item.setAmount(item.fetchAmount() - amount);
+            }
+            sold.push({ payout });
+        }
+
+        const payout = sold.reduce((total, line) => total + line.payout, 0);
+        if (payout > 0) {
+            const backpack = session.actor.backpack;
+            const adena = backpack.fetchItemFromSelfId(57);
+            if (adena) {
+                const total = adena.fetchAmount() + payout;
+                await Database.updateItemAmount(session.actor.fetchId(), adena.fetchId(), total);
+                adena.setAmount(total);
+            } else {
+                const packet = await Database.setItem(session.actor.fetchId(), {
+                    selfId: 57,
+                    name: 'Adena',
+                    amount: payout,
+                    equipped: false,
+                    slot: 0
+                });
+                backpack.insertItem(Number(packet.insertId), 57, { amount: payout });
+            }
+        }
+
+        const rows = npcSellRows(session.actor);
+        shop.items = new Map(rows.map((row) => [row.item.fetchId(), {
+            selfId: row.item.fetchSelfId(),
+            price: row.price
+        }]));
+
+        session.dataSendToMe(ServerResponse.userInfo(session.actor));
+        session.dataSendToMe(ServerResponse.itemsList(session.actor.backpack.fetchItems()));
+        session.dataSendToMe(ServerResponse.sellList(
+            rows,
+            session.actor.backpack.fetchTotalAdena()
+        ));
+    } catch (err) {
+        utils.infoWarn('Sell', 'NPC shop sell error: %s', err.message || err);
         session.dataSendToMe(ServerResponse.actionFailed());
     }
 }

--- a/src/GameServer/World/Generics/NpcBypasses/AdminShop.js
+++ b/src/GameServer/World/Generics/NpcBypasses/AdminShop.js
@@ -28,6 +28,7 @@ module.exports = function(session, parts) {
     }
 
     session.activeMerchantTrade = null;
+    session.activeNpcSellShop = null;
     session.activeAdminShop = {
         category: parts[1],
         itemIds: new Set(itemIds)

--- a/src/GameServer/World/Generics/NpcBypasses/BuyShop.js
+++ b/src/GameServer/World/Generics/NpcBypasses/BuyShop.js
@@ -7,6 +7,7 @@ module.exports = function(session, parts) {
     session.activeMerchantTrade = null;
     session.activeAdminShop = null;
     session.activeNpcShop = null;
+    session.activeNpcSellShop = null;
 
     let list = [];
     let entries = [];

--- a/src/GameServer/World/Generics/NpcBypasses/ExchangeShop.js
+++ b/src/GameServer/World/Generics/NpcBypasses/ExchangeShop.js
@@ -42,6 +42,7 @@ module.exports = function(session, parts) {
     session.activeMerchantTrade = null;
     session.activeAdminShop = null;
     session.activeNpcShop = null;
+    session.activeNpcSellShop = null;
 
     const npcSelfId = session.activeNpcTalk?.selfId;
     const rows = ExchangeLists.fetchForNpc(npcSelfId);

--- a/src/GameServer/World/Generics/NpcBypasses/SellShop.js
+++ b/src/GameServer/World/Generics/NpcBypasses/SellShop.js
@@ -1,0 +1,32 @@
+const ServerResponse = invoke('GameServer/Network/Response');
+
+function sellRows(actor) {
+    return actor.backpack.fetchItems()
+        .filter((item) => !item.fetchEquipped() && item.fetchSelfId() !== 57)
+        .map((item) => ({
+            item,
+            amount: item.fetchAmount(),
+            price: Math.max(1, Math.floor(item.fetchPrice() * 0.5))
+        }));
+}
+
+module.exports = function(session) {
+    session.activeMerchantTrade = null;
+    session.activeAdminShop = null;
+    session.activeNpcShop = null;
+
+    const rows = sellRows(session.actor);
+    session.activeNpcSellShop = {
+        npcSelfId: session.activeNpcTalk?.selfId,
+        items: new Map(rows.map((row) => [row.item.fetchId(), {
+            selfId: row.item.fetchSelfId(),
+            price: row.price
+        }]))
+    };
+
+    session.dataSendToMe(ServerResponse.sellList(
+        rows,
+        session.actor.backpack.fetchTotalAdena()
+    ));
+    session.dataSendToMe(ServerResponse.actionFailed());
+};

--- a/src/GameServer/World/Generics/NpcExchangeShopLists.js
+++ b/src/GameServer/World/Generics/NpcExchangeShopLists.js
@@ -88,7 +88,7 @@ function renderHtml(npcSelfId, message = '') {
         lines.push(`${esc(row.result.name)} - ${required} <a action="bypass -h exchange-shop buy ${index}">Exchange</a><br>`);
     });
 
-    lines.push('<br><a action="bypass -h sell-junk">Sell unequipped items (50% price)</a><br>');
+    lines.push('<br><a action="bypass -h sell-shop">Sell items</a><br>');
     lines.push('</body></html>');
     return lines.join('');
 }

--- a/src/GameServer/World/Generics/NpcTalk.js
+++ b/src/GameServer/World/Generics/NpcTalk.js
@@ -5,6 +5,7 @@ function npcTalk(session, npc) {
     const filename = path + npc.fetchSelfId() + '.html';
 
     session.activeNpcShop = null;
+    session.activeNpcSellShop = null;
     session.activeNpcTalk = {
         selfId: npc.fetchSelfId(),
         objectId: npc.fetchId(),

--- a/tests/test_npc_sell_shop.js
+++ b/tests/test_npc_sell_shop.js
@@ -1,0 +1,101 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const SellShop = invoke('GameServer/World/Generics/NpcBypasses/SellShop');
+const Sell = invoke('GameServer/Network/Request/Sell');
+const Database = invoke('Database');
+const ServerResponse = invoke('GameServer/Network/Response');
+
+function item(id, selfId, amount, price, equipped = false) {
+    return {
+        fetchId: () => id,
+        fetchSelfId: () => selfId,
+        fetchAmount: () => amount,
+        fetchPrice: () => price,
+        fetchEquipped: () => equipped,
+        fetchClass1: () => 4,
+        fetchClass2: () => 5,
+        isWearable: () => false
+    };
+}
+
+const sellable = item(1001, 1539, 12, 40);
+const equipped = item(1002, 17, 100, 10, true);
+const adena = item(1003, 57, 500, 1);
+const packets = [];
+const session = {
+    activeNpcTalk: { selfId: 7004 },
+    actor: {
+        backpack: {
+            fetchItems: () => [sellable, equipped, adena],
+            fetchTotalAdena: () => 500
+        }
+    },
+    dataSendToMe(packet) {
+        packets.push(packet);
+    }
+};
+
+SellShop(session, ['sell-shop']);
+
+assert.strictEqual(packets[0][0], 0x10, 'city merchant sale should open the native C4 SellList window');
+assert.strictEqual(packets[1][0], 0x25, 'SellList should terminate the NPC interaction after opening');
+assert.strictEqual(packets[0].readInt16LE(9), 1, 'SellList should only offer unequipped non-Adena items');
+assert.strictEqual(packets[0].readInt32LE(17), 1539, 'SellList should identify the offered inventory item');
+assert.strictEqual(packets[0].readInt32LE(39), 20, 'SellList should show the C4 half-reference sell price');
+assert.strictEqual(session.activeNpcSellShop.items.get(1001).price, 20, 'server should retain the offered item and price for request validation');
+
+const amount = { value: 12 };
+const adenaAmount = { value: 500 };
+const mutableItem = {
+    ...item(1001, 1539, amount.value, 40),
+    fetchAmount: () => amount.value,
+    setAmount: (value) => { amount.value = value; }
+};
+const mutableAdena = {
+    ...item(1003, 57, adenaAmount.value, 1),
+    fetchAmount: () => adenaAmount.value,
+    setAmount: (value) => { adenaAmount.value = value; }
+};
+const sellPackets = [];
+const sellSession = {
+    activeNpcSellShop: { items: new Map([[1001, { selfId: 1539, price: 20 }]]) },
+    actor: {
+        fetchId: () => 42,
+        backpack: {
+            items: [mutableItem, mutableAdena],
+            fetchItems() { return this.items; },
+            fetchItemFromSelfId: (selfId) => selfId === 57 ? mutableAdena : mutableItem,
+            fetchTotalAdena: () => adenaAmount.value
+        }
+    },
+    dataSendToMe(packet) { sellPackets.push(packet); }
+};
+const originalUpdate = Database.updateItemAmount;
+const originalUserInfo = ServerResponse.userInfo;
+const originalItemsList = ServerResponse.itemsList;
+Database.updateItemAmount = () => Promise.resolve();
+ServerResponse.userInfo = () => Buffer.from([0x04]);
+ServerResponse.itemsList = () => Buffer.from([0x1b]);
+const request = Buffer.alloc(21);
+request.writeInt32LE(0, 1);
+request.writeInt32LE(1, 5);
+request.writeInt32LE(1001, 9);
+request.writeInt32LE(1539, 13);
+request.writeInt32LE(5, 17);
+
+Sell(sellSession, request).then(() => {
+    Database.updateItemAmount = originalUpdate;
+    ServerResponse.userInfo = originalUserInfo;
+    ServerResponse.itemsList = originalItemsList;
+    assert.strictEqual(amount.value, 7, 'NPC sale should remove only the amount selected in the native window');
+    assert.strictEqual(adenaAmount.value, 600, 'NPC sale should credit the advertised half-reference price');
+    assert.strictEqual(sellPackets[0][0], 0x04, 'NPC sale should refresh UserInfo after the transaction');
+    assert.strictEqual(sellPackets[2][0], 0x10, 'NPC sale should keep the native SellList open with the remaining items');
+}).catch((error) => {
+    Database.updateItemAmount = originalUpdate;
+    ServerResponse.userInfo = originalUserInfo;
+    ServerResponse.itemsList = originalItemsList;
+    throw error;
+});


### PR DESCRIPTION
## What changed

City merchants now open the native C4 sell window, allowing players to select individual inventory items and quantities instead of automatically selling their whole unequipped inventory.

The server validates the inventory object, item ID, quantity, and the price originally shown in the sell list before completing each sale. It also refreshes the inventory and sell list after a transaction.

## Why

The former `sell-junk` bypass immediately liquidated every unequipped item for half price. That did not match Lineage II C4 merchant behavior and gave players no choice over what to keep.

## Player impact

Players can now use city shops exactly as expected: choose the items and quantities to sell in the standard client interface. Automated bot liquidation keeps its existing internal path.

## Validation

- `node scripts/check-syntax.js`
- `node tests/test_npc_sell_shop.js`
- `node tests/test_c4_protocol_packets.js`
- `node tests/test_npc_interaction_completion.js`
- `node tests/test_npc_shop_stock.js`
- `git diff --check`
