### PR TITLE
Keep client world in sync with bot and NPC lifecycle

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -35,6 +35,7 @@ const tests = [
     'tests/test_bot_market_opportunity.js',
     'tests/test_bot_population_state.js',
     'tests/test_bot_population_policy.js',
+    'tests/test_bot_population_cooldown_cleanup.js',
     'tests/test_bot_pvp_risk.js',
     'tests/test_pk_hunting_state.js',
     'tests/test_pk_chat_guard.js',

--- a/src/GameServer/Bot/Population/Cooldown.js
+++ b/src/GameServer/Bot/Population/Cooldown.js
@@ -2,6 +2,23 @@ const World     = invoke('GameServer/World/World');
 const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
 const Metrics   = invoke('GameServer/Bot/Population/PopulationMetrics');
 const MarketOpportunity = invoke('GameServer/Bot/Economy/MarketOpportunity');
+const ServerResponse = invoke('GameServer/Network/Response');
+
+function removeFromClientWorld(session) {
+    const objectId = session?.actor?.fetchId?.();
+    if (!objectId) return;
+
+    // A bot can have been visible to a player before walking out of the
+    // server's 6000-unit visibility radius.  At cooldown time that player is
+    // no longer returned by fetchVisibleUsers(), so broadcasting through the
+    // normal proximity path leaves a stale client-side character behind.
+    const packet = ServerResponse.deleteOb(objectId);
+    World.user.sessions.forEach((viewer) => {
+        if (viewer !== session && typeof viewer.dataSendToMe === 'function') {
+            viewer.dataSendToMe(packet);
+        }
+    });
+}
 
 function isVisibleToRealPlayer(session) {
     if (!session || !session.actor) return false;
@@ -21,6 +38,7 @@ const Cooldown = {
 
             const BotAI = invoke('GameServer/Bot/BotAI');
             BotAI.stop(session);
+            removeFromClientWorld(session);
             if (session.actor && typeof session.actor.destructor === 'function') {
                 session.actor.destructor();
             }

--- a/src/GameServer/World/Generics/SpawnNpcs.js
+++ b/src/GameServer/World/Generics/SpawnNpcs.js
@@ -1,5 +1,31 @@
 const Npc       = invoke('GameServer/Npc/Npc');
 const DataCache = invoke('GameServer/DataCache');
+const ServerResponse = invoke('GameServer/Network/Response');
+
+const VISIBILITY_RADIUS = 6000;
+
+function distanceSquared(first, second) {
+    const dx = first.fetchLocX() - second.fetchLocX();
+    const dy = first.fetchLocY() - second.fetchLocY();
+    return (dx * dx) + (dy * dy);
+}
+
+function notifyNearby(world, npc, response = ServerResponse) {
+    if (!world?.user?.sessions || !npc) return;
+    const radiusSquared = VISIBILITY_RADIUS * VISIBILITY_RADIUS;
+    const packet = response.npcInfo(npc);
+
+    world.user.sessions.forEach((session) => {
+        const actor = session?.actor;
+        if (
+            actor?.fetchIsOnline?.() === true &&
+            typeof session.dataSendToMe === 'function' &&
+            distanceSquared(actor, npc) <= radiusSquared
+        ) {
+            session.dataSendToMe(packet);
+        }
+    });
+}
 
 function createNpc(world, npc, coords, spawnDefinition = null) {
     const instance = new Npc(world.npc.nextId++, { ...utils.crushOb(npc), ...coords });
@@ -28,6 +54,10 @@ function randomCoords(definition) {
 function spawnNpc(world, definition) {
     const coords = randomCoords(definition);
     const npc = createNpc(world, definition.npc, coords, definition);
+    // Respawns happen independently of player movement.  Announce the new
+    // object immediately, otherwise it can aggro a nearby player before that
+    // player next crosses UpdateEnvironment's movement refresh threshold.
+    notifyNearby(world, npc);
     return npc;
 }
 
@@ -65,6 +95,7 @@ function spawnNpcs() {
 
 module.exports = spawnNpcs;
 module.exports.spawnNpc = spawnNpc;
+module.exports.notifyNearby = notifyNearby;
 module.exports.shouldRespawn = function shouldRespawn(spawn) {
     return Number(spawn?.respawn) > 0;
 };

--- a/tests/test_bot_population_cooldown_cleanup.js
+++ b/tests/test_bot_population_cooldown_cleanup.js
@@ -1,0 +1,61 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const World = invoke('GameServer/World/World');
+const BotManager = invoke('GameServer/Bot/BotManager');
+const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
+const BotAI = invoke('GameServer/Bot/BotAI');
+const Cooldown = invoke('GameServer/Bot/Population/Cooldown');
+
+const originalUsers = World.user;
+const originalSessions = BotManager.sessions;
+const originalUpsertState = LifeState.upsertState;
+const originalStop = BotAI.stop;
+
+async function run() {
+    const packets = [];
+    let destroyed = false;
+    const botSession = {
+        accountId: 'bot_ghost',
+        actor: {
+            fetchId: () => 481516,
+            destructor() { destroyed = true; }
+        }
+    };
+    const playerSession = {
+        accountId: 'player',
+        dataSendToMe(packet) { packets.push(packet); }
+    };
+
+    World.user = { sessions: [playerSession, botSession] };
+    BotManager.sessions = [botSession];
+    LifeState.upsertState = (state) => Promise.resolve(state);
+    BotAI.stop = () => {};
+
+    const result = await Cooldown.transitionToColdState(botSession, {
+        characterId: 481516,
+        name: 'GhostBot'
+    }, 'test_cleanup');
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(destroyed, true, 'the cooled bot should be destroyed on the server');
+    assert.strictEqual(botSession.actor, null, 'the cooled bot should no longer have an active actor');
+    assert.strictEqual(BotManager.sessions.includes(botSession), false, 'the cooled bot should leave the hot population');
+    assert.strictEqual(packets.length, 1, 'players must receive a cleanup packet even when the bot is no longer visible');
+    assert.strictEqual(packets[0][0], 0x12, 'the cleanup packet must be DeleteObject');
+    assert.strictEqual(packets[0].readInt32LE(1), 481516, 'DeleteObject must identify the cooled bot');
+}
+
+run()
+    .then(() => console.log('Bot population cooldown cleanup checks passed'))
+    .catch((err) => {
+        console.error(err);
+        process.exitCode = 1;
+    })
+    .finally(() => {
+        World.user = originalUsers;
+        BotManager.sessions = originalSessions;
+        LifeState.upsertState = originalUpsertState;
+        BotAI.stop = originalStop;
+    });

--- a/tests/test_npc_respawn.js
+++ b/tests/test_npc_respawn.js
@@ -11,4 +11,30 @@ assert.strictEqual(SpawnNpcs.shouldRespawn({ respawn: -1 }), false, 'datapack se
 assert.strictEqual(SpawnNpcs.shouldRespawn({ respawn: 0 }), false, 'zero respawn must not schedule an NPC respawn');
 assert.strictEqual(SpawnNpcs.shouldRespawn({ respawn: 60 }), true, 'positive respawn must schedule an NPC respawn');
 
+const packets = [];
+const npc = {
+    fetchId: () => 1014747,
+    fetchLocX: () => 0,
+    fetchLocY: () => 0
+};
+const sessionAt = (x, online = true) => ({
+    actor: {
+        fetchLocX: () => x,
+        fetchLocY: () => 0,
+        fetchIsOnline: () => online
+    },
+    dataSendToMe(packet) { packets.push(packet); }
+});
+
+SpawnNpcs.notifyNearby({
+    user: {
+        sessions: [sessionAt(5999), sessionAt(6001), sessionAt(10, false)]
+    }
+}, npc, {
+    npcInfo: (entry) => Buffer.from([0x16, entry.fetchId() & 0xff])
+});
+
+assert.strictEqual(packets.length, 1, 'a respawn must announce itself to nearby online players immediately');
+assert.strictEqual(packets[0][0], 0x16, 'the respawn announcement must be NpcInfo');
+
 console.log('NPC respawn regression checks passed');


### PR DESCRIPTION
## What changed

- Remove cooled bots from connected clients before their server sessions are discarded.
- Send `NpcInfo` immediately to nearby online players when an NPC respawns.

## Why

Clients could retain stale bot objects after population cooldowns. Separately, NPC respawns were added only to the server world; a nearby player who did not cross the environment-refresh movement threshold could be attacked by an NPC the client had never received.

## Player impact

Bots that leave the active population no longer remain as phantom characters. Respawned monsters become visible and selectable before they can aggro nearby players.

## Validation

- `npm run check`
- `npm test`