### PR TITLE
Fix companion party buff reliability

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -14,6 +14,7 @@ const tests = [
     'tests/test_bot_death_respawn.js',
     'tests/test_bot_gear.js',
     'tests/test_bot_gear_skill_hints.js',
+    'tests/test_generated_cold_skills.js',
     'tests/test_bot_goal_state.js',
     'tests/test_bot_goal_planner.js',
     'tests/test_bot_goal_market_priority.js',

--- a/src/GameServer/Actor/Generics/Die.js
+++ b/src/GameServer/Actor/Generics/Die.js
@@ -1,4 +1,19 @@
 const ServerResponse = invoke('GameServer/Network/Response');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
+const EffectTicker = invoke('GameServer/Effects/EffectTicker');
+const calculateStats = invoke('GameServer/Actor/Generics/CalculateStats');
+
+function clearEffectsOnDeath(session, actor) {
+    EffectTicker.clearAll(actor);
+    // Death removes abnormal effects in C4. Clear both the authoritative store
+    // and legacy/UI bookkeeping so a later support pass sees the revived member
+    // as genuinely unbuffed.
+    actor.effects = {};
+    actor.activeBuffs = {};
+    actor.supportReservations = {};
+    EffectStore.prune(actor);
+    calculateStats(session, actor);
+}
 
 function die(session, actor) {
     if (actor.isDead()) {
@@ -6,6 +21,7 @@ function die(session, actor) {
     }
 
     actor.destructor();
+    clearEffectsOnDeath(session, actor);
     // Death cancels the timers that normally release transient action flags
     // (cast, hit, sit animation, pickup). Reset them explicitly so a town
     // restart cannot leave the actor permanently blocked after those timers

--- a/src/GameServer/Bot/AI/BotSupportPlanner.js
+++ b/src/GameServer/Bot/AI/BotSupportPlanner.js
@@ -1,7 +1,37 @@
 const EffectStore = invoke('GameServer/Effects/EffectStore');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 
 const REFRESH_THRESHOLD_MS = 2 * 60 * 1000;
 const CAST_RESERVATION_MS = 5000;
+
+const PHYSICAL_ROLES = new Set(['tank', 'dagger', 'archer', 'dps']);
+const CASTER_ROLES = new Set(['mage', 'healer', 'buffer']);
+const DAMAGE_DEALER_ROLES = new Set(['dagger', 'archer', 'dps']);
+
+// These are single-target buffs whose value depends on the recipient's combat
+// role. Defensive, resistance and movement buffs intentionally stay universal.
+const INDIVIDUAL_BUFF_TARGET_ROLES = {
+    power_of_paagrio: PHYSICAL_ROLES,
+    might: PHYSICAL_ROLES,
+    holy_weapon: PHYSICAL_ROLES,
+    focus: PHYSICAL_ROLES,
+    haste: PHYSICAL_ROLES,
+    guidance: PHYSICAL_ROLES,
+    death_whisper: PHYSICAL_ROLES,
+    chant_of_fury: PHYSICAL_ROLES,
+    chant_of_rage: PHYSICAL_ROLES,
+    vampiric_rage: PHYSICAL_ROLES,
+    eye_of_paagrio: PHYSICAL_ROLES,
+    berserker_spirit: DAMAGE_DEALER_ROLES,
+    rage_of_paagrio: DAMAGE_DEALER_ROLES,
+    soul_of_paagrio: CASTER_ROLES,
+    wisdom_of_paagrio: CASTER_ROLES,
+    blessed_soul: CASTER_ROLES,
+    empower: CASTER_ROLES,
+    concentration: CASTER_ROLES,
+    acumen: CASTER_ROLES,
+    wild_magic: CASTER_ROLES
+};
 
 function supportSkills(actor) {
     const skills = actor?.skillset?.fetchSkills?.() || actor?.skillset?.skills || [];
@@ -11,6 +41,16 @@ function supportSkills(actor) {
             const semantic = skill.fetchSemantic?.();
             return semantic?.effectType === 'buff' && ['friendly', 'ally', 'party'].includes(semantic.target);
         });
+}
+
+function isUsefulForTarget(target, skill) {
+    const semantic = skill?.fetchSemantic?.() || {};
+    // Party skills retain their native all-members behaviour. The role policy
+    // only prevents wasting individual casts on roles that cannot use them.
+    if (semantic.target === 'party' || skill?.fetchTargetKind?.() === 'party') return true;
+
+    const allowedRoles = INDIVIDUAL_BUFF_TARGET_ROLES[semantic.effect];
+    return !allowedRoles || allowedRoles.has(BotRoles.inferRole(target));
 }
 
 function statKeys(skill) {
@@ -88,7 +128,7 @@ function allActions(members, providers, respectReservations = true) {
     return members
         .filter((member) => member?.actor && !member.actor.state?.fetchDead?.())
         .flatMap((member) => providers.flatMap((provider) => supportSkills(provider)
-            .filter((skill) => canCast(provider, skill) && needsSkill(member.actor, skill) && (!respectReservations || !isReserved(member.actor, skill)))
+            .filter((skill) => isUsefulForTarget(member.actor, skill) && canCast(provider, skill) && needsSkill(member.actor, skill) && (!respectReservations || !isReserved(member.actor, skill)))
             .map((skill) => ({ provider, target: member.actor, leader: member.leader === true, skill, effect: skill.fetchSemantic().effect }))));
 }
 
@@ -113,6 +153,7 @@ module.exports = {
     REFRESH_THRESHOLD_MS,
     CAST_RESERVATION_MS,
     supportSkills,
+    isUsefulForTarget,
     needsSkill,
     actionCompare,
     reserve,

--- a/src/GameServer/Bot/AI/BotSupportPlanner.js
+++ b/src/GameServer/Bot/AI/BotSupportPlanner.js
@@ -32,11 +32,9 @@ function needsSkill(target, skill) {
     const current = EffectStore.list(target, { includeDebuffs: false })
         .filter((effect) => overlaps(effect, keys));
 
-    // Older actors may still carry the temporary activeBuffs marker until their
-    // first structured effect update. Treat it as an active equal-or-better buff.
-    if (current.length === 0 && semantic.effect && Number(target?.activeBuffs?.[semantic.effect] || 0) > Date.now()) {
-        return false;
-    }
+    // `activeBuffs` is retained for packet/UI compatibility only. It can outlive
+    // an effect after death, dispel, or an interrupted cast, so support decisions
+    // must be based exclusively on the target's structured effect state.
     if (current.some((effect) => Number(effect.level || 0) > level)) return false;
     if (current.some((effect) => Number(effect.level || 0) === level && EffectStore.remainingMs(target, effect.key) > REFRESH_THRESHOLD_MS)) {
         return false;

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -455,26 +455,11 @@ const BotAI = {
     },
 
     say(session, text) {
-        if (!session.actor) return;
-        const ServerResponse = invoke('GameServer/Network/Response');
-        session.dataSendToOthers(
-            ServerResponse.speak(session.actor, { kind: 0x00, text: text }),
-            session.actor
-        );
+        invoke('GameServer/Bot/BotManager').botSay(session, text);
     },
 
     tell(session, targetSession, text) {
-        if (!session.actor || !targetSession || !targetSession.dataSendToMe) return;
-        const BotChatText = invoke('GameServer/Bot/AI/BotChatText');
-        const lines = BotChatText.splitForTell(text);
-        if (!lines.length) return;
-
-        const ServerResponse = invoke('GameServer/Network/Response');
-        lines.forEach((line) => {
-            targetSession.dataSendToMe(
-                ServerResponse.speak(session.actor, { kind: 2, text: line })
-            );
-        });
+        invoke('GameServer/Bot/BotManager').botTell(session, targetSession, text);
     },
 
     trade(session, text) {

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -467,14 +467,21 @@ const BotManager = {
             if (!firstCharacter) return;
 
             const firstStoreCfg = merchantConfigFor(botData, firstCharacter.name);
-            const gearReady = (firstStoreCfg
+            // Cold-generated characters may have been created before their
+            // profile skills were persisted. Reconcile them before loading the
+            // runtime actor so active companions never keep a level-one kit.
+            const skillsReady = this.awardProfileSkills(firstCharacter.id, {
+                classId: firstCharacter.classId,
+                level: firstCharacter.level
+            });
+            const gearReady = skillsReady.then(() => (firstStoreCfg
                 ? Promise.resolve()
                 : BotGear.ensureCharacterGear(firstCharacter, botData))
                 .then(() => ShotStock.ensureCharacterStock(firstCharacter.id, {
                     classId: firstCharacter.classId,
                     targetAmount: ShotStock.DEFAULT_TARGET_AMOUNT
                 }))
-                .then(() => Shared.fetchCharacters(username));
+                .then(() => Shared.fetchCharacters(username)));
 
             gearReady.then((readyCharacters) => {
                 const character = readyCharacters[0];
@@ -649,7 +656,7 @@ const BotManager = {
                         `Hello there! Ready to kill some keltirs?`,
                         `Hi! Beautiful day to hunt, isn't it?`
                     ];
-                    this.botSay(session, phrases[Math.floor(Math.random() * phrases.length)]);
+                    this.botSay(session, phrases[Math.floor(Math.random() * phrases.length)], playerSession);
                 }, 1000 + Math.random() * 1000);
             }
 
@@ -661,7 +668,7 @@ const BotManager = {
             )) {
                 handledByRule = true;
                 setTimeout(() => {
-                    this.botSay(session, `I take no orders, ${player.fetchName()}.`);
+                    this.botSay(session, `I take no orders, ${player.fetchName()}.`, playerSession);
                 }, 500 + Math.random() * 500);
             }
 
@@ -669,7 +676,7 @@ const BotManager = {
                 handledByRule = true;
                 setTimeout(() => {
                     if (session.partyCompanion === true && session.followPlayerSession === playerSession) {
-                        this.botSay(session, `Sure! I will follow you and assist in combat.`);
+                        this.botSay(session, `Sure! I will follow you and assist in combat.`, playerSession);
                         session.plan = 'following';
                     } else {
                         this.botTell(session, playerSession, `I can come closer, but invite me if you want party follow.`);
@@ -688,7 +695,7 @@ const BotManager = {
             else if (directCommandTarget && (text.includes("stop") || text.includes("стой") || text.includes("wait"))) {
                 handledByRule = true;
                 setTimeout(() => {
-                    this.botSay(session, `Staying here! Let me know if you need help.`);
+                    this.botSay(session, `Staying here! Let me know if you need help.`, playerSession);
                     session.plan = 'resting';
                     bot.moveTo({
                         from: { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() },
@@ -700,7 +707,7 @@ const BotManager = {
             else if (directCommandTarget && (text.includes("hunt") || text.includes("иди качайся") || text.includes("кач"))) {
                 handledByRule = true;
                 setTimeout(() => {
-                    this.botSay(session, `Alright, returning to hunt keltirs!`);
+                    this.botSay(session, `Alright, returning to hunt keltirs!`, playerSession);
                     if (session.followPlayerSession === playerSession && session.partyCompanion === true) {
                         BotSocialMemory.recordEvent(playerSession, session, 'party_dismissed', 'chat_hunt');
                     }
@@ -766,6 +773,12 @@ const BotManager = {
         }
 
         if (request.buff) {
+            // A direct "buff" request is not a general conversation prompt.
+            // Classes without a learned friendly/party support skill (for
+            // example tanks) should simply ignore it instead of advertising a
+            // missing buff service.
+            if (BotSupportPlanner.supportSkills(bot).length === 0) return false;
+
             const providers = this.sessions
                 .filter((session) => session?.actor && (
                     session === botSession ||
@@ -817,8 +830,38 @@ const BotManager = {
         return false;
     },
 
-    botSay(session, text) {
+    partyChatRecipients(session, targetSession = null) {
+        const leaderSession = session?.partyCompanion === true ? session.followPlayerSession : null;
+        if (!leaderSession?.actor) return [];
+
+        const companions = this.sessions.filter((candidate) => (
+            candidate?.partyCompanion === true &&
+            candidate.followPlayerSession === leaderSession &&
+            candidate.actor
+        ));
+        if (targetSession && targetSession !== leaderSession && !companions.includes(targetSession)) return [];
+
+        return [leaderSession, ...companions].filter((candidate) => typeof candidate.dataSendToMe === 'function');
+    },
+
+    botPartySay(session, text, targetSession = null) {
+        if (!session?.actor) return false;
+        const recipients = this.partyChatRecipients(session, targetSession);
+        if (recipients.length === 0) return false;
+
+        const ServerResponse = invoke('GameServer/Network/Response');
+        const packet = ServerResponse.speak(session.actor, { kind: 3, text: text });
+        recipients.forEach((recipient) => recipient.dataSendToMe(packet));
+        return true;
+    },
+
+    botSay(session, text, targetSession = null) {
         if (!session.actor) return;
+        if (targetSession && this.partyChatRecipients(session, targetSession).length === 0) {
+            this.botTell(session, targetSession, text);
+            return;
+        }
+        if (this.botPartySay(session, text, targetSession)) return;
         const ServerResponse = invoke('GameServer/Network/Response');
         session.dataSendToOthers(
             ServerResponse.speak(session.actor, { kind: 0x00, text: text }),
@@ -831,6 +874,11 @@ const BotManager = {
         const BotChatText = invoke('GameServer/Bot/AI/BotChatText');
         const lines = BotChatText.splitForTell(text);
         if (!lines.length) return;
+
+        if (this.partyChatRecipients(session, targetSession).length > 0) {
+            lines.forEach((line) => this.botPartySay(session, line, targetSession));
+            return;
+        }
 
         const ServerResponse = invoke('GameServer/Network/Response');
         lines.forEach((line) => {

--- a/src/GameServer/Bot/Population/GeneratedColdSeeder.js
+++ b/src/GameServer/Bot/Population/GeneratedColdSeeder.js
@@ -7,6 +7,7 @@ const SpotProfiles = invoke('GameServer/Bot/Population/SpotProfiles');
 const LevelingRoutes = invoke('GameServer/Bot/AI/LevelingRoutes');
 const GearSkillHints = invoke('GameServer/Bot/AI/GearSkillHints');
 const ShotStock = invoke('GameServer/Inventory/ShotStock');
+const Skillset = invoke('GameServer/Actor/Skillset');
 
 const CLASS_POOL = [
     { race: 0, classId: 0, sex: 0, role: 'dps' },
@@ -151,6 +152,12 @@ function awardBaseSkills(characterId, classId) {
     });
 }
 
+function awardProfileSkills(characterId, classId, level) {
+    const targetLevel = Math.max(1, Number(level) || 1);
+    if (targetLevel <= 1) return Promise.resolve();
+    return new Skillset().awardSkills(characterId, classId, targetLevel);
+}
+
 function ensureAdena(characterId, amount) {
     return Database.fetchItems(characterId).then((existing) => {
         const adena = (existing || []).find((item) => Number(item.selfId) === 57);
@@ -163,9 +170,10 @@ function ensureAdena(characterId, amount) {
     });
 }
 
-function ensureBaseLoadout(characterId, classId, adena) {
+function ensureBaseLoadout(characterId, classId, adena, level = 1) {
     return awardBaseGear(characterId, classId)
         .then(() => awardBaseSkills(characterId, classId))
+        .then(() => awardProfileSkills(characterId, classId, level))
         .then(() => ensureAdena(characterId, adena))
         .then(() => ShotStock.ensureCharacterStock(characterId, {
             classId,
@@ -186,7 +194,7 @@ function ensureCharacter(username, index) {
             const character = characters[0];
             const level = Number(character.level || profileForIndex(index).level);
             const adena = Number(character.adena || Math.round(level * 85));
-            return ensureBaseLoadout(character.id, character.classId, adena)
+            return ensureBaseLoadout(character.id, character.classId, adena, level)
                 .then(() => ({ character: { ...character, adena }, created: false }));
         }
 
@@ -216,7 +224,8 @@ function ensureCharacter(username, index) {
                 sp: Math.round(level * level * 3),
                 adena: Math.round(level * 85)
             };
-            return ensureBaseLoadout(character.id, base.classId, character.adena)
+            return Database.updateCharacterExperience(character.id, level, character.exp, character.sp)
+                .then(() => ensureBaseLoadout(character.id, base.classId, character.adena, level))
                 .then(() => ({ character, created: true, base, spot, levelProfile, vitals, loc }));
         });
     });
@@ -285,6 +294,8 @@ function stateFor(character, index, seedMeta = {}) {
 
 const GeneratedColdSeeder = {
     running: false,
+
+    awardProfileSkills,
 
     seedToTarget(target = Config.generatedColdTarget) {
         const desired = Math.max(0, Number(target || 0));

--- a/tests/test_bot_chat_commands.js
+++ b/tests/test_bot_chat_commands.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 require('../src/Global');
 
 const BotManager = invoke('GameServer/Bot/BotManager');
+const BotAI = invoke('GameServer/Bot/BotAI');
 const BotSocialMemory = invoke('GameServer/Bot/AI/BotSocialMemory');
 const Generics = invoke(path.actor);
 const SkillModel = invoke('GameServer/Model/Skill');
@@ -123,6 +124,45 @@ try {
     supportCast = null;
     BotManager.handlePlayerSpeak(playerSession, { text: 'heal me' });
     assert.strictEqual(supportCast, null, 'direct support should reject a heal the bot has not learned');
+
+    const partyPackets = [];
+    const partyBot = fakeActor(2000012, 'PartyBot', { locX: 100 });
+    const partyBotSession = fakeSession('bot_party', partyBot);
+    partyBotSession.partyCompanion = true;
+    partyBotSession.followPlayerSession = playerSession;
+    partyBotSession.dataSendToOthers = () => {
+        throw new Error('party companion chat must not use nearby chat');
+    };
+    playerSession.dataSendToMe = (packet) => partyPackets.push(packet);
+    BotManager.sessions = [partyBotSession];
+    BotManager.botSay(partyBotSession, 'Party call');
+    BotManager.botTell(partyBotSession, playerSession, 'Direct party call');
+    BotAI.say(partyBotSession, 'AI party call');
+    BotAI.tell(partyBotSession, playerSession, 'AI direct party call');
+    assert.deepStrictEqual(
+        partyPackets.map((packet) => packet.readInt32LE(5)),
+        [3, 3, 3, 3],
+        'companion messages to its leader must use the party-chat channel, including BotAI messages'
+    );
+    const outsidePackets = [];
+    const outsideSession = fakeSession('outside_player', fakeActor(2000013, 'OutsidePlayer'));
+    outsideSession.dataSendToMe = (packet) => outsidePackets.push(packet);
+    BotManager.botTell(partyBotSession, outsideSession, 'External tell');
+    assert.deepStrictEqual(outsidePackets.map((packet) => packet.readInt32LE(5)), [2], 'a message outside the party must remain a private tell');
+    BotManager.botSay(partyBotSession, 'External reply', outsideSession);
+    assert.deepStrictEqual(outsidePackets.map((packet) => packet.readInt32LE(5)), [2, 2], 'an addressed reply outside the party must remain a private tell');
+
+    const tank = fakeActor(2000011, 'TankWithoutBuffs', { classId: 1, mp: 30, locX: 100 });
+    const tankSession = fakeSession('bot_tank', tank);
+    const tankReplies = [];
+    BotManager.sessions = [tankSession];
+    BotManager.botTell = (_botSession, _playerSession, text) => tankReplies.push(text);
+    player.fetchDestId = () => tank.fetchId();
+    supportCast = null;
+    BotManager.handlePlayerSpeak(playerSession, { text: 'buff me' });
+    assert.strictEqual(supportCast, null, 'a bot without friendly support skills must not cast a buff');
+    assert.deepStrictEqual(tankReplies, [], 'a bot without friendly support skills must ignore a direct buff request');
+    BotManager.botTell = originalBotTell;
 
     const buffer = fakeActor(2000008, 'MageWithBuff', { classId: 25, mp: 30, locX: 100 });
     buffer.skillset.skills.push(new SkillModel({

--- a/tests/test_bot_support_planner.js
+++ b/tests/test_bot_support_planner.js
@@ -36,6 +36,13 @@ const shaman = actor('Noren', 49, [soulShieldTwo]);
 const mage = actor('Saren', 25, [shieldOne]);
 const target = actor('Slava', 0);
 
+target.activeBuffs = { shield: Date.now() + (10 * 60 * 1000) };
+assert.strictEqual(
+    BotSupportPlanner.needsSkill(target, shieldOne),
+    true,
+    'a legacy UI marker without a structured effect must not block a rebuff'
+);
+
 EffectStore.apply(target, { key: 'shield', id: 1040, level: 1, type: 'buff', stats: { pDefMul: 1.08 }, durationMs: 10 * 60 * 1000 });
 assert.strictEqual(BotSupportPlanner.needsSkill(target, shieldOne), false, 'do not overwrite an equal-level active buff');
 assert.strictEqual(BotSupportPlanner.needsSkill(target, soulShieldTwo), true, 'upgrade an active defensive buff when the party has a higher level');
@@ -79,5 +86,14 @@ assert.strictEqual(
 );
 action = BotSupportPlanner.nextAction(partyCaster, [{ actor: partyTarget, leader: true }], [singleCaster, partyCaster]);
 assert.strictEqual(action.skill.fetchSelfId(), 3040, 'the mass buff provider should be selected first');
+
+EffectStore.apply(partyTarget, { key: 'party_shield', id: 3040, level: 1, type: 'buff', stats: { pDefMul: 1.08 }, durationMs: 10 * 60 * 1000 });
+const newPartyMember = actor('NewPartyMember', 0);
+action = BotSupportPlanner.nextAction(
+    partyCaster,
+    [{ actor: partyTarget, leader: true }, { actor: newPartyMember, leader: false }],
+    [partyCaster]
+);
+assert.strictEqual(action.target, newPartyMember, 'a newly added unbuffed member should start the next party-buff pass');
 
 console.log('Bot support planner checks passed');

--- a/tests/test_bot_support_planner.js
+++ b/tests/test_bot_support_planner.js
@@ -96,4 +96,29 @@ action = BotSupportPlanner.nextAction(
 );
 assert.strictEqual(action.target, newPartyMember, 'a newly added unbuffed member should start the next party-buff pass');
 
+const might = skill(1068, 'Might', 2, 'might', { pAtkMul: 1.12 });
+const concentration = skill(1078, 'Concentration', 3, 'concentration', { cancelAdd: -36 });
+const berserkerSpirit = skill(1062, 'Berserker Spirit', 2, 'berserker_spirit', { pAtkMul: 1.08, pDefMul: 0.92 });
+const blessShield = skill(1243, 'Bless Shield', 1, 'bless_shield', { rShldMul: 1.05 });
+const roleAwareBuffer = actor('RoleAwareBuffer', 49, [might, concentration]);
+const roleMage = actor('RoleMage', 25);
+const roleArcher = actor('RoleArcher', 9);
+const roleTank = actor('RoleTank', 4);
+assert.strictEqual(BotSupportPlanner.isUsefulForTarget(roleMage, might), false, 'Might should not be assigned to a mage');
+assert.strictEqual(BotSupportPlanner.isUsefulForTarget(roleArcher, might), true, 'Might should be assigned to an archer');
+assert.strictEqual(BotSupportPlanner.isUsefulForTarget(roleArcher, concentration), false, 'Concentration should not be assigned to a physical fighter');
+assert.strictEqual(BotSupportPlanner.isUsefulForTarget(roleMage, concentration), true, 'Concentration should be assigned to a caster');
+assert.strictEqual(BotSupportPlanner.isUsefulForTarget(roleTank, berserkerSpirit), false, 'Berserker Spirit should not lower a tank\'s defences');
+assert.strictEqual(BotSupportPlanner.isUsefulForTarget(roleMage, berserkerSpirit), false, 'Berserker Spirit should not be assigned to a caster');
+assert.strictEqual(BotSupportPlanner.isUsefulForTarget(roleArcher, berserkerSpirit), true, 'Berserker Spirit should be assigned to a damage dealer');
+assert.strictEqual(BotSupportPlanner.isUsefulForTarget(roleMage, blessShield), true, 'defensive shield buffs should remain available to casters');
+const physicalBuffer = actor('PhysicalBuffer', 49, [might]);
+action = BotSupportPlanner.nextAction(physicalBuffer, [
+    { actor: roleMage, leader: true },
+    { actor: roleArcher, leader: false }
+], [physicalBuffer]);
+assert.strictEqual(action.target, roleArcher, 'the next individual physical buff should skip the mage and target the archer');
+assert.strictEqual(action.skill.fetchSelfId(), 1068, 'the physical buff should be chosen for the physical target');
+assert.strictEqual(BotSupportPlanner.isUsefulForTarget(roleMage, partyShield), true, 'party buffs should remain available to every party role');
+
 console.log('Bot support planner checks passed');

--- a/tests/test_generated_cold_skills.js
+++ b/tests/test_generated_cold_skills.js
@@ -1,0 +1,46 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const DataCache = invoke('GameServer/DataCache');
+const Database = invoke('Database');
+const GeneratedColdSeeder = invoke('GameServer/Bot/Population/GeneratedColdSeeder');
+
+DataCache.init();
+
+const original = {
+    fetchSkill: Database.fetchSkill,
+    fetchSkills: Database.fetchSkills,
+    setSkill: Database.setSkill,
+    updateSkillLevel: Database.updateSkillLevel
+};
+const stored = [];
+
+try {
+    Database.fetchSkill = (characterId, selfId) => Promise.resolve(stored.filter((skill) => skill.selfId === selfId));
+    Database.fetchSkills = () => Promise.resolve(stored);
+    Database.setSkill = (skill) => {
+        stored.push({ selfId: skill.selfId, name: skill.name, level: skill.level, passive: skill.passive });
+        return Promise.resolve();
+    };
+    Database.updateSkillLevel = (characterId, selfId, level) => {
+        const skill = stored.find((entry) => entry.selfId === selfId);
+        if (skill) skill.level = level;
+        return Promise.resolve();
+    };
+
+    GeneratedColdSeeder.awardProfileSkills(1, 38, 16).then(() => {
+        assert.ok(stored.some((skill) => skill.selfId === 1040), 'a level 16 Dark Wizard should receive Shield from its class tree');
+        assert.ok(stored.some((skill) => skill.selfId === 1011), 'a level 16 Dark Wizard should receive its available heal skill');
+        assert.ok(stored.some((skill) => skill.selfId === 1206), 'a level 16 Dark Wizard should receive Wind Shackle from its class tree');
+        console.log('Generated cold skill checks passed');
+    }).catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    }).finally(() => {
+        Object.assign(Database, original);
+    });
+} catch (error) {
+    Object.assign(Database, original);
+    throw error;
+}

--- a/tests/test_party_buff_targets.js
+++ b/tests/test_party_buff_targets.js
@@ -37,6 +37,15 @@ try {
     };
     const targets = new Attack().resolveSkillTargets(casterSession, caster, leader, partyBuff);
     assert.deepStrictEqual(targets.map((target) => target.fetchId()), [1, 2, 3], 'a party buff should fan out to every active companion-party member');
+
+    const newMember = actor(4);
+    World.user.sessions.push({
+        actor: newMember,
+        partyCompanion: true,
+        followPlayerSession: leaderSession
+    });
+    const updatedTargets = new Attack().resolveSkillTargets(casterSession, caster, leader, partyBuff);
+    assert.deepStrictEqual(updatedTargets.map((target) => target.fetchId()), [1, 2, 3, 4], 'a party buff should include a member added after the party was formed');
 } finally {
     World.user = originalUsers;
 }

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -653,8 +653,13 @@ try {
     bufferSession.followPlayerSession = bufferLeaderSession;
     bufferSession.partyCompanion = true;
     bufferSession.plan = 'following';
+    EffectStore.apply(bufferLeader, {
+        key: 'shield', id: 1040, level: 1, type: 'buff', stats: { pDefMul: 1.08 }, durationMs: 10 * 60 * 1000
+    });
+    EffectStore.apply(bufferBot, {
+        key: 'shield', id: 1040, level: 1, type: 'buff', stats: { pDefMul: 1.08 }, durationMs: 10 * 60 * 1000
+    });
     const unbuffedCompanion = fakeActor(2000029, { locX: 120, locY: 0 });
-    unbuffedCompanion.activeBuffs.shield = 0;
     const unbuffedCompanionSession = fakeSession('bot_unbuffed_party', unbuffedCompanion);
     unbuffedCompanionSession.followPlayerSession = bufferLeaderSession;
     unbuffedCompanionSession.partyCompanion = true;

--- a/tests/test_restart_point_revive.js
+++ b/tests/test_restart_point_revive.js
@@ -5,10 +5,68 @@ require('../src/Global');
 const die = invoke('GameServer/Actor/Generics/Die');
 const revive = invoke('GameServer/Actor/Generics/Revive');
 const StateModel = invoke('GameServer/Model/State');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
+const calculateStats = invoke('GameServer/Actor/Generics/CalculateStats');
 
 const dyingActor = {
     state: new StateModel(),
+    level: 20,
+    classId: 0,
+    hp: 100,
+    mp: 100,
     fetchId: () => 41,
+    fetchLevel() { return this.level; },
+    fetchClassId() { return this.classId; },
+    fetchCon: () => 30,
+    fetchMen: () => 30,
+    fetchStr: () => 30,
+    fetchDex: () => 30,
+    fetchInt: () => 30,
+    fetchWit: () => 30,
+    fetchHp() { return this.hp; },
+    fetchMp() { return this.mp; },
+    fetchMaxHp() { return this.maxHp; },
+    fetchMaxMp() { return this.maxMp; },
+    fetchPAtk: () => 10,
+    fetchMAtk: () => 10,
+    fetchPDef: () => 10,
+    fetchMDef: () => 10,
+    fetchAccur: () => 0,
+    fetchEvasion: () => 0,
+    fetchCritical: () => 40,
+    fetchAtkSpd: () => 300,
+    fetchWalkSpd: () => 80,
+    fetchRunSpd: () => 120,
+    isSpellcaster: () => 0,
+    setMaxHp(value) { this.maxHp = value; },
+    setHp(value) { this.hp = value; },
+    setMaxMp(value) { this.maxMp = value; },
+    setMp(value) { this.mp = value; },
+    setMaxLoad(value) { this.maxLoad = value; },
+    setLoad(value) { this.load = value; },
+    setCollectivePAtk(value) { this.collectivePAtk = value; },
+    setCollectiveMAtk(value) { this.collectiveMAtk = value; },
+    setCollectivePDef(value) { this.collectivePDef = value; },
+    setCollectiveMDef(value) { this.collectiveMDef = value; },
+    setCollectiveAccur(value) { this.collectiveAccur = value; },
+    setCollectiveEvasion(value) { this.collectiveEvasion = value; },
+    setCollectiveCritical(value) { this.collectiveCritical = value; },
+    setCollectiveAtkSpd(value) { this.collectiveAtkSpd = value; },
+    setCollectiveCastSpd(value) { this.collectiveCastSpd = value; },
+    setCollectiveWalkSpd(value) { this.collectiveWalkSpd = value; },
+    setCollectiveRunSpd(value) { this.collectiveRunSpd = value; },
+    backpack: {
+        fetchTotalArmorBonusMp: () => 0,
+        fetchTotalLoad: () => 0,
+        fetchTotalWeaponPAtk: () => 100,
+        fetchTotalWeaponMAtk: () => 50,
+        fetchTotalArmorPDef: () => 100,
+        fetchTotalArmorMDef: () => 80,
+        fetchTotalWeaponAccur: () => 5,
+        fetchTotalArmorEvasion: () => 2,
+        fetchTotalWeaponCritical: () => 40,
+        fetchTotalWeaponAtkSpd: () => 300
+    },
     isDead() { return this.state.fetchDead(); },
     destructor() {}
 };
@@ -17,11 +75,20 @@ dyingActor.state.setCasts(true);
 dyingActor.state.setSeated(true);
 dyingActor.state.setAnimated(true);
 dyingActor.state.setPickinUp(true);
+EffectStore.apply(dyingActor, { key: 'shield', id: 1040, type: 'buff', stats: { pDefMul: 1.12 }, durationMs: 60000 });
+dyingActor.activeBuffs = { shield: Date.now() + 60000 };
+dyingActor.supportReservations = { shield: { expiresAt: Date.now() + 5000 } };
+calculateStats({}, dyingActor);
+const buffedPDef = dyingActor.collectivePDef;
 
 die({ dataSendToMeAndOthers() {} }, dyingActor);
 
 assert.strictEqual(dyingActor.state.fetchDead(), true, 'death should mark the actor dead');
 assert.strictEqual(dyingActor.state.isBlocked(), false, 'death should clear action flags whose cancellation would otherwise permanently block movement after a restart');
+assert.deepStrictEqual(EffectStore.list(dyingActor), [], 'death should remove active effects');
+assert.deepStrictEqual(dyingActor.activeBuffs, {}, 'death should clear legacy buff markers');
+assert.deepStrictEqual(dyingActor.supportReservations, {}, 'death should clear stale support reservations');
+assert.ok(dyingActor.collectivePDef < buffedPDef, 'death should recalculate stats without removed buff bonuses');
 
 const packets = [];
 const actor = {


### PR DESCRIPTION
## What changed
- Restored profile-level skills for generated cold bots and reconciled them before hot activation.
- Made individual support buffs role-aware while preserving defensive shield buffs for casters.
- Cleared stale buff state after death and kept support decisions based on active effects.
- Routed companion-party messages through party chat, while replies to players outside the party remain private tells.

## Why
Generated high-level bots could retain only level-one skills. Party support could then misreport availability, choose unsuitable targets, or send companion chatter to nearby chat.

## Validation
- `npm test`
- `npm run check`
- Party companion, support planner, chat-command, party-target, and generated-cold-skill regressions