### PR TITLE
Fix bot component crafting progression

### DIFF
--- a/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
+++ b/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
@@ -249,13 +249,18 @@ function planFor(state = {}, options = {}) {
     const next = strategy === 'direct_drop'
         ? direct && { ...direct, itemId: Number(target.item.selfId) }
         : nextMaterial?.source && { ...nextMaterial.source, itemId: Number(nextMaterial.selfId) };
-    const readyToCraft = strategy === 'craft' && (
-        missingMaterialPlans.length === 0 || hasReadyCraftComponent(target.recipe, state, allowedRecipeIds)
-    );
+    // Keep final-equipment readiness distinct from an available intermediate
+    // craft.  Both routes go to a station, but reporting a ready Cokes batch
+    // as "can craft Atuba Mace" made the progression telemetry lie and hid
+    // the remaining work in a long component chain.
+    const readyToCraft = strategy === 'craft' && missingMaterialPlans.length === 0;
+    const componentReady = strategy === 'craft'
+        && !readyToCraft
+        && hasReadyCraftComponent(target.recipe, state, allowedRecipeIds);
     const requiresParty = Boolean(next && !soloSafeForSource(state, next));
 
     return {
-        status: readyToCraft ? 'ready_to_craft' : next ? 'active' : 'blocked',
+        status: readyToCraft ? 'ready_to_craft' : componentReady ? 'component_ready' : next ? 'active' : 'blocked',
         grade: String(target.item.etc?.rank || gradeForLevel(state.level)).toLowerCase(),
         role: roleFor(state),
         rateModelVersion: RATE_MODEL_VERSION,
@@ -272,7 +277,7 @@ function planFor(state = {}, options = {}) {
 
 function shouldFinishPreviousPlan(previous, refreshed) {
     if (!previous || !refreshed || previous.grade === refreshed.grade || previous.strategy !== 'craft') return false;
-    if (!['active', 'ready_to_craft'].includes(refreshed.status)) return false;
+    if (!['active', 'component_ready', 'ready_to_craft'].includes(refreshed.status)) return false;
     const missing = (refreshed.materials || []).filter((material) => Number(material.missing || 0) > 0);
     const total = (refreshed.materials || []).reduce((sum, material) => sum + Number(material.amount || 0), 0);
     const remaining = missing.reduce((sum, material) => sum + Number(material.missing || 0), 0);

--- a/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
+++ b/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
@@ -257,7 +257,11 @@ function planFor(state = {}, options = {}) {
     const componentReady = strategy === 'craft'
         && !readyToCraft
         && hasReadyCraftComponent(target.recipe, state, allowedRecipeIds);
-    const requiresParty = Boolean(next && !soloSafeForSource(state, next));
+    // A ready final recipe or component is a station action, not a request to
+    // fight at the next (possibly unsafe) material source.  Let it leave the
+    // party gate and finish the prepared manufacture first.
+    const requiresParty = !readyToCraft && !componentReady
+        && Boolean(next && !soloSafeForSource(state, next));
 
     return {
         status: readyToCraft ? 'ready_to_craft' : componentReady ? 'component_ready' : next ? 'active' : 'blocked',

--- a/src/GameServer/Bot/Economy/ColdCraftingService.js
+++ b/src/GameServer/Bot/Economy/ColdCraftingService.js
@@ -55,7 +55,7 @@ function readyRecipeFor(state, recipe, visited = new Set()) {
 
 function beginTravel(state, timestamp = Date.now()) {
     const plan = state?.stats?.equipmentPlan;
-    if (!state || state.activity === 'traveling' || !['active', 'ready_to_craft'].includes(plan?.status) || plan.strategy !== 'craft') return null;
+    if (!state || state.activity === 'traveling' || !['active', 'component_ready', 'ready_to_craft'].includes(plan?.status) || plan.strategy !== 'craft') return null;
     const finalRecipe = C4RecipeItems.resolveByRecipeId(plan.recipeId);
     const recipe = readyRecipeFor(state, finalRecipe);
     const station = stationForRecipe(recipe?.recipeId);

--- a/src/GameServer/Bot/Economy/CraftTelemetry.js
+++ b/src/GameServer/Bot/Economy/CraftTelemetry.js
@@ -10,7 +10,7 @@ function itemName(selfId, plan = {}) {
 }
 
 function active(plan) {
-    return ['active', 'ready_to_craft'].includes(plan?.status) && ['craft', 'direct_drop'].includes(plan?.strategy);
+    return ['active', 'component_ready', 'ready_to_craft'].includes(plan?.status) && ['craft', 'direct_drop'].includes(plan?.strategy);
 }
 
 function planEvents(state, previous = {}, next = {}) {
@@ -47,10 +47,14 @@ function planEvents(state, previous = {}, next = {}) {
         const completedId = Number(previous.next.itemId);
         const nextId = Number(next.next?.itemId || 0);
         events.push({
-            type: next.status === 'ready_to_craft' ? 'craft_materials_ready' : 'craft_material_complete',
+            type: next.status === 'ready_to_craft'
+                ? 'craft_materials_ready'
+                : next.status === 'component_ready' ? 'craft_component_ready' : 'craft_material_complete',
             summary: next.status === 'ready_to_craft'
-                ? `${state.name} collected enough ${itemName(completedId, previous)} and can craft ${next.target?.name}`
-                : `${state.name} collected enough ${itemName(completedId, previous)}; next: ${itemName(nextId, next)}`,
+                ? `${state.name} collected all final materials and can craft ${next.target?.name}`
+                : next.status === 'component_ready'
+                    ? `${state.name} collected enough ${itemName(completedId, previous)} and can craft an intermediate resource for ${next.target?.name}`
+                    : `${state.name} collected enough ${itemName(completedId, previous)}; next: ${itemName(nextId, next)}`,
             weight: 3,
             meta: {
                 recipeId: next.recipeId || null,

--- a/src/GameServer/Bot/Economy/ItemDisposition.js
+++ b/src/GameServer/Bot/Economy/ItemDisposition.js
@@ -24,7 +24,7 @@ function basePrice(item, template = templateFor(item?.selfId)) {
 
 function reservedCraftAmounts(state) {
     const plan = state?.stats?.equipmentPlan;
-    if (!['active', 'ready_to_craft'].includes(plan?.status) || plan.strategy !== 'craft') return {};
+    if (!['active', 'component_ready', 'ready_to_craft'].includes(plan?.status) || plan.strategy !== 'craft') return {};
     return (plan.materials || []).reduce((reserved, material) => {
         const selfId = Number(material.selfId || 0);
         if (!selfId) return reserved;

--- a/tests/test_bot_craft_telemetry.js
+++ b/tests/test_bot_craft_telemetry.js
@@ -37,6 +37,10 @@ assert.strictEqual(advanced[0].meta.nextItemId, 1870);
 const ready = CraftTelemetry.planEvents(state, initial, { ...initial, status: 'ready_to_craft', next: null });
 assert.strictEqual(ready[0].type, 'craft_materials_ready');
 
+const component = CraftTelemetry.planEvents(state, initial, { ...initial, status: 'component_ready', next: null });
+assert.strictEqual(component[0].type, 'craft_component_ready');
+assert(component[0].summary.includes('intermediate resource'), 'component readiness must not be reported as final equipment readiness');
+
 const travel = CraftTelemetry.stationTravelEvent({ ...state, stats: { equipmentPlan: initial } }, { stationId: 'resource_core', reason: 'component_craft' });
 assert.strictEqual(travel.type, 'craft_station_travel');
 assert.strictEqual(travel.meta.stationId, 'resource_core');

--- a/tests/test_bot_gear_acquisition.js
+++ b/tests/test_bot_gear_acquisition.js
@@ -93,6 +93,27 @@ const oriharkonRecipe = invoke('GameServer/Items/C4RecipeItems').resolveByRecipe
 const syntheticCokesRecipe = invoke('GameServer/Items/C4RecipeItems').resolveByRecipeId(36);
 const atubaMaceRecipe = invoke('GameServer/Items/C4RecipeItems').resolveByRecipeId(189);
 const steelRecipe = invoke('GameServer/Items/C4RecipeItems').resolveByRecipeId(30);
+const crystalSupplement = invoke('GameServer/Bot/Economy/CraftSupplementMaterials');
+const atubaWithCokesIngredients = atubaMaceRecipe.materials.reduce((inventory, material) => {
+    if (Number(material.selfId) === 1879 || crystalSupplement.isSupplementalMaterial(material.selfId)) return inventory;
+    inventory[material.selfId] = { selfId: material.selfId, amount: material.amount };
+    return inventory;
+}, {
+    1870: { selfId: 1870, amount: 3 },
+    1871: { selfId: 1871, amount: 3 }
+});
+const componentPlan = GearAcquisitionPlanner.planFor({
+    level: 20,
+    stats: { classId: 0, role: 'dps' },
+    inventory: atubaWithCokesIngredients
+}, { spots: [], recipeId: atubaMaceRecipe.recipeId });
+assert.strictEqual(componentPlan.status, 'component_ready', 'a ready Cokes batch must be distinguished from final Atuba Mace readiness');
+assert(ColdCraftingService.beginTravel({
+    level: 20,
+    activity: 'hunting',
+    inventory: atubaWithCokesIngredients,
+    stats: { equipmentPlan: componentPlan }
+}, 1000), 'a component-ready plan must still travel to its crafting station');
 const resourceStationRecipeIds = new Set(CraftShopService.stationRecipes(
     CraftShopService.CraftStations.find((entry) => entry.id === 'resource_core'),
     CraftShopService.availableRecipes({ level: 70, stats: { classId: 57 } })
@@ -114,7 +135,6 @@ const resourceState = {
         1872: { selfId: 1872, amount: 4 }
     }
 };
-const crystalSupplement = invoke('GameServer/Bot/Economy/CraftSupplementMaterials');
 assert.strictEqual(crystalSupplement.isSupplementalMaterial(1458), true, 'crystals must be supplemented only at the final manufacture step');
 assert.strictEqual(crystalSupplement.isSupplementalMaterial(2130), true, 'gemstones must be supplemented only at the final manufacture step');
 assert.strictEqual(crystalSupplement.isSupplementalMaterial(1869), false, 'farmable craft resources must never be supplemented');

--- a/tests/test_bot_gear_acquisition.js
+++ b/tests/test_bot_gear_acquisition.js
@@ -108,6 +108,7 @@ const componentPlan = GearAcquisitionPlanner.planFor({
     inventory: atubaWithCokesIngredients
 }, { spots: [], recipeId: atubaMaceRecipe.recipeId });
 assert.strictEqual(componentPlan.status, 'component_ready', 'a ready Cokes batch must be distinguished from final Atuba Mace readiness');
+assert.strictEqual(componentPlan.requiresParty, false, 'a ready component must go to its station instead of waiting for a party for a later farming source');
 assert(ColdCraftingService.beginTravel({
     level: 20,
     activity: 'hunting',


### PR DESCRIPTION
## Summary

- Distinguish a ready intermediate resource from a final equipment recipe in bot progression.
- Send bots with a prepared component directly to the Giran crafting station instead of waiting for a party for a later farming spot.
- Make crafting telemetry describe the real stage of the chain.

## Why

A component that was ready to manufacture was reported as final equipment readiness and could be held behind an unrelated party requirement.

## Validation

- `npm run check`
- `node tests/test_bot_gear_acquisition.js`
- `node tests/test_bot_craft_telemetry.js`
- `node tests/test_bot_cold_component_chain.js`
- `node tests/test_bot_craft_wait_recovery.js`
- Live cold-population observation: component-ready bots traveled to `resource_core` and crafted Steel, Braided Hemp, and Coarse Bone Powder.