### PR TITLE
Fix starter and party combat behavior

### DIFF
--- a/data/Html/7009.html
+++ b/data/Html/7009.html
@@ -1,0 +1,12 @@
+<html><body>
+<font color="LEVEL">Newbie Helper:</font><br>
+Welcome, young adventurer! I can bestow powerful magic blessings upon you to aid your leveling, as long as you are under level 25. Select one of the blessings below:<br>
+<br>
+<a action="bypass -h newbie_buff windwalk">Bless me with Wind Walk (Increases Speed)</a><br>
+<a action="bypass -h newbie_buff shield">Bless me with Shield (Increases P. Def)</a><br>
+<a action="bypass -h newbie_buff haste">Bless me with Haste (Increases Atk. Spd)</a><br>
+<br>
+<a action="bypass -h newbie_buff heal">Fully recover my HP and MP</a><br>
+<br>
+May the light guide your path!
+</body></html>

--- a/data/Html/7019.html
+++ b/data/Html/7019.html
@@ -1,0 +1,12 @@
+<html><body>
+<font color="LEVEL">Newbie Helper:</font><br>
+Welcome, young adventurer! I can bestow powerful magic blessings upon you to aid your leveling, as long as you are under level 25. Select one of the blessings below:<br>
+<br>
+<a action="bypass -h newbie_buff windwalk">Bless me with Wind Walk (Increases Speed)</a><br>
+<a action="bypass -h newbie_buff shield">Bless me with Shield (Increases P. Def)</a><br>
+<a action="bypass -h newbie_buff haste">Bless me with Haste (Increases Atk. Spd)</a><br>
+<br>
+<a action="bypass -h newbie_buff heal">Fully recover my HP and MP</a><br>
+<br>
+May the light guide your path!
+</body></html>

--- a/data/Html/7131.html
+++ b/data/Html/7131.html
@@ -1,0 +1,12 @@
+<html><body>
+<font color="LEVEL">Newbie Helper:</font><br>
+Welcome, young adventurer! I can bestow powerful magic blessings upon you to aid your leveling, as long as you are under level 25. Select one of the blessings below:<br>
+<br>
+<a action="bypass -h newbie_buff windwalk">Bless me with Wind Walk (Increases Speed)</a><br>
+<a action="bypass -h newbie_buff shield">Bless me with Shield (Increases P. Def)</a><br>
+<a action="bypass -h newbie_buff haste">Bless me with Haste (Increases Atk. Spd)</a><br>
+<br>
+<a action="bypass -h newbie_buff heal">Fully recover my HP and MP</a><br>
+<br>
+May the light guide your path!
+</body></html>

--- a/data/Html/7400.html
+++ b/data/Html/7400.html
@@ -1,0 +1,12 @@
+<html><body>
+<font color="LEVEL">Newbie Helper:</font><br>
+Welcome, young adventurer! I can bestow powerful magic blessings upon you to aid your leveling, as long as you are under level 25. Select one of the blessings below:<br>
+<br>
+<a action="bypass -h newbie_buff windwalk">Bless me with Wind Walk (Increases Speed)</a><br>
+<a action="bypass -h newbie_buff shield">Bless me with Shield (Increases P. Def)</a><br>
+<a action="bypass -h newbie_buff haste">Bless me with Haste (Increases Atk. Spd)</a><br>
+<br>
+<a action="bypass -h newbie_buff heal">Fully recover my HP and MP</a><br>
+<br>
+May the light guide your path!
+</body></html>

--- a/data/Html/7530.html
+++ b/data/Html/7530.html
@@ -1,0 +1,12 @@
+<html><body>
+<font color="LEVEL">Newbie Helper:</font><br>
+Welcome, young adventurer! I can bestow powerful magic blessings upon you to aid your leveling, as long as you are under level 25. Select one of the blessings below:<br>
+<br>
+<a action="bypass -h newbie_buff windwalk">Bless me with Wind Walk (Increases Speed)</a><br>
+<a action="bypass -h newbie_buff shield">Bless me with Shield (Increases P. Def)</a><br>
+<a action="bypass -h newbie_buff haste">Bless me with Haste (Increases Atk. Spd)</a><br>
+<br>
+<a action="bypass -h newbie_buff heal">Fully recover my HP and MP</a><br>
+<br>
+May the light guide your path!
+</body></html>

--- a/data/Html/7575.html
+++ b/data/Html/7575.html
@@ -1,0 +1,12 @@
+<html><body>
+<font color="LEVEL">Newbie Helper:</font><br>
+Welcome, young adventurer! I can bestow powerful magic blessings upon you to aid your leveling, as long as you are under level 25. Select one of the blessings below:<br>
+<br>
+<a action="bypass -h newbie_buff windwalk">Bless me with Wind Walk (Increases Speed)</a><br>
+<a action="bypass -h newbie_buff shield">Bless me with Shield (Increases P. Def)</a><br>
+<a action="bypass -h newbie_buff haste">Bless me with Haste (Increases Atk. Spd)</a><br>
+<br>
+<a action="bypass -h newbie_buff heal">Fully recover my HP and MP</a><br>
+<br>
+May the light guide your path!
+</body></html>

--- a/data/Items/Weapons/c4_s_grade.json
+++ b/data/Items/Weapons/c4_s_grade.json
@@ -115,7 +115,7 @@
             "class2": 0,
             "mass": 1350,
             "price": 48800000,
-            "kind": "Weapon.Fist"
+            "kind": "Weapon.DualFist"
         },
         "stats": {
             "pAtk": 342,

--- a/data/Items/Weapons/weapons.json
+++ b/data/Items/Weapons/weapons.json
@@ -925,92 +925,92 @@
     "etc": { "slot": 7, "mp": 0, "soulshot": 0, "spiritshot": 0, "rank": "none", "cristals": 0 }
 },{
     "selfId": 253,
-    "template": { "kind": "Weapon.Fist", "name": "Spiked Gloves", "class1": 0, "class2": 0, "mass": 1590, "price": 768 },
+    "template": { "kind": "Weapon.DualFist", "name": "Spiked Gloves", "class1": 0, "class2": 0, "mass": 1590, "price": 768 },
     "stats": { "pAtk": 10, "pAtkRnd": 5, "mAtk": 6, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 0, "spiritshot": 0, "rank": "none", "cristals": 0 }
 },{
     "selfId": 254,
-    "template": { "kind": "Weapon.Fist", "name": "Iron Gloves", "class1": 0, "class2": 0, "mass": 1580, "price": 12500 },
+    "template": { "kind": "Weapon.DualFist", "name": "Iron Gloves", "class1": 0, "class2": 0, "mass": 1580, "price": 12500 },
     "stats": { "pAtk": 13, "pAtkRnd": 5, "mAtk": 9, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 0, "spiritshot": 0, "rank": "none", "cristals": 0 }
 },{
     "selfId": 255,
-    "template": { "kind": "Weapon.Fist", "name": "Fox Claw Gloves", "class1": 0, "class2": 0, "mass": 1560, "price": 54100 },
+    "template": { "kind": "Weapon.DualFist", "name": "Fox Claw Gloves", "class1": 0, "class2": 0, "mass": 1560, "price": 54100 },
     "stats": { "pAtk": 21, "pAtkRnd": 5, "mAtk": 12, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 2, "spiritshot": 2, "rank": "none", "cristals": 0 }
 },{
     "selfId": 256,
-    "template": { "kind": "Weapon.Fist", "name": "Cestus", "class1": 0, "class2": 0, "mass": 1570, "price": 136000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Cestus", "class1": 0, "class2": 0, "mass": 1570, "price": 136000 },
     "stats": { "pAtk": 29, "pAtkRnd": 5, "mAtk": 17, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 2, "spiritshot": 2, "rank": "none", "cristals": 0 }
 },{
     "selfId": 257,
-    "template": { "kind": "Weapon.Fist", "name": "Viper's Fang", "class1": 0, "class2": 0, "mass": 1560, "price": 244000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Viper's Fang", "class1": 0, "class2": 0, "mass": 1560, "price": 244000 },
     "stats": { "pAtk": 38, "pAtkRnd": 5, "mAtk": 21, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 2, "spiritshot": 2, "rank": "none", "cristals": 0 }
 },{
     "selfId": 258,
-    "template": { "kind": "Weapon.Fist", "name": "Bagh-Nakh", "class1": 0, "class2": 0, "mass": 1540, "price": 409000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Bagh-Nakh", "class1": 0, "class2": 0, "mass": 1540, "price": 409000 },
     "stats": { "pAtk": 49, "pAtkRnd": 5, "mAtk": 26, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 2, "spiritshot": 2, "rank": "d", "cristals": 743 }
 },{
     "selfId": 259,
-    "template": { "kind": "Weapon.Fist", "name": "Single-Edged Jamadhr", "class1": 0, "class2": 0, "mass": 1550, "price": 644000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Single-Edged Jamadhr", "class1": 0, "class2": 0, "mass": 1550, "price": 644000 },
     "stats": { "pAtk": 62, "pAtkRnd": 5, "mAtk": 32, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 2, "spiritshot": 2, "rank": "d", "cristals": 1170 }
 },{
     "selfId": 260,
-    "template": { "kind": "Weapon.Fist", "name": "Triple-Edged Jamadhr", "class1": 0, "class2": 0, "mass": 1540, "price": 967000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Triple-Edged Jamadhr", "class1": 0, "class2": 0, "mass": 1540, "price": 967000 },
     "stats": { "pAtk": 78, "pAtkRnd": 5, "mAtk": 39, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 2, "spiritshot": 2, "rank": "d", "cristals": 1758 }
 },{
     "selfId": 261,
-    "template": { "kind": "Weapon.Fist", "name": "Bich'Hwa", "class1": 0, "class2": 0, "mass": 1510, "price": 1400000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Bich'Hwa", "class1": 0, "class2": 0, "mass": 1510, "price": 1400000 },
     "stats": { "pAtk": 96, "pAtkRnd": 5, "mAtk": 47, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 3, "spiritshot": 3, "rank": "d", "cristals": 2545 }
 },{
     "selfId": 262,
-    "template": { "kind": "Weapon.Fist", "name": "Scallop Jamadhr", "class1": 0, "class2": 0, "mass": 1520, "price": 1800000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Scallop Jamadhr", "class1": 0, "class2": 0, "mass": 1520, "price": 1800000 },
     "stats": { "pAtk": 112, "pAtkRnd": 5, "mAtk": 54, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 3, "spiritshot": 3, "rank": "d", "cristals": 3272 }
 },{
     "selfId": 263,
-    "template": { "kind": "Weapon.Fist", "name": "Chakram", "class1": 0, "class2": 0, "mass": 1490, "price": 2290000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Chakram", "class1": 0, "class2": 0, "mass": 1490, "price": 2290000 },
     "stats": { "pAtk": 130, "pAtkRnd": 5, "mAtk": 61, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 2, "spiritshot": 2, "rank": "c", "cristals": 916 }
 },{
     "selfId": 264,
-    "template": { "kind": "Weapon.Fist", "name": "Pata", "class1": 0, "class2": 0, "mass": 1440, "price": 7830000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Pata", "class1": 0, "class2": 0, "mass": 1440, "price": 7830000 },
     "stats": { "pAtk": 204, "pAtkRnd": 5, "mAtk": 89, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 1, "spiritshot": 1, "rank": "b", "cristals": 1044 }
 },{
     "selfId": 265,
-    "template": { "kind": "Weapon.Fist", "name": "Fisted Blade", "class1": 0, "class2": 0, "mass": 1480, "price": 4300000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Fisted Blade", "class1": 0, "class2": 0, "mass": 1480, "price": 4300000 },
     "stats": { "pAtk": 169, "pAtkRnd": 5, "mAtk": 76, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 3, "spiritshot": 3, "rank": "c", "cristals": 1720 }
 },{
     "selfId": 266,
-    "template": { "kind": "Weapon.Fist", "name": "Great Pata", "class1": 0, "class2": 0, "mass": 1460, "price": 6130000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Great Pata", "class1": 0, "class2": 0, "mass": 1460, "price": 6130000 },
     "stats": { "pAtk": 190, "pAtkRnd": 5, "mAtk": 83, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 3, "spiritshot": 3, "rank": "c", "cristals": 2452 }
 },{
     "selfId": 267,
-    "template": { "kind": "Weapon.Fist", "name": "Arthro Nail", "class1": 0, "class2": 0, "mass": 1420, "price": 8680000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Arthro Nail", "class1": 0, "class2": 0, "mass": 1420, "price": 8680000 },
     "stats": { "pAtk": 213, "pAtkRnd": 5, "mAtk": 91, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 1, "spiritshot": 1, "rank": "b", "cristals": 1157 }
 },{
     "selfId": 268,
-    "template": { "kind": "Weapon.Fist", "name": "Bellion Cestus", "class1": 0, "class2": 0, "mass": 1390, "price": 13100000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Bellion Cestus", "class1": 0, "class2": 0, "mass": 1390, "price": 13100000 },
     "stats": { "pAtk": 236, "pAtkRnd": 5, "mAtk": 99, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 1, "spiritshot": 1, "rank": "b", "cristals": 1746 }
 },{
     "selfId": 269,
-    "template": { "kind": "Weapon.Fist", "name": "Blood Tornado", "class1": 0, "class2": 0, "mass": 1370, "price": 18300000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Blood Tornado", "class1": 0, "class2": 0, "mass": 1370, "price": 18300000 },
     "stats": { "pAtk": 259, "pAtkRnd": 5, "mAtk": 107, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 1, "spiritshot": 1, "rank": "a", "cristals": 1464 }
 },{
     "selfId": 270,
-    "template": { "kind": "Weapon.Fist", "name": "Dragon Grinder", "class1": 0, "class2": 0, "mass": 1350, "price": 27000000 },
+    "template": { "kind": "Weapon.DualFist", "name": "Dragon Grinder", "class1": 0, "class2": 0, "mass": 1350, "price": 27000000 },
     "stats": { "pAtk": 282, "pAtkRnd": 5, "mAtk": 114, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 1, "spiritshot": 1, "rank": "a", "cristals": 2160 }
 },{
@@ -1570,7 +1570,7 @@
     "etc": { "slot": 7, "mp": 0, "soulshot": 3, "spiritshot": 3, "rank": "d", "cristals": 2545 }
 },{
     "selfId": 2368,
-    "template": { "kind": "Weapon.Fist", "name": "Training Gloves", "class1": 0, "class2": 0, "mass": 1580, "price": 138 },
+    "template": { "kind": "Weapon.DualFist", "name": "Training Gloves", "class1": 0, "class2": 0, "mass": 1580, "price": 138 },
     "stats": { "pAtk": 7, "pAtkRnd": 5, "mAtk": 5, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 0, "spiritshot": 0, "rank": "none", "cristals": 0 }
 },{
@@ -1585,7 +1585,7 @@
     "etc": { "slot": 7, "mp": 0, "soulshot": 0, "spiritshot": 0, "rank": "none", "cristals": 0 }
 },{
     "selfId": 2371,
-    "template": { "kind": "Weapon.Fist", "name": "Fist of Butcher", "class1": 0, "class2": 0, "mass": 1400, "price": 25500 },
+    "template": { "kind": "Weapon.DualFist", "name": "Fist of Butcher", "class1": 0, "class2": 0, "mass": 1400, "price": 25500 },
     "stats": { "pAtk": 16, "pAtkRnd": 5, "mAtk": 10, "atkSpd": 325, "crit": 40, "accur": 4.75 },
     "etc": { "slot": 14, "mp": 0, "soulshot": 0, "spiritshot": 0, "rank": "none", "cristals": 0 }
 },{

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -78,6 +78,7 @@ const tests = [
     'tests/test_macros.js',
     'tests/test_npc_combat_range.js',
     'tests/test_npc_interaction_completion.js',
+    'tests/test_newbie_helper_starting_zones.js',
     'tests/test_npc_shop_stock.js',
     'tests/test_npc_sell_shop.js',
     'tests/test_personal_warehouse.js',

--- a/src/GameServer/Actor/Attack.js
+++ b/src/GameServer/Actor/Attack.js
@@ -21,6 +21,13 @@ const WEAPON_MASK_BY_KIND = Object.freeze({
     'Weapon.BigBlunt': 16384
 });
 
+function weaponMaskFor(actor) {
+    const kind = actor?.backpack?.fetchTotalWeaponKind?.() || '';
+    const hasShield = (actor?.backpack?.fetchEquippedArmors?.() || [])
+        .some((item) => item?.fetchKind?.() === 'Armor.Shield');
+    return WEAPON_MASK_BY_KIND[kind] || (hasShield ? 1048576 : 0);
+}
+
 class Attack {
     constructor() {
         this.timers = new Set();
@@ -408,10 +415,7 @@ class Attack {
 
         const requires = semantic.requires || {};
         if (requires.weaponsAllowed) {
-            const kind = actor?.backpack?.fetchTotalWeaponKind?.() || '';
-            const hasShield = (actor?.backpack?.fetchEquippedArmors?.() || [])
-                .some((item) => item?.fetchKind?.() === 'Armor.Shield');
-            const mask = WEAPON_MASK_BY_KIND[kind] || (hasShield ? 1048576 : 0);
+            const mask = weaponMaskFor(actor);
             if ((Number(requires.weaponsAllowed) & mask) === 0) {
                 return 'Incorrect weapon.';
             }
@@ -777,3 +781,4 @@ function incomingWeaponVulnerabilityModifier(target, { bow = false } = {}) {
 }
 
 module.exports = Attack;
+module.exports.weaponMaskFor = weaponMaskFor;

--- a/src/GameServer/Bot/AI/BotCombatUtility.js
+++ b/src/GameServer/Bot/AI/BotCombatUtility.js
@@ -1,4 +1,5 @@
 const C4SkillRules = invoke('GameServer/Skills/C4SkillRules');
+const Attack = invoke('GameServer/Actor/Attack');
 
 const OFFENSIVE_TYPES = new Set([
     C4SkillRules.DAMAGE,
@@ -27,6 +28,8 @@ function evaluate(bot, target, skill, role) {
     if (!skill || skill.fetchPassive?.()) return null;
     const semantic = skill.fetchSemantic?.() || {};
     if (semantic.notUsedInC4) return null;
+    const allowedWeapons = Number(semantic.requires?.weaponsAllowed) || 0;
+    if (allowedWeapons && (allowedWeapons & Attack.weaponMaskFor(bot)) === 0) return null;
     if (!OFFENSIVE_TYPES.has(skill.fetchSkillType?.())) return null;
     if (skill.fetchTargetKind?.() !== 'enemy') return null;
 

--- a/src/GameServer/Effects/EffectStore.js
+++ b/src/GameServer/Effects/EffectStore.js
@@ -68,7 +68,16 @@ function apply(actor, effect) {
     if (!actor) return null;
     const normalized = normalize(effect);
     if (!normalized.key || !normalized.id) return null;
-    ensure(actor)[normalized.key] = normalized;
+    const store = ensure(actor);
+    const existing = store[normalized.key];
+
+    // A key represents one C4 effect/stack slot. Refreshing an equal or higher
+    // level is valid, but a lower-level cast must never downgrade it.
+    if (existing && Number(existing.level || 0) > normalized.level) {
+        return existing;
+    }
+
+    store[normalized.key] = normalized;
     return normalized;
 }
 

--- a/src/GameServer/Effects/EffectStore.js
+++ b/src/GameServer/Effects/EffectStore.js
@@ -74,7 +74,7 @@ function apply(actor, effect) {
     // A key represents one C4 effect/stack slot. Refreshing an equal or higher
     // level is valid, but a lower-level cast must never downgrade it.
     if (existing && Number(existing.level || 0) > normalized.level) {
-        return existing;
+        return null;
     }
 
     store[normalized.key] = normalized;

--- a/src/GameServer/Skills/C4SkillEffects.js
+++ b/src/GameServer/Skills/C4SkillEffects.js
@@ -644,6 +644,11 @@ function applyEffect(session, target, skill, semantic, source = session?.actor) 
         durationMs
     });
 
+    // A stronger effect already occupies this C4 stack slot. The rejected cast
+    // must not restart its DoT/HoT ticker, refresh its icon, or interrupt the
+    // target as though the weaker effect had landed.
+    if (!effect) return null;
+
     const buff = BuffCatalog.byTypeOrKey(semantic.effect);
     if (buff && semantic.effectType === 'buff') {
         if (!target.activeBuffs) target.activeBuffs = {};

--- a/tests/test_bot_combat_skill_selection.js
+++ b/tests/test_bot_combat_skill_selection.js
@@ -21,7 +21,7 @@ function skill(selfId, options = {}) {
     };
 }
 
-function bot(classId, ownedSkills = [], mp = 100) {
+function bot(classId, ownedSkills = [], mp = 100, weaponKind = '') {
     return {
         fetchClassId: () => classId,
         fetchMp: () => mp,
@@ -33,6 +33,10 @@ function bot(classId, ownedSkills = [], mp = 100) {
             fetchSkill(selfId) {
                 return this.skills.find((entry) => entry.selfId === selfId) || null;
             }
+        },
+        backpack: {
+            fetchTotalWeaponKind: () => weaponKind,
+            fetchEquippedArmors: () => []
         }
     };
 }
@@ -70,11 +74,19 @@ try {
     assert.strictEqual(mageGenerics.skills.length, 0, 'mage without learned nuke should not cast an invented skill');
     assert.strictEqual(mageGenerics.attacks.length, 1, 'mage without learned nuke should fall back to a normal attack');
 
-    const archer = bot(9, [skill(56, { mp: 5, range: 700, power: 24 })], 20);
+    const archer = bot(9, [skill(56, { mp: 5, range: 700, power: 24, semantic: { requires: { weaponsAllowed: 32 } } })], 20, 'Weapon.Bow');
     const archerGenerics = generics();
     BotAI.executeCombat({}, archer, npc(1102), archerGenerics);
     assert.deepStrictEqual(archerGenerics.skills[0], { id: 1102, selfId: 56, ctrl: true });
     assert.strictEqual(archerGenerics.attacks.length, 0, 'archer with learned Power Shot should cast it before ranged attack fallback');
+
+    const swordFighter = bot(18, [
+        skill(56, { name: 'Power Shot', mp: 5, range: 700, power: 90, semantic: { requires: { weaponsAllowed: 32 } } }),
+        skill(3, { name: 'Power Strike', mp: 5, range: 40, power: 30 })
+    ], 100, 'Weapon.Sword');
+    const swordFighterGenerics = generics();
+    BotAI.executeCombat({}, swordFighter, npc(1111), swordFighterGenerics);
+    assert.strictEqual(swordFighterGenerics.skills[0].selfId, 3, 'a sword fighter must not prepare Power Shot and should use its valid melee skill');
 
     const fighter = bot(0, [], 20);
     const fighterGenerics = generics();

--- a/tests/test_bot_support_planner.js
+++ b/tests/test_bot_support_planner.js
@@ -47,6 +47,12 @@ EffectStore.apply(target, { key: 'shield', id: 1040, level: 1, type: 'buff', sta
 assert.strictEqual(BotSupportPlanner.needsSkill(target, shieldOne), false, 'do not overwrite an equal-level active buff');
 assert.strictEqual(BotSupportPlanner.needsSkill(target, soulShieldTwo), true, 'upgrade an active defensive buff when the party has a higher level');
 
+EffectStore.apply(target, { key: 'shield', id: 1040, level: 3, type: 'buff', stats: { pDefMul: 1.2 }, durationMs: 10 * 60 * 1000 });
+const rejectedDowngrade = EffectStore.apply(target, { key: 'shield', id: 1040, level: 1, type: 'buff', stats: { pDefMul: 1.08 }, durationMs: 10 * 60 * 1000 });
+assert.strictEqual(rejectedDowngrade.level, 3, 'runtime effect storage must reject a lower-level buff over a stronger one');
+assert.strictEqual(EffectStore.list(target).find((effect) => effect.key === 'shield').level, 3, 'a rejected lower-level buff must not replace the active stronger level');
+EffectStore.remove(target, 'shield');
+
 let action = BotSupportPlanner.nextAction(mage, [{ actor: target, leader: true }], [shaman, mage]);
 assert.strictEqual(action, null, 'a non-orc caster should defer an equivalent upgrade to the shaman');
 action = BotSupportPlanner.nextAction(shaman, [{ actor: target, leader: true }], [shaman, mage]);
@@ -120,5 +126,21 @@ action = BotSupportPlanner.nextAction(physicalBuffer, [
 assert.strictEqual(action.target, roleArcher, 'the next individual physical buff should skip the mage and target the archer');
 assert.strictEqual(action.skill.fetchSelfId(), 1068, 'the physical buff should be chosen for the physical target');
 assert.strictEqual(BotSupportPlanner.isUsefulForTarget(roleMage, partyShield), true, 'party buffs should remain available to every party role');
+
+const fullPackageBuffer = actor('FullPackageBuffer', 49, [might, concentration]);
+const packageArcher = actor('PackageArcher', 9);
+const packageMage = actor('PackageMage', 25);
+action = BotSupportPlanner.nextAction(fullPackageBuffer, [
+    { actor: packageArcher, leader: true },
+    { actor: packageMage, leader: false }
+], [fullPackageBuffer]);
+assert.strictEqual(action.skill.fetchSelfId(), 1068, 'an autonomous buffer should start its full package with the first eligible member');
+EffectStore.apply(packageArcher, { key: 'might', id: 1068, level: 2, type: 'buff', stats: { pAtkMul: 1.12 }, durationMs: 10 * 60 * 1000 });
+action = BotSupportPlanner.nextAction(fullPackageBuffer, [
+    { actor: packageArcher, leader: true },
+    { actor: packageMage, leader: false }
+], [fullPackageBuffer]);
+assert.strictEqual(action.skill.fetchSelfId(), 1078, 'after a successful cast, the autonomous buffer should advance to the next needed party buff without another request');
+assert.strictEqual(action.target, packageMage, 'the next planned buff should target its eligible party member');
 
 console.log('Bot support planner checks passed');

--- a/tests/test_bot_support_planner.js
+++ b/tests/test_bot_support_planner.js
@@ -49,7 +49,7 @@ assert.strictEqual(BotSupportPlanner.needsSkill(target, soulShieldTwo), true, 'u
 
 EffectStore.apply(target, { key: 'shield', id: 1040, level: 3, type: 'buff', stats: { pDefMul: 1.2 }, durationMs: 10 * 60 * 1000 });
 const rejectedDowngrade = EffectStore.apply(target, { key: 'shield', id: 1040, level: 1, type: 'buff', stats: { pDefMul: 1.08 }, durationMs: 10 * 60 * 1000 });
-assert.strictEqual(rejectedDowngrade.level, 3, 'runtime effect storage must reject a lower-level buff over a stronger one');
+assert.strictEqual(rejectedDowngrade, null, 'runtime effect storage must report a lower-level buff as rejected');
 assert.strictEqual(EffectStore.list(target).find((effect) => effect.key === 'shield').level, 3, 'a rejected lower-level buff must not replace the active stronger level');
 EffectStore.remove(target, 'shield');
 

--- a/tests/test_newbie_helper_starting_zones.js
+++ b/tests/test_newbie_helper_starting_zones.js
@@ -1,0 +1,24 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const npcs = require('../data/Npcs/npcs.json');
+const spawns = require('../data/Npcs/Spawns/spawns.json');
+const helperIds = npcs
+    .filter((npc) => npc.template?.name === 'Newbie Helper')
+    .map((npc) => npc.selfId)
+    .sort((left, right) => left - right);
+
+assert.deepStrictEqual(helperIds, [7009, 7019, 7131, 7400, 7530, 7575],
+    'all six racial starting-zone Newbie Helpers must remain covered');
+
+const spawnedIds = new Set(spawns.flatMap((group) => group.spawns || []).map((spawn) => spawn.selfId));
+for (const selfId of helperIds) {
+    assert(spawnedIds.has(selfId), `Newbie Helper ${selfId} must be spawned in its racial starting zone`);
+
+    const html = fs.readFileSync(path.join(__dirname, '..', 'data', 'Html', `${selfId}.html`), 'utf8');
+    for (const buff of ['windwalk', 'shield', 'haste']) {
+        assert(html.includes(`newbie_buff ${buff}`), `Newbie Helper ${selfId} must offer ${buff}`);
+    }
+    assert(html.includes('newbie_buff heal'), `Newbie Helper ${selfId} must offer recovery`);
+}

--- a/tests/test_skill_semantics.js
+++ b/tests/test_skill_semantics.js
@@ -7251,6 +7251,12 @@ const fatalCounter = skill({ selfId: 314, name: 'Fatal Counter', spell: false, l
 assert.strictEqual(restrictedSkillAttack.skillUseConditionFailure(bowUser, fatalCounter), null, 'Fatal Counter must allow its sourced bow requirement');
 bowUser.backpack.fetchTotalWeaponKind = () => 'Weapon.Sword';
 assert.strictEqual(restrictedSkillAttack.skillUseConditionFailure(bowUser, fatalCounter), 'Incorrect weapon.', 'Weapon-restricted skills must reject an incompatible weapon');
+const starterFistUser = creature({ id: 2000310 });
+starterFistUser.backpack.fetchTotalWeaponKind = () => 'Weapon.Fist';
+assert.strictEqual(restrictedSkillAttack.skillUseConditionFailure(starterFistUser, ironPunch), 'Incorrect weapon.', 'Iron Punch must reject the one-handed starter fist');
+const dualFistUser = creature({ id: 2000311 });
+dualFistUser.backpack.fetchTotalWeaponKind = () => 'Weapon.DualFist';
+assert.strictEqual(restrictedSkillAttack.skillUseConditionFailure(dualFistUser, ironPunch), null, 'Iron Punch must allow C4 dual-fist weapons such as Spiked Gloves');
 const focusAttack = C4SkillRules.resolve({ selfId: 317, name: 'Focus Attack', level: 1 });
 assert.deepStrictEqual(focusAttack.stats, { pAccuracyCombatAdd: 5, hitMainTarget: true }, 'Focus Attack must preserve its pole accuracy and main-target behavior');
 assert.strictEqual(focusAttack.toggleMpConsume, 7, 'Focus Attack must consume 7 MP every two seconds');

--- a/tests/test_skill_semantics.js
+++ b/tests/test_skill_semantics.js
@@ -4366,6 +4366,17 @@ const curseOutcome = SkillEffects.execute(session(), caster, curseTarget, curseP
 assert.strictEqual(cursePoison.fetchTargetKind(), 'enemy', 'Curse: Poison should resolve as an enemy poison effect');
 assert.strictEqual(cursePoison.fetchSemantic().baseLandRate, 5, 'Curse: Poison level 4 should use sourced power as land rate');
 assert.strictEqual(curseOutcome.effect.dot.damage, 31, 'Curse: Poison level 4 should use the sourced L2J damage table');
+
+const strongerPoisonTicker = curseTarget.effectTimers.poison;
+const weakerPoison = skill({ selfId: 1168, name: 'Curse:Poison', spell: true, power: 5, level: 1, buff: 30000 });
+const weakerPoisonOutcome = SkillEffects.execute(session(), caster, curseTarget, weakerPoison, {
+    magicSkill: true,
+    rng: () => 0,
+    attack: { clearLoadedShot() {} }
+});
+assert.strictEqual(weakerPoisonOutcome.effect, null, 'a lower-level poison should be rejected while a stronger poison is active');
+assert.strictEqual(curseTarget.effectTimers.poison, strongerPoisonTicker, 'a rejected poison must not restart the stronger poison ticker');
+assert.strictEqual(EffectStore.list(curseTarget).find((effect) => effect.key === 'poison').level, 4, 'a rejected poison must retain the stronger effect level');
 EffectStore.remove(curseTarget, 'poison');
 
 const curseDiscordData = activeSkills.find((entry) => entry.selfId === 1163);


### PR DESCRIPTION
## Summary
- add Newbie Helper buff menus in all racial starting zones
- restore C4 dual-fist weapon types and prevent melee bots from selecting skills for the wrong weapon
- prevent lower-level buffs and effects from replacing or restarting stronger active effects

## Root causes
Starter-zone helpers had no HTML menus, dual fists were classified as ordinary fists, combat scoring ignored weapon requirements, and rejected effects still restarted active periodic timers.

## Validation
- node tests/test_newbie_helper_starting_zones.js
- node tests/test_skill_semantics.js
- node tests/test_bot_combat_skill_selection.js
- node tests/test_bot_support_planner.js
- node tests/test_effect_ticker.js
- node tests/test_party_buff_targets.js
- npm run check
- git diff --check