### PR TITLE
Keep cold bots off the Giran plaza

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -45,6 +45,7 @@ const tests = [
     'tests/test_bot_population_state.js',
     'tests/test_bot_population_policy.js',
     'tests/test_bot_population_cooldown_cleanup.js',
+    'tests/test_bot_cold_state_context.js',
     'tests/test_bot_pvp_risk.js',
     'tests/test_pk_hunting_state.js',
     'tests/test_pk_chat_guard.js',

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -568,6 +568,7 @@ const BotManager = {
                         session.plan = botData.plan || 'hunting';
                         session.backgroundActivity = botData.backgroundActivity || session.plan;
                         session.currentSpot = botData.currentSpot || null;
+                        session.coldLifeState = botData.coldLifeState || null;
                         if (botData.spawnReady !== false) {
                             this.prepareBotForSpawn(session, botData);
                         }

--- a/src/GameServer/Bot/Economy/ColdCraftingService.js
+++ b/src/GameServer/Bot/Economy/ColdCraftingService.js
@@ -267,9 +267,30 @@ async function craft(state, random = Math.random) {
         }
     });
     const continueCrafting = componentCraft && !!readyRecipeFor(refreshed, finalRecipe);
+    const returnAfterComponent = componentCraft && !continueCrafting && craftReturn?.loc;
     const settled = continueCrafting
         ? { ...refreshed, activity: 'crafting' }
-        : refreshed;
+        : returnAfterComponent ? {
+            ...refreshed,
+            activity: 'traveling',
+            stats: {
+                ...(refreshed.stats || {}),
+                craftReturn: null,
+                travel: {
+                    from: { ...(state.loc || station.loc) },
+                    to: { ...craftReturn.loc },
+                    startedAt: timestamp,
+                    arrivalAt: timestamp + NATIVE_TRAVEL_MS,
+                    townName: craftReturn.regionName || 'Hunting Ground',
+                    regionName: craftReturn.regionName || state.currentRegion,
+                    viaTown: returnTown?.name || null,
+                    method: 'gatekeeper_spot',
+                    spotId: craftReturn.spotId || null,
+                    arrivalActivity: 'hunting',
+                    reason: 'component_craft_return'
+                }
+            }
+        } : refreshed;
     return {
         state: settled,
         crafted: success,

--- a/src/GameServer/Bot/Population/BackgroundResolver.js
+++ b/src/GameServer/Bot/Population/BackgroundResolver.js
@@ -92,7 +92,7 @@ function resolveTravel(state, timestamp = Date.now()) {
         // Routes persisted before native cold travel had no method.  Treat the
         // known long-distance lifecycle reasons as native too, so a restart
         // does not leave old craft/market travellers visibly map-walking.
-        || ['component_craft', 'equipment_craft', 'equipment_craft_return', 'return_after_market'].includes(travel.reason);
+        || ['component_craft', 'component_craft_return', 'equipment_craft', 'equipment_craft_return', 'return_after_market'].includes(travel.reason);
     const startedAt = Number(travel.startedAt || timestamp);
     const arrivalAt = Number(travel.arrivalAt);
     const progress = isLegacyGiranMarketTrip ? 1 : nativeTransit

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -3,6 +3,7 @@ const Metrics  = invoke('GameServer/Bot/Population/PopulationMetrics');
 const DataCache = invoke('GameServer/DataCache');
 const Config = invoke('GameServer/Bot/Population/PopulationConfig');
 const CraftShopService = invoke('GameServer/Bot/Economy/CraftShopService');
+const SpotService = invoke('GameServer/Bot/AI/SpotService');
 
 const TABLE = 'bot_life_state';
 const GearSkillHints = invoke('GameServer/Bot/AI/GearSkillHints');
@@ -432,6 +433,57 @@ function recoverStaleHotStates() {
     });
 }
 
+function mergeSessionIntoLifeState(session, state, phase, reason = '', options = {}) {
+    const observed = recordFromSession(session, phase, reason);
+    const observedStats = parseJson(observed.statsJson, {});
+    const observedInventory = parseJson(observed.inventorySummary, {});
+    const timestamp = now();
+    return {
+        ...state,
+        accountName: observed.accountName,
+        name: observed.characterName,
+        level: observed.level,
+        exp: observed.exp,
+        sp: observed.sp,
+        adena: observed.adena,
+        phase,
+        activity: options.activity || state.activity || observed.activity,
+        loc: options.loc || state.loc || { locX: observed.locX, locY: observed.locY, locZ: observed.locZ },
+        vitals: { hp: observed.hp, maxHp: observed.maxHp, mp: observed.mp, maxMp: observed.maxMp },
+        levelBand: observed.targetLevelBand || state.levelBand,
+        timing: {
+            ...(state.timing || {}),
+            activityStartedAt: timestamp,
+            nextResolveAt: options.nextResolveAt ?? state.timing?.nextResolveAt ?? null,
+            lastHotAt: phase === 'hot' ? timestamp : state.timing?.lastHotAt || null
+        },
+        stats: { ...(state.stats || {}), ...observedStats, lastReason: reason },
+        inventory: observedInventory
+    };
+}
+
+function shouldRecoverOrphanedGiranState(state = {}) {
+    if (state.phase !== 'cold' || state.currentRegion !== 'Giran' || !state.spotId) return false;
+    if (['traveling', 'shopping', 'merchant', 'crafting'].includes(state.activity)) return false;
+    const stats = state.stats || {};
+    // An ordinary bot may be in Giran only while traveling, shopping, or
+    // running a store. Any remaining market/craft metadata on a resting or
+    // hunting bot is stale context, not an active reason to occupy the plaza.
+    return !stats.marketStore && !stats.craftShop;
+}
+
+function recoverOrphanedGiranState(state = {}) {
+    if (!shouldRecoverOrphanedGiranState(state)) return state;
+    const spot = SpotService.findById(state.spotId);
+    if (!spot?.center) return state;
+    return {
+        ...state,
+        currentRegion: state.homeRegion || state.currentRegion,
+        loc: SpotService.randomPointNear(spot, 400),
+        timing: { ...(state.timing || {}), nextResolveAt: now() + 30000 }
+    };
+}
+
 function recoverStaleCraftWaits() {
     const timestamp = now();
     return Database.execute([
@@ -493,6 +545,13 @@ const BotLifeState = {
             )`,
             []
         ]).then(() => ensureColumns()).then(() => recoverStaleHotStates()).then(() => recoverStaleCraftWaits()).then(() => hydrateCache()).then((count) => {
+            const repairs = [...cache.values()]
+                .map(recoverOrphanedGiranState)
+                .filter((state) => state !== cache.get(state.characterId));
+            return repairs.reduce((chain, state) => chain.then(() => save(rowFromState(state)).then(() => {
+                cache.set(state.characterId, state);
+            })), Promise.resolve()).then(() => count);
+        }).then((count) => {
             initialized = true;
             utils.infoSuccess('BotLife', 'state table ready states=%d', count);
             return true;
@@ -507,7 +566,14 @@ const BotLifeState = {
     markHot(session, reason = 'hot') {
         if (!session || !session.actor) return Promise.resolve(null);
 
-        const row = recordFromSession(session, 'hot', reason);
+        const preservedState = session.coldLifeState;
+        const row = preservedState
+            ? rowFromState(mergeSessionIntoLifeState(session, preservedState, 'hot', reason, {
+                // The activation position can be deliberately near a player.
+                // It is not the bot's durable background location.
+                loc: preservedState.loc
+            }))
+            : recordFromSession(session, 'hot', reason);
         const marketState = session.coldMarketState;
         const craftState = refreshCraftShop(session.coldCraftState);
         if (marketState?.stats?.marketStore) {
@@ -601,6 +667,16 @@ const BotLifeState = {
                 stats: { ...(craftState.stats || {}), lastReason: reason },
                 inventory: parseJson(row.inventorySummary, {})
             };
+            return this.upsertState(nextState, reason);
+        }
+
+        if (session.coldLifeState) {
+            const preserved = recoverOrphanedGiranState(session.coldLifeState);
+            const nextState = mergeSessionIntoLifeState(session, preserved, 'cold', reason, {
+                loc: preserved.loc,
+                nextResolveAt: now() + 30000 + Math.round(Math.random() * 90000)
+            });
+            session.coldLifeState = nextState;
             return this.upsertState(nextState, reason);
         }
 

--- a/src/GameServer/Bot/Population/HotActivation.js
+++ b/src/GameServer/Bot/Population/HotActivation.js
@@ -168,6 +168,7 @@ const HotActivation = {
                 locY: placement.loc?.locY,
                 locZ: placement.loc?.locZ,
                 keepStoreLocation: !!marketStore || !!craftShop,
+                coldLifeState: !marketStore && !craftShop ? state : null,
                 coldMarketState: marketStore ? state : null,
                 coldCraftState: craftShop ? state : null,
                 privateStore: marketStore ? {

--- a/tests/test_bot_cold_component_chain.js
+++ b/tests/test_bot_cold_component_chain.js
@@ -71,15 +71,18 @@ async function run() {
         activity: 'crafting',
         loc: { locX: 83396, locY: 147904, locZ: -3400 },
         inventory,
-        stats: { equipmentPlan: { status: 'ready_to_craft', strategy: 'craft', recipeId: finalRecipe.recipeId } }
+        stats: {
+            equipmentPlan: { status: 'ready_to_craft', strategy: 'craft', recipeId: finalRecipe.recipeId },
+            craftReturn: { loc: { locX: -8200, locY: 11300, locZ: -3100 }, spotId: '2_-24', regionName: 'Wandering' }
+        }
     }, () => 0);
 
     assert.strictEqual(result.reason, 'component_crafted', 'the ready nested resource must be crafted before the final equipment');
     assert.strictEqual(exchange.crafterMp, 1, 'a public crafting station must not consume its MP for a cold manufacture');
     assert.strictEqual(exchange.product.amount, 3, 'a ready component batch must produce every prepared unit in one station exchange');
     assert(exchange.materials.every((material) => material.amount % 3 === 0), 'a component batch must consume materials for its full prepared quantity');
-    assert.strictEqual(result.state.activity, 'hunting', 'a component craft without enough raw inputs for the next batch must resume farming instead of idling at the station');
-    assert.strictEqual(result.state.stats.travel, null, 'a component craft must not start a return trip before the final recipe is complete');
+    assert.strictEqual(result.state.activity, 'traveling', 'a component craft without enough raw inputs for the next batch must leave the Giran station');
+    assert.strictEqual(result.state.stats.travel.reason, 'component_craft_return', 'component crafting must return through the gatekeeper before resuming material farming');
 
     Database.fetchItems = async () => [];
     LifeState.refreshInventory = async (state) => {

--- a/tests/test_bot_cold_state_context.js
+++ b/tests/test_bot_cold_state_context.js
@@ -1,0 +1,100 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
+const SpotService = invoke('GameServer/Bot/AI/SpotService');
+
+const originalUpsertState = LifeState.upsertState;
+const originalFindById = SpotService.findById;
+const originalRandomPointNear = SpotService.randomPointNear;
+
+async function run() {
+    let saved = null;
+    LifeState.upsertState = (state) => {
+        saved = state;
+        return Promise.resolve(state);
+    };
+
+    const session = {
+        accountId: 'bot_context',
+        homeRegion: 'Wandering',
+        plan: 'resting',
+        currentSpot: { id: '2_-24' },
+        coldLifeState: {
+            characterId: 77,
+            accountName: 'bot_context',
+            name: 'ContextBot',
+            level: 24,
+            exp: 1000,
+            sp: 200,
+            adena: 5000,
+            phase: 'hot',
+            activity: 'hunting',
+            homeRegion: 'Wandering',
+            currentRegion: 'Wandering',
+            spotId: '2_-24',
+            loc: { locX: -8200, locY: 11300, locZ: -3100 },
+            vitals: { hp: 100, maxHp: 100, mp: 50, maxMp: 50 },
+            timing: {},
+            party: { partyId: null, role: 'dps' },
+            stats: { equipmentPlan: { target: { name: 'Atuba Mace' } } },
+            inventory: {}
+        },
+        actor: {
+            fetchId: () => 77,
+            fetchName: () => 'ContextBot',
+            fetchLevel: () => 24,
+            fetchExp: () => 1200,
+            fetchSp: () => 220,
+            fetchClassId: () => 53,
+            fetchClanId: () => 0,
+            fetchLocX: () => 83180,
+            fetchLocY: () => 147780,
+            fetchLocZ: () => -3466,
+            fetchHp: () => 100,
+            fetchMaxHp: () => 100,
+            fetchMp: () => 50,
+            fetchMaxMp: () => 50,
+            backpack: { fetchItems: () => [] }
+        }
+    };
+
+    await LifeState.markCold(session, 'test_context');
+
+    assert(saved, 'cooldown should persist a state');
+    assert.deepStrictEqual(saved.loc, { locX: -8200, locY: 11300, locZ: -3100 }, 'a bot activated in Giran must return to its saved field location when cooled');
+    assert.strictEqual(saved.currentRegion, 'Wandering');
+    assert.strictEqual(saved.spotId, '2_-24');
+    assert.strictEqual(saved.stats.equipmentPlan.target.name, 'Atuba Mace', 'cooldown must preserve the acquisition plan');
+
+    SpotService.findById = () => ({ center: { locX: -8000, locY: 11000, locZ: -3100 } });
+    SpotService.randomPointNear = () => ({ locX: -7900, locY: 11100, locZ: -3100 });
+    session.coldLifeState = {
+        ...session.coldLifeState,
+        phase: 'cold',
+        activity: 'resting',
+        currentRegion: 'Giran',
+        loc: { locX: 83180, locY: 147780, locZ: -3466 },
+        stats: {
+            ...session.coldLifeState.stats,
+            craftReturn: { loc: { locX: 1, locY: 2, locZ: 3 } },
+            marketReturn: { loc: { locX: 4, locY: 5, locZ: 6 } }
+        }
+    };
+    await LifeState.markCold(session, 'test_orphan_repair');
+    assert.deepStrictEqual(saved.loc, { locX: -7900, locY: 11100, locZ: -3100 }, 'a stale craftReturn must not keep an ordinary bot on the Giran plaza');
+    assert.strictEqual(saved.currentRegion, 'Wandering');
+}
+
+run()
+    .then(() => console.log('Bot cold life-state context checks passed'))
+    .catch((err) => {
+        console.error(err);
+        process.exitCode = 1;
+    })
+    .finally(() => {
+        LifeState.upsertState = originalUpsertState;
+        SpotService.findById = originalFindById;
+        SpotService.randomPointNear = originalRandomPointNear;
+    });


### PR DESCRIPTION
## What changed

- Preserve a bot's background life state when it becomes visible to a player.
- Return bots to their assigned hunting area after crafting an intermediate material.
- Repair stale cold bot records that would otherwise leave ordinary bots on the Giran plaza.

## Why

Some bots could lose their return context after a city or crafting visit and remain seated in Giran without a shop. This keeps the plaza reserved for actual merchants and crafting services.

## Validation

- Added regression coverage for cold-state preservation and component-craft returns.
- Ran npm test and npm run check.
- Verified after restart that the Giran plaza contains only crafting stations and bots in transit.