### PR TITLE
Persist character status across relog

### DIFF
--- a/database/sql/database.sql
+++ b/database/sql/database.sql
@@ -20,6 +20,8 @@ CREATE TABLE `characters`(
     `maxHp`       float       NOT NULL,
     `mp`          float       NOT NULL DEFAULT 25,
     `maxMp`       float       NOT NULL,
+    `cp`          float                NULL,
+    `effects`     text                 NULL,
     `exp`         bigint      NOT NULL DEFAULT 0,
     `sp`          int(10)     NOT NULL DEFAULT 0,
     `pk`          int(10)     NOT NULL DEFAULT 0,

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -30,6 +30,7 @@ const tests = [
     'tests/test_c4_buff_modifiers.js',
     'tests/test_c4_protocol_packets.js',
     'tests/test_cast_interrupt.js',
+    'tests/test_character_status_persistence.js',
     'tests/test_change_class.js',
     'tests/test_clan_bot_invite.js',
     'tests/test_clan_system.js',

--- a/src/Database.js
+++ b/src/Database.js
@@ -20,6 +20,17 @@ function migrateCharacterExperience(optn) {
     });
 }
 
+function migrateCharacterStatus() {
+    return conn.query('ALTER TABLE `characters` ADD COLUMN `cp` FLOAT NULL')
+        .catch((error) => {
+            if (error?.errno !== 1060) utils.infoWarn('DB', 'failed to add characters.cp: %s', error.message);
+        })
+        .then(() => conn.query('ALTER TABLE `characters` ADD COLUMN `effects` TEXT NULL'))
+        .catch((error) => {
+            if (error?.errno !== 1060) utils.infoWarn('DB', 'failed to add characters.effects: %s', error.message);
+        });
+}
+
 const Database = {
     init: (callback) => {
         const optn = options.default.Database;
@@ -41,7 +52,8 @@ const Database = {
                         utils.infoWarn('DB', 'failed to add items.petData: %s', error.message);
                     }
                 }),
-                migrateCharacterExperience(optn)
+                migrateCharacterExperience(optn),
+                migrateCharacterStatus()
             ]).finally(callback);
 
         }).catch(error => {
@@ -340,6 +352,17 @@ const Database = {
                 maxHp: maxHp,
                    mp: mp,
                 maxMp: maxMp,
+            }, 'id = ? LIMIT 1', id)
+        );
+    },
+
+    updateCharacterStatus(id, { hp, mp, cp, effects }) {
+        return Database.execute(
+            builder.update('characters', {
+                hp,
+                mp,
+                cp,
+                effects
             }, 'id = ? LIMIT 1', id)
         );
     },

--- a/src/GameServer/Actor/CharacterStatus.js
+++ b/src/GameServer/Actor/CharacterStatus.js
@@ -1,0 +1,89 @@
+const EffectStore  = invoke('GameServer/Effects/EffectStore');
+const EffectTicker = invoke('GameServer/Effects/EffectTicker');
+
+function activeBuffs(actor) {
+    return EffectStore.list(actor)
+        .filter((effect) => effect.type !== 'debuff' && effect.toggle !== true && Number(effect.expiresAt) > Date.now());
+}
+
+function serializeEffects(actor) {
+    return JSON.stringify(activeBuffs(actor));
+}
+
+function parseEffects(value) {
+    if (Array.isArray(value)) return value;
+    if (typeof value !== 'string' || !value.trim()) return [];
+
+    try {
+        const effects = JSON.parse(value);
+        return Array.isArray(effects) ? effects : [];
+    } catch (_) {
+        return [];
+    }
+}
+
+function restoreEffects(session, actor, value) {
+    const restored = [];
+    parseEffects(value).forEach((effect) => {
+        if (
+            !effect ||
+            effect.type === 'debuff' ||
+            effect.toggle === true ||
+            !effect.key ||
+            !Number(effect.id) ||
+            Number(effect.expiresAt) <= Date.now()
+        ) {
+            return;
+        }
+
+        const applied = EffectStore.apply(actor, effect);
+        if (!applied) return;
+
+        if (!actor.activeBuffs) actor.activeBuffs = {};
+        actor.activeBuffs[applied.key] = applied.expiresAt;
+        if (applied.dot) EffectTicker.applyDot(session, actor, actor, applied);
+        if (applied.manaDot) EffectTicker.applyManaDot(session, actor, actor, applied);
+        if (applied.manaHot) EffectTicker.applyManaHot(session, actor, actor, applied);
+        if (applied.hot) EffectTicker.applyHot(session, actor, actor, applied);
+        EffectTicker.scheduleExpiry(session, actor, applied);
+        restored.push(applied);
+    });
+    return restored;
+}
+
+function savedVitals(actor) {
+    const cp = actor?.model?.cp;
+    return {
+        hp: Number(actor.fetchHp()),
+        mp: Number(actor.fetchMp()),
+        cp: cp !== null && cp !== undefined && Number.isFinite(Number(cp)) ? Number(cp) : null
+    };
+}
+
+function restoreVitals(actor, vitals) {
+    const clamp = (value, maximum) => Math.max(0, Math.min(Number(value), Number(maximum)));
+
+    if (Number.isFinite(vitals?.hp)) actor.setHp(clamp(vitals.hp, actor.fetchMaxHp()));
+    if (Number.isFinite(vitals?.mp)) actor.setMp(clamp(vitals.mp, actor.fetchMaxMp()));
+    if (Number.isFinite(vitals?.cp) && typeof actor.setCp === 'function') {
+        actor.setCp(clamp(vitals.cp, actor.fetchMaxCp()));
+    }
+}
+
+function persistenceRecord(actor) {
+    return {
+        hp: Number(actor.fetchHp()),
+        mp: Number(actor.fetchMp()),
+        cp: Number(actor.fetchCp?.()) || 0,
+        effects: serializeEffects(actor)
+    };
+}
+
+module.exports = {
+    serializeEffects,
+    parseEffects,
+    restoreEffects,
+    savedVitals,
+    restoreVitals,
+    persistenceRecord
+};

--- a/src/GameServer/Actor/Generics/EnterWorld.js
+++ b/src/GameServer/Actor/Generics/EnterWorld.js
@@ -1,5 +1,6 @@
 const DataCache   = invoke('GameServer/DataCache');
 const ConsoleText = invoke('GameServer/ConsoleText');
+const CharacterStatus = invoke('GameServer/Actor/CharacterStatus');
 
 function enterWorld(session, actor) {
     const Generics = invoke(path.actor);
@@ -7,8 +8,14 @@ function enterWorld(session, actor) {
     // Set character as online
     actor.setIsOnline(true);
 
+    // Effects must be available before the stat calculation; e.g. a max-HP
+    // buff affects the cap used when the persisted HP is restored.
+    const vitals = CharacterStatus.savedVitals(actor);
+    CharacterStatus.restoreEffects(session, actor, actor.model.effects);
+
     // Calculate accumulated statistics
     Generics.calculateStats(session, actor);
+    CharacterStatus.restoreVitals(actor, vitals);
     actor.skillset.populate(actor.fetchId());
 
     // Start vitals replenish

--- a/src/GameServer/Effects/EffectTicker.js
+++ b/src/GameServer/Effects/EffectTicker.js
@@ -23,6 +23,14 @@ function clear(actor, key) {
     return removed;
 }
 
+function clearAll(actor) {
+    const keys = new Set([
+        ...Object.keys(actor?.effectTimers || {}),
+        ...Object.keys(actor?.effectExpiryTimers || {})
+    ]);
+    keys.forEach((key) => clear(actor, key));
+}
+
 function clearRuntime(actor, key) {
     if (!actor?.effectTimers?.[key]) return false;
     clearInterval(actor.effectTimers[key]);
@@ -293,5 +301,6 @@ module.exports = {
     applyHot,
     scheduleExpiry,
     refreshEffects,
-    clear
+    clear,
+    clearAll
 };

--- a/src/GameServer/Network/Request/Logout.js
+++ b/src/GameServer/Network/Request/Logout.js
@@ -2,6 +2,8 @@ const ServerResponse = invoke('GameServer/Network/Response');
 
 function logout(session, buffer) {
 
+    session.persistCharacterStatus?.();
+    if (session.actor) invoke('GameServer/Effects/EffectTicker').clearAll(session.actor);
     session.actor?.destructor();
 
     session.dataSendToMe(

--- a/src/GameServer/Network/Request/Restart.js
+++ b/src/GameServer/Network/Request/Restart.js
@@ -3,6 +3,8 @@ const Shared         = invoke('GameServer/Network/Shared');
 
 function restart(session, buffer) {
 
+    session.persistCharacterStatus?.();
+    if (session.actor) invoke('GameServer/Effects/EffectTicker').clearAll(session.actor);
     session.actor?.destructor();
 
     session.dataSendToMe(

--- a/src/GameServer/Session.js
+++ b/src/GameServer/Session.js
@@ -169,6 +169,16 @@ class Session {
         this.actor = new Actor(this, properties);
     }
 
+    persistCharacterStatus({ currentOnly = false } = {}) {
+        if (!this.actor?.fetchId) return Promise.resolve();
+        if (currentOnly && !(World.user?.sessions || []).includes(this)) return Promise.resolve();
+
+        const Database = invoke('Database');
+        const CharacterStatus = invoke('GameServer/Actor/CharacterStatus');
+        return Database.updateCharacterStatus(this.actor.fetchId(), CharacterStatus.persistenceRecord(this.actor))
+            .catch((error) => utils.infoWarn('DB', 'failed to save character status: %s', error.message));
+    }
+
     fetchAccountId() {
         return this.accountId;
     }
@@ -265,6 +275,8 @@ class Session {
             utils.infoWarn('GameServer', 'connection closed');
         }
         if (this.actor) {
+            this.persistCharacterStatus({ currentOnly: true });
+            invoke('GameServer/Effects/EffectTicker').clearAll(this.actor);
             const PartyCompanionService = invoke('GameServer/Bot/AI/PartyCompanionService');
             PartyCompanionService.detachAll(this, {
                 event: 'party_dismissed',

--- a/tests/test_character_status_persistence.js
+++ b/tests/test_character_status_persistence.js
@@ -1,0 +1,98 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const CharacterStatus = invoke('GameServer/Actor/CharacterStatus');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
+const EffectTicker = invoke('GameServer/Effects/EffectTicker');
+
+const actor = {
+    model: { cp: 23 },
+    hp: 67,
+    mp: 31,
+    maxHp: 100,
+    maxMp: 80,
+    cp: 23,
+    maxCp: 50,
+    fetchHp() { return this.hp; },
+    fetchMp() { return this.mp; },
+    fetchCp() { return this.cp; },
+    fetchMaxHp() { return this.maxHp; },
+    fetchMaxMp() { return this.maxMp; },
+    fetchMaxCp() { return this.maxCp; },
+    setHp(value) { this.hp = value; },
+    setMp(value) { this.mp = value; },
+    setCp(value) { this.cp = value; }
+};
+
+EffectStore.apply(actor, {
+    key: 'might', id: 1068, level: 3, type: 'buff', stats: { pAtkMul: 1.15 }, durationMs: 60000
+});
+EffectStore.apply(actor, {
+    key: 'poison', id: 129, level: 1, type: 'debuff', durationMs: 60000
+});
+EffectStore.apply(actor, {
+    key: 'vampiric_rage', id: 1268, level: 1, type: 'buff', toggle: true, durationMs: 60000
+});
+
+const stored = CharacterStatus.persistenceRecord(actor);
+assert.deepStrictEqual(JSON.parse(stored.effects).map((effect) => effect.key), ['might'], 'only non-toggle buffs should survive a logout');
+assert.deepStrictEqual({ hp: stored.hp, mp: stored.mp, cp: stored.cp }, { hp: 67, mp: 31, cp: 23 }, 'all three vital values should be persisted');
+
+const restored = {
+    model: { cp: stored.cp },
+    activeBuffs: {},
+    effects: {},
+    hp: stored.hp,
+    mp: stored.mp,
+    cp: stored.cp,
+    maxHp: 100,
+    maxMp: 80,
+    maxCp: 50,
+    fetchHp() { return this.hp; },
+    fetchMp() { return this.mp; },
+    fetchCp() { return this.cp; },
+    fetchMaxHp() { return this.maxHp; },
+    fetchMaxMp() { return this.maxMp; },
+    fetchMaxCp() { return this.maxCp; },
+    setHp(value) { this.hp = value; },
+    setMp(value) { this.mp = value; },
+    setCp(value) { this.cp = value; }
+};
+
+assert.strictEqual(CharacterStatus.restoreEffects({}, restored, stored.effects).length, 1, 'active buffs should be restored before recalculating stats');
+assert.strictEqual(EffectStore.list(restored)[0].key, 'might', 'restored effect should retain its key and stat payload');
+assert.ok(restored.activeBuffs.might > Date.now(), 'legacy buff tracking should remain in sync after restore');
+
+const hotEffect = {
+    key: 'chant_of_life',
+    id: 1229,
+    level: 1,
+    type: 'buff',
+    hot: { heal: 4, count: 2, intervalMs: 1000 },
+    expiresAt: Date.now() + 60000
+};
+const originalApplyHot = EffectTicker.applyHot;
+let resumedHot = 0;
+EffectTicker.applyHot = (...args) => {
+    resumedHot += 1;
+    return originalApplyHot(...args);
+};
+CharacterStatus.restoreEffects({}, restored, JSON.stringify([hotEffect]));
+EffectTicker.applyHot = originalApplyHot;
+assert.strictEqual(resumedHot, 1, 'restoring a periodic buff should resume its ticker');
+
+const vitals = CharacterStatus.savedVitals(restored);
+restored.maxHp = 60;
+restored.maxMp = 20;
+restored.maxCp = 10;
+CharacterStatus.restoreVitals(restored, vitals);
+assert.deepStrictEqual({ hp: restored.hp, mp: restored.mp, cp: restored.cp }, { hp: 60, mp: 20, cp: 10 }, 'restored vitals should clamp to the recalculated maximums');
+
+restored.model.cp = null;
+restored.cp = restored.maxCp;
+CharacterStatus.restoreVitals(restored, CharacterStatus.savedVitals(restored));
+assert.strictEqual(restored.cp, restored.maxCp, 'a NULL CP column should leave the initial full CP untouched');
+
+EffectTicker.clearAll(restored);
+console.log('Character status persistence checks passed');


### PR DESCRIPTION
## Summary
- Persist HP, MP, CP, and remaining non-toggle buff durations when a character leaves the game.
- Restore effects before stat calculation and clamp saved vitals to the restored maxima.
- Add automatic schema migration and regression coverage for relog status restoration.

## Root cause
Character vitals were only written in limited gameplay flows, while CP and active effects had no persistence path.

## Validation
- npm run check
- npm test