### PR TITLE
Add bot warehouse storage

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -22,6 +22,7 @@ const tests = [
     'tests/test_bot_cold_travel_without_spot.js',
     'tests/test_bot_cold_market_purchase.js',
     'tests/test_bot_cold_market_listing.js',
+    'tests/test_bot_warehouse.js',
     'tests/test_bot_cold_market_trade_chat.js',
     'tests/test_bot_background_drops.js',
     'tests/test_bot_background_respawn.js',

--- a/src/GameServer/Bot/AI/States/ShoppingState.js
+++ b/src/GameServer/Bot/AI/States/ShoppingState.js
@@ -3,6 +3,7 @@ const ServerResponse = invoke('GameServer/Network/Response');
 const TradeService   = invoke('GameServer/Bot/TradeService');
 const ShotStock      = invoke('GameServer/Inventory/ShotStock');
 const BotTownTravel  = invoke('GameServer/Bot/AI/BotTownTravel');
+const BotWarehouse   = invoke('GameServer/Bot/Economy/BotWarehouseService');
 
 function formatAdena(value) {
     return String(value).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
@@ -99,11 +100,30 @@ module.exports = {
             }
         }
 
+        // Do this before the generic junk-sell bypass: materials and useful
+        // gear that no buyer accepted belong in the bot's own warehouse.
+        let warehouse;
+        try {
+            warehouse = await BotWarehouse.depositActor(bot);
+        } catch (err) {
+            // The generic sell-junk bypass would destroy the very items we
+            // meant to protect, so keep the bag intact and retry next visit.
+            utils.infoWarn('Shopping', 'warehouse deposit failed for %s: %s', bot.fetchName(), err.message);
+            session.lastTradeSummary = 'kept inventory after warehouse deposit failure';
+            BotAI.say(session, 'My warehouse clerk is unavailable. I will keep this bag and try again later.');
+            this.scheduleRestock(session, bot, Generics, BotAI);
+            return;
+        }
+        if (warehouse.count > 0) {
+            const sample = warehouse.items.slice(0, 2).map((item) => `${item.amount}x ${item.name}`).join(', ');
+            BotAI.say(session, `Stored ${sample}${warehouse.items.length > 2 ? ' and more' : ''} in my warehouse.`);
+        }
+
         if (!soldToBuyer) {
             NpcTalkResponse(session, { link: 'sell-junk' });
-            session.lastTradeSummary = `used general sell-junk at ${session.shoppingTarget?.town || 'town'}`;
+            session.lastTradeSummary = `${warehouse.count ? `stored ${warehouse.count}, then ` : ''}used general sell-junk at ${session.shoppingTarget?.town || 'town'}`;
         } else {
-            // Clear leftovers that no local buyer wanted, but keep the market sale as the visible trade event.
+            // Clear only the leftovers that neither a buyer nor the warehouse wanted.
             NpcTalkResponse(session, { link: 'sell-junk' });
         }
 

--- a/src/GameServer/Bot/Economy/BotWarehouseService.js
+++ b/src/GameServer/Bot/Economy/BotWarehouseService.js
@@ -1,0 +1,75 @@
+const Database = invoke('Database');
+const ItemDisposition = invoke('GameServer/Bot/Economy/ItemDisposition');
+
+function itemData(item) {
+    return {
+        id: Number(item.fetchId?.() || item.id),
+        selfId: Number(item.fetchSelfId?.() || item.selfId),
+        name: item.fetchName?.() || item.name || '',
+        amount: Number(item.fetchAmount?.() || item.amount || 0),
+        equipped: !!(item.fetchEquipped?.() || item.equipped),
+        rank: item.fetchRank?.() || item.rank || 'none',
+        kind: item.fetchKind?.() || item.kind || '',
+        stackable: !!(item.fetchStackable?.() || item.stackable),
+        petData: item.fetchPetData?.() || item.petData
+    };
+}
+
+async function depositActor(actor) {
+    const backpack = actor?.backpack;
+    if (!backpack || !actor?.fetchId) return { count: 0, items: [] };
+
+    const stored = [];
+    for (const source of backpack.fetchItems().slice()) {
+        const item = itemData(source);
+        if (!ItemDisposition.isWarehouseCandidate(item)) continue;
+        const result = await Database.transferInventoryToWarehouse(actor.fetchId(), item);
+        if (Number(result.inventoryAmount) === 0) backpack.items = backpack.items.filter((entry) => entry !== source);
+        else source.setAmount(result.inventoryAmount);
+        stored.push({ selfId: item.selfId, name: item.name, amount: item.amount });
+    }
+    return { count: stored.reduce((sum, item) => sum + item.amount, 0), items: stored };
+}
+
+async function depositCold(state) {
+    const candidates = ItemDisposition.warehouseCandidates(state);
+    if (!state || !candidates.length) return { state, count: 0, items: [] };
+
+    const rows = await Database.fetchItems(state.characterId);
+    const inventory = { ...(state.inventory || {}) };
+    const stored = [];
+    for (const candidate of candidates) {
+        let remaining = Number(candidate.amount || 0);
+        const sources = rows.filter((row) => Number(row.selfId) === Number(candidate.selfId) && !row.equipped);
+        // Do not change the cold summary when the physical row changed under us.
+        if (sources.reduce((sum, source) => sum + Number(source.amount || 0), 0) < remaining) continue;
+        for (const source of sources) {
+            if (remaining <= 0) break;
+            const amount = Math.min(remaining, Number(source.amount || 0));
+            await Database.transferInventoryToWarehouse(state.characterId, {
+                id: source.id,
+                selfId: candidate.selfId,
+                name: candidate.name,
+                amount,
+                stackable: !!candidate.stackable,
+                petData: source.petData
+            });
+            source.amount = Number(source.amount || 0) - amount;
+            remaining -= amount;
+        }
+        inventory[String(candidate.selfId)] = { ...candidate, amount: 0 };
+        stored.push({ selfId: candidate.selfId, name: candidate.name, amount: candidate.amount });
+    }
+    if (!stored.length) return { state, count: 0, items: [] };
+    return {
+        state: {
+            ...state,
+            inventory,
+            stats: { ...(state.stats || {}), lastWarehouseDeposit: { items: stored, at: Date.now() } }
+        },
+        count: stored.reduce((sum, item) => sum + item.amount, 0),
+        items: stored
+    };
+}
+
+module.exports = { depositActor, depositCold, itemData };

--- a/src/GameServer/Bot/Economy/ColdMarketListingService.js
+++ b/src/GameServer/Bot/Economy/ColdMarketListingService.js
@@ -1,4 +1,5 @@
 const ItemDisposition = invoke('GameServer/Bot/Economy/ItemDisposition');
+const BotWarehouse = invoke('GameServer/Bot/Economy/BotWarehouseService');
 const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
 const MarketOpportunity = invoke('GameServer/Bot/Economy/MarketOpportunity');
 const { marketStoreTitle } = invoke('GameServer/Bot/Economy/MarketStoreTitle');
@@ -172,15 +173,24 @@ function resolve(state, timestamp = Date.now()) {
         timing: { ...(state.timing || {}), nextResolveAt: timestamp + 30000 }
     };
     MarketOpportunity.removeColdStore(state.characterId);
-    const liquidated = hasStock ? ItemDisposition.npcLiquidationCandidates(nextState) : [];
-    return LifeState.applyNpcLiquidation(nextState, liquidated)
-        .then((liquidatedState) => LifeState.upsertState(liquidatedState || nextState, hasStock ? 'cold_market_expired' : 'cold_market_sold_out'))
-        .then((saved) => ({
-            state: saved || nextState,
-            closed: true,
-            reason: hasStock ? 'expired' : 'sold_out',
-            liquidatedCount: liquidated.reduce((sum, item) => sum + Number(item.count || 0), 0)
-        }));
+    return (hasStock ? BotWarehouse.depositCold(nextState) : Promise.resolve({ state: nextState, count: 0 }))
+        .then((warehouse) => {
+            const storedState = warehouse.state || nextState;
+            const liquidated = hasStock ? ItemDisposition.npcLiquidationCandidates(storedState) : [];
+            return LifeState.applyNpcLiquidation(storedState, liquidated).then((liquidatedState) => ({
+                state: liquidatedState || storedState,
+                warehouseCount: warehouse.count || 0,
+                liquidated
+            }));
+        })
+        .then(({ state: liquidatedState, warehouseCount, liquidated }) => LifeState.upsertState(liquidatedState, hasStock ? 'cold_market_expired' : 'cold_market_sold_out')
+            .then((saved) => ({
+                state: saved || liquidatedState,
+                closed: true,
+                reason: hasStock ? 'expired' : 'sold_out',
+                warehouseCount,
+                liquidatedCount: liquidated.reduce((sum, item) => sum + Number(item.count || 0), 0)
+            })));
 }
 
 function reconcileInventory(state) {

--- a/src/GameServer/Bot/Economy/ItemDisposition.js
+++ b/src/GameServer/Bot/Economy/ItemDisposition.js
@@ -2,6 +2,7 @@ const DataCache = invoke('GameServer/DataCache');
 
 const SELLABLE_KINDS = ['Weapon.', 'Armor.', 'Other.Material'];
 const NPC_LIQUIDATION_MAX_UNIT_PRICE = 1000;
+const WAREHOUSE_GEAR_MIN_BASE_PRICE = 1000;
 
 function templateFor(selfId) {
     return (DataCache.items || []).find((item) => Number(item.selfId) === Number(selfId)) || null;
@@ -54,6 +55,23 @@ function npcLiquidationCandidates(state, options = {}) {
     }));
 }
 
+// Materials remain useful for future crafting/trading regardless of their NPC
+// value. Gear is worth retaining only once it has crossed out of the starter
+// trash band, leaving cheap no-grade drops for liquidation.
+function isWarehouseCandidate(item, template = templateFor(item?.selfId)) {
+    const selfId = Number(item?.selfId || 0);
+    const amount = Number(item?.amount || 0);
+    const kind = item?.kind || template?.template?.kind || '';
+    if (!selfId || selfId === 57 || amount <= 0 || item?.equipped) return false;
+    if (kind.startsWith('Other.Material')) return true;
+    return (kind.startsWith('Weapon.') || kind.startsWith('Armor.'))
+        && basePrice(item, template) > WAREHOUSE_GEAR_MIN_BASE_PRICE;
+}
+
+function warehouseCandidates(state) {
+    return Object.values(state?.inventory || {}).filter((item) => isWarehouseCandidate(item));
+}
+
 function saleSummary(state, options = {}) {
     const items = saleCandidates(state, options);
     return {
@@ -63,4 +81,14 @@ function saleSummary(state, options = {}) {
     };
 }
 
-module.exports = { NPC_LIQUIDATION_MAX_UNIT_PRICE, basePrice, npcLiquidationCandidates, priceFor, saleCandidates, saleSummary };
+module.exports = {
+    NPC_LIQUIDATION_MAX_UNIT_PRICE,
+    WAREHOUSE_GEAR_MIN_BASE_PRICE,
+    basePrice,
+    isWarehouseCandidate,
+    npcLiquidationCandidates,
+    priceFor,
+    saleCandidates,
+    saleSummary,
+    warehouseCandidates
+};

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -86,6 +86,7 @@ function inventorySummaryFromItems(items = []) {
             name: item.fetchName ? item.fetchName() : item.name || itemName(selfId),
             amount: Number(summary[key]?.amount || 0) + amount,
             equipped: !!(item.fetchEquipped ? item.fetchEquipped() : item.equipped),
+            stackable: !!(item.fetchStackable ? item.fetchStackable() : item.stackable),
             slot: Number(item.fetchSlot ? item.fetchSlot() : item.slot || 0),
             rank: item.fetchRank ? item.fetchRank() : item.rank || itemTemplate(selfId)?.etc?.rank || 'none',
             kind: item.fetchKind ? item.fetchKind() : item.kind || itemTemplate(selfId)?.template?.kind || ''

--- a/tests/test_bot_warehouse.js
+++ b/tests/test_bot_warehouse.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const DataCache = invoke('GameServer/DataCache');
+const Database = invoke('Database');
+const ItemDisposition = invoke('GameServer/Bot/Economy/ItemDisposition');
+const BotWarehouse = invoke('GameServer/Bot/Economy/BotWarehouseService');
+
+DataCache.init();
+
+const originals = {
+    fetchItems: Database.fetchItems,
+    transferInventoryToWarehouse: Database.transferInventoryToWarehouse
+};
+
+async function run() {
+    const material = { selfId: 1870, name: 'Animal Bone', amount: 20, kind: 'Other.Material', rank: 'none' };
+    const trash = { selfId: 1, name: 'Short Sword', amount: 1, kind: 'Weapon.Sword', rank: 'none' };
+    const usefulGear = { selfId: 2, name: 'Long Sword', amount: 1, kind: 'Weapon.Sword', rank: 'none' };
+    assert.strictEqual(ItemDisposition.isWarehouseCandidate(material), true, 'materials must be kept even when cheap');
+    assert.strictEqual(ItemDisposition.isWarehouseCandidate(trash), false, 'cheap no-grade gear remains liquidation trash');
+    assert.strictEqual(ItemDisposition.isWarehouseCandidate(usefulGear), true, 'valuable no-grade gear must survive an unsuccessful sale');
+
+    const calls = [];
+    Database.fetchItems = () => Promise.resolve([
+        { id: 31, selfId: 1870, amount: 20, equipped: false },
+        { id: 32, selfId: 2, amount: 1, equipped: false },
+        { id: 33, selfId: 94, amount: 1, equipped: false },
+        { id: 34, selfId: 94, amount: 1, equipped: false }
+    ]);
+    Database.transferInventoryToWarehouse = (characterId, item) => {
+        calls.push({ characterId, ...item });
+        return Promise.resolve({ inventoryAmount: 0, warehouseAmount: item.amount });
+    };
+    const state = {
+        characterId: 55,
+        inventory: {
+            1870: material,
+            1: trash,
+            2: usefulGear,
+            94: { selfId: 94, name: 'Bec de Corbin', amount: 2, kind: 'Weapon.Pole', rank: 'c' }
+        },
+        stats: {}
+    };
+    const result = await BotWarehouse.depositCold(state);
+    assert.strictEqual(result.count, 23);
+    assert.deepStrictEqual(calls.map((item) => item.selfId).sort((a, b) => a - b), [2, 94, 94, 1870]);
+    assert.strictEqual(result.state.inventory['1870'].amount, 0);
+    assert.strictEqual(result.state.inventory['2'].amount, 0);
+    assert.strictEqual(result.state.inventory['94'].amount, 0, 'duplicate non-stackable gear must be deposited from separate item rows');
+    assert.strictEqual(result.state.inventory['1'].amount, 1, 'low-level trash must remain available for NPC liquidation');
+    assert.strictEqual(result.state.stats.lastWarehouseDeposit.items.length, 3);
+
+    const liveItems = [
+        { id: 41, ...material, fetchId() { return this.id; }, fetchSelfId() { return this.selfId; }, fetchName() { return this.name; }, fetchAmount() { return this.amount; }, fetchKind() { return this.kind; }, fetchRank() { return this.rank; }, fetchEquipped() { return false; }, fetchStackable() { return true; } },
+        { id: 42, ...trash, fetchId() { return this.id; }, fetchSelfId() { return this.selfId; }, fetchName() { return this.name; }, fetchAmount() { return this.amount; }, fetchKind() { return this.kind; }, fetchRank() { return this.rank; }, fetchEquipped() { return false; }, fetchStackable() { return false; } }
+    ];
+    const liveBackpack = { items: liveItems, fetchItems() { return this.items; } };
+    const live = await BotWarehouse.depositActor({
+        fetchId: () => 56,
+        backpack: liveBackpack
+    });
+    assert.strictEqual(live.count, 20, 'active bots must also deposit valuable leftovers before sell-junk');
+    assert.deepStrictEqual(liveBackpack.items.map((item) => item.selfId), [1], 'only junk should remain in the active bot backpack');
+    console.log('Bot warehouse checks passed');
+}
+
+run().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+}).finally(() => {
+    Database.fetchItems = originals.fetchItems;
+    Database.transferInventoryToWarehouse = originals.transferInventoryToWarehouse;
+});


### PR DESCRIPTION
## Summary

- bots now transfer unsold materials and valuable unequipped gear into their personal warehouse
- cold market listings store valuable leftovers before liquidating only low-value junk at an NPC
- active bots preserve the same items before their town `sell-junk` fallback
- storage handles valuable no-grade gear, duplicate non-stackable items, and safe recovery from a warehouse write failure

## Why

Bots previously discarded all remaining inventory through generic liquidation after an unsuccessful sale. This kept the economy from retaining resources and useful equipment for later use.

## Validation

- `npm run check`
- `npm test`
- live server observation: warehouse records and cold-market deposit state were persisted successfully
