### PR TITLE
Improve bot recovery and progression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 data/Geodata/
 config/local.ini
 tmp/
+/.codex-remote-attachments

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -66,6 +66,7 @@ const tests = [
     'tests/test_cp_stats.js',
     'tests/test_effect_restrictions.js',
     'tests/test_effect_ticker.js',
+    'tests/test_automation_regeneration.js',
     'tests/test_equipment_item_skills.js',
     'tests/test_grade_penalty.js',
     'tests/test_equipment_slots.js',

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -16,6 +16,7 @@ const tests = [
     'tests/test_bot_economy_pricing.js',
     'tests/test_bot_gear_acquisition.js',
     'tests/test_bot_gear_skill_hints.js',
+    'tests/test_bot_class_progression.js',
     'tests/test_generated_cold_skills.js',
     'tests/test_bot_goal_state.js',
     'tests/test_bot_goal_planner.js',

--- a/src/GameServer/Actor/Attack.js
+++ b/src/GameServer/Actor/Attack.js
@@ -25,7 +25,7 @@ function weaponMaskFor(actor) {
     const kind = actor?.backpack?.fetchTotalWeaponKind?.() || '';
     const hasShield = (actor?.backpack?.fetchEquippedArmors?.() || [])
         .some((item) => item?.fetchKind?.() === 'Armor.Shield');
-    return WEAPON_MASK_BY_KIND[kind] || (hasShield ? 1048576 : 0);
+    return (WEAPON_MASK_BY_KIND[kind] || 0) | (hasShield ? 1048576 : 0);
 }
 
 class Attack {

--- a/src/GameServer/Actor/Generics/EnterWorld.js
+++ b/src/GameServer/Actor/Generics/EnterWorld.js
@@ -1,6 +1,7 @@
 const DataCache   = invoke('GameServer/DataCache');
 const ConsoleText = invoke('GameServer/ConsoleText');
 const CharacterStatus = invoke('GameServer/Actor/CharacterStatus');
+const ServerResponse = invoke('GameServer/Network/Response');
 
 function enterWorld(session, actor) {
     const Generics = invoke(path.actor);
@@ -16,7 +17,15 @@ function enterWorld(session, actor) {
     // Calculate accumulated statistics
     Generics.calculateStats(session, actor);
     CharacterStatus.restoreVitals(actor, vitals);
-    actor.skillset.populate(actor.fetchId());
+    actor.skillset.populate(actor.fetchId(), () => {
+        // Skill loading is asynchronous.  The first calculation above runs
+        // before Expertise is available and can temporarily apply the C4
+        // grade penalty to correctly equipped characters.  Recalculate and
+        // refresh the client once the real skillset is present.
+        Generics.calculateStats(session, actor);
+        session.dataSendToMe?.(ServerResponse.userInfo(actor));
+        session.dataSendToMe?.(ServerResponse.abnormalStatusUpdate.fromActor(actor));
+    });
 
     // Start vitals replenish
     actor.automation.setRevHp(DataCache.revitalize.hp[actor.fetchLevel()]);

--- a/src/GameServer/Actor/Generics/LevelUp.js
+++ b/src/GameServer/Actor/Generics/LevelUp.js
@@ -22,9 +22,32 @@ function levelUp(session, actor, nextLevel) {
     actor.automation.setRevHp(DataCache.revitalize.hp[level]);
     actor.automation.setRevMp(DataCache.revitalize.mp[level]);
 
+    // Bots must advance through professions instead of continuing to receive
+    // starter-class skills after their level has crossed a transfer threshold.
+    const isBot = session.accountId?.startsWith('bot_') === true;
+    const awardSkills = isBot
+        ? invoke('GameServer/Bot/BotClassProgression').reconcile({
+            characterId: id,
+            classId,
+            level,
+            seed: actor.fetchName()
+        }).then((progression) => {
+            if (Number(progression.classId) !== Number(classId)) actor.setClassId(progression.classId);
+            return new Promise((resolve) => actor.skillset.populate(id, resolve));
+        })
+        : actor.skillset.awardSkills(id, classId, level);
+
     // Check for new skills
-    actor.skillset.awardSkills(id, classId, level).then(() => {
+    awardSkills.then(() => {
+        invoke(path.actor).calculateStats(session, actor);
+        actor.fillupVitals();
         session.dataSendToMe(ServerResponse.skillsList(actor.skillset.fetchSkills()));
+        if (isBot) {
+            // A bot has no client of its own, so nearby players and party
+            // members need the normal character refresh after a profession.
+            session.dataSendToOthers?.(ServerResponse.charInfo(actor), actor);
+            Database.updateCharacterVitals(id, actor.fetchHp(), actor.fetchMaxHp(), actor.fetchMp(), actor.fetchMaxMp());
+        }
     })
 
     // Level up effect

--- a/src/GameServer/Actor/Skillset.js
+++ b/src/GameServer/Actor/Skillset.js
@@ -2,6 +2,13 @@ const SkillModel = invoke('GameServer/Model/Skill');
 const DataCache  = invoke('GameServer/DataCache');
 const Database   = invoke('Database');
 
+function definedLevel(skill, requestedLevel) {
+    const levels = skill?.levels || [];
+    return levels.find((entry) => Number(entry.level) === Number(requestedLevel))
+        || levels.filter((entry) => Number(entry.level) <= Number(requestedLevel)).at(-1)
+        || null;
+}
+
 class Skillset {
     constructor() {
         this.resetSkills();
@@ -24,7 +31,7 @@ class Skillset {
         this.resetSkills();
 
         const skillLevelLookup = (skill, level, success) => {
-            const item = skill.levels?.find((ob) => ob.level === level);
+            const item = definedLevel(skill, level);
             item ? success(item) : utils.infoWarn('GameServer', 'unknown Skill Id %d with Level %d', skill.selfId, level);
         };
 
@@ -56,20 +63,30 @@ class Skillset {
                 }
 
                 return new Promise((done) => {
-                    skill.levels = skill.levels.filter((ob) => ob.pLevel <= level).pop();
+                    const requested = skill.levels.filter((ob) => ob.pLevel <= level).pop();
+                    const resolved = definedLevel(skillDetails, requested?.level);
+                    if (!resolved) {
+                        utils.infoWarn('GameServer', 'unknown Skill Id %d with Level %d', skill.selfId, requested?.level);
+                        done();
+                        return;
+                    }
 
                     Database.fetchSkill(id, skill.selfId).then((ownedSkill) => {
                         const storedLevel = ownedSkill[0]?.level;
 
                         // The skill is present in DB, update its level
                         if (storedLevel) {
-                            Database.updateSkillLevel(id, skill.selfId, skill.levels.level).then(() => {
+                            Database.updateSkillLevel(id, skill.selfId, resolved.level).then(() => {
                                 done();
                             });
                         }
                         else {
                             // The skill is a new addition based on character's level
-                            skill = { ...utils.crushOb(skill), passive: skillDetails.template?.passive ?? false };
+                            skill = {
+                                ...utils.crushOb(skill),
+                                passive: skillDetails.template?.passive ?? false,
+                                level: resolved.level
+                            };
                             Database.setSkill(skill, id).then(() => {
                                 done();
                             });

--- a/src/GameServer/Automation.js
+++ b/src/GameServer/Automation.js
@@ -81,7 +81,10 @@ class Automation extends SelectedModel {
 
     fetchRevHpAmount(creature) {
         const base = this.fetchPlayerRegenBase(creature, 'CON');
-        return Math.max(0, base * EffectStats.multiplier(creature, 'regHp') * this.fetchRegenStateMultiplier(creature));
+        return Math.max(0, (
+            (base * EffectStats.multiplier(creature, 'regHp'))
+            + EffectStats.add(creature, 'regHpAdd')
+        ) * this.fetchRegenStateMultiplier(creature));
     }
 
     fetchRevMpAmount(creature) {

--- a/src/GameServer/Automation.js
+++ b/src/GameServer/Automation.js
@@ -52,36 +52,75 @@ class Automation extends SelectedModel {
 
         this.stopReplenish();
         this.timer.replenish = setInterval(() => {
-            const maxHp = creature.fetchMaxHp();
-            const maxMp = creature.fetchMaxMp();
-
-            const minHp = Math.min(creature.fetchHp() + this.fetchRevHpAmount(creature), maxHp);
-            const minMp = Math.min(creature.fetchMp() + this.fetchRevMpAmount(creature), maxMp);
-
-            creature.setHp(minHp);
-            creature.setMp(minMp);
-
-            if (creature.fetchKind === undefined) {
-                creature.statusUpdateVitals(creature);
-            }
-            else {
-                creature.broadcastVitals();
-            }
-
-            if (minHp >= maxHp && minMp >= maxMp) {
-                this.stopReplenish();
-            }
+            this.replenishVitalsTick(creature);
         }, 3000);
     }
 
+    replenishVitalsTick(creature) {
+        const maxHp = creature.fetchMaxHp();
+        const maxMp = creature.fetchMaxMp();
+        const minHp = Math.min(creature.fetchHp() + this.fetchRevHpAmount(creature), maxHp);
+        const minMp = Math.min(creature.fetchMp() + this.fetchRevMpAmount(creature), maxMp);
+
+        creature.setHp(minHp);
+        creature.setMp(minMp);
+
+        if (creature.fetchKind === undefined) {
+            creature.statusUpdateVitals(creature);
+        }
+        else {
+            creature.broadcastVitals();
+        }
+
+        if (minHp >= maxHp && minMp >= maxMp) {
+            this.stopReplenish();
+        }
+
+        return { hp: minHp, mp: minMp };
+    }
+
     fetchRevHpAmount(creature) {
-        const base = Number(this.fetchRevHp()) || 0;
-        return Math.max(0, Math.round(base * EffectStats.multiplier(creature, 'regHp')));
+        const base = this.fetchPlayerRegenBase(creature, 'CON');
+        return Math.max(0, base * EffectStats.multiplier(creature, 'regHp') * this.fetchRegenStateMultiplier(creature));
     }
 
     fetchRevMpAmount(creature) {
-        const base = Number(this.fetchRevMp()) || 0;
-        return Math.max(0, Math.round(base * EffectStats.multiplier(creature, 'regMp') + EffectStats.add(creature, 'regMpAdd')));
+        const base = this.fetchPlayerRegenBase(creature, 'MEN');
+        return Math.max(0, (
+            (base * EffectStats.multiplier(creature, 'regMp'))
+            + EffectStats.add(creature, 'regMpAdd')
+        ) * this.fetchRegenStateMultiplier(creature));
+    }
+
+    fetchPlayerRegenBase(creature, stat) {
+        const base = Number(stat === 'CON' ? this.fetchRevHp() : this.fetchRevMp()) || 0;
+
+        // L2J C4 applies the level and CON/MEN modifiers to the template's
+        // level-adjusted regeneration value. NPCs keep their explicit
+        // template regeneration values.
+        if (typeof creature?.fetchClassId !== 'function') return base;
+
+        const rawStat = stat === 'CON'
+            ? Number(creature.fetchCon?.()) || 0
+            : Number(creature.fetchMen?.()) || 0;
+        const adjustedStat = Math.max(1, Math.round(
+            (rawStat + EffectStats.add(creature, stat))
+            * EffectStats.multiplier(creature, `${stat}Mul`)
+        ));
+        const level = Number(creature.fetchLevel?.()) || 1;
+        const statModifier = invoke('GameServer/Formulas').calcBaseMod[stat](adjustedStat);
+        return base * invoke('GameServer/Formulas').calcLevelMod(level) * statModifier;
+    }
+
+    fetchRegenStateMultiplier(creature) {
+        if (typeof creature?.fetchClassId !== 'function') return 1;
+
+        const state = creature.state;
+        return state?.fetchSeated?.() === true
+            ? 1.5
+            : state?.inMotion?.() === true
+                ? 0.7
+                : 1.1;
     }
 
     stopReplenish() {

--- a/src/GameServer/Bot/AI/BotRoles.js
+++ b/src/GameServer/Bot/AI/BotRoles.js
@@ -1,3 +1,5 @@
+const ClassProgression = invoke('GameServer/ClassProgression');
+
 const ROLE_CLASSES = {
     healer: [15, 16, 29, 30, 42, 43],
     buffer: [17, 49, 50, 51],
@@ -14,8 +16,14 @@ function classIdOf(value) {
     return null;
 }
 
-function inferRole(value) {
+function roleClassId(value) {
     const classId = classIdOf(value);
+    if (classId === null || classId === undefined) return classId;
+    return Number(ClassProgression.getThirdClass(classId)?.parentClassId || classId);
+}
+
+function inferRole(value) {
+    const classId = roleClassId(value);
     if (classId === null || classId === undefined) return 'dps';
 
     if (ROLE_CLASSES.healer.includes(classId)) return 'healer';
@@ -29,7 +37,7 @@ function inferRole(value) {
 }
 
 function isRole(value, role) {
-    const classId = classIdOf(value);
+    const classId = roleClassId(value);
     const classes = ROLE_CLASSES[role];
     return !!classes && classes.includes(classId);
 }

--- a/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
+++ b/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
@@ -53,6 +53,15 @@ function inventoryMap(inventory = {}) {
         : new Map(Object.values(inventory).map((item) => [Number(item.selfId), Number(item.amount || 0)]));
 }
 
+function inventoryItems(inventory = {}) {
+    const rows = Array.isArray(inventory) ? inventory : Object.values(inventory);
+    return rows.flatMap((row) => {
+        if (Number(row?.amount || 0) < 1) return [];
+        const item = (DataCache.items || []).find((entry) => Number(entry.selfId) === Number(row.selfId));
+        return item ? [item] : [];
+    });
+}
+
 function itemScore(item, role) {
     const stats = item.stats || {};
     const slot = Number(item.etc?.slot || 0);
@@ -71,9 +80,34 @@ function suitable(item, state, role, requiredRank = gradeForLevel(state.level)) 
     return JEWEL_SLOTS.has(slot) && kind === 'Armor.Jewel';
 }
 
+function isSlotUpgrade(item, ownedItems, role) {
+    const slot = WEAPON_SLOTS.has(Number(item.etc?.slot || 0)) ? 'weapon' : Number(item.etc?.slot || 0);
+    const rank = String(item.etc?.rank || 'none').toLowerCase();
+    const score = itemScore(item, role);
+    const price = Number(item.template?.price || 0);
+    // One item per paperdoll slot is enough. Keep a same-grade replacement
+    // only when it is genuinely stronger, or equally strong but from a more
+    // expensive progression tier.
+    return !ownedItems.some((owned) => (
+        (WEAPON_SLOTS.has(Number(owned.etc?.slot || 0)) ? 'weapon' : Number(owned.etc?.slot || 0)) === slot
+        && String(owned.etc?.rank || 'none').toLowerCase() === rank
+        && (itemScore(owned, role) > score
+            || (itemScore(owned, role) === score && Number(owned.template?.price || 0) >= price))
+    ));
+}
+
+function cGradePriceCap(level) {
+    const value = Number(level || 1);
+    if (value < 44) return 2290000;
+    if (value < 48) return 2870000;
+    if (value < 50) return 4300000;
+    return Infinity;
+}
+
 function preferredTarget(state = {}, options = {}) {
     const role = roleFor(state);
     const owned = inventoryMap(state.inventory);
+    const ownedItems = inventoryItems(state.inventory);
     const stationService = { level: 70, stats: { classId: 57 } };
     const availableToStations = CraftShopService.availableRecipes(stationService);
     const publishedRecipeIds = new Set(CraftShopService.CraftStations.flatMap((station) => (
@@ -91,13 +125,23 @@ function preferredTarget(state = {}, options = {}) {
         .map((item) => ({ item, recipe: recipesByProduct.get(Number(item.selfId)) }))
         .filter(({ recipe }) => !options.recipeId || Number(recipe.recipeId) === Number(options.recipeId))
         .filter(({ item }) => Number(owned.get(Number(item.selfId)) || 0) < 1)
+        .filter(({ item }) => isSlotUpgrade(item, ownedItems, role))
         .sort((a, b) => {
             const aSlot = Number(a.item.etc?.slot || 0);
             const bSlot = Number(b.item.etc?.slot || 0);
             const priority = (slot) => WEAPON_SLOTS.has(slot) ? 3 : ARMOR_SLOTS.has(slot) ? 2 : 1;
             return priority(bSlot) - priority(aSlot) || itemScore(b.item, role) - itemScore(a.item, role) || Number(b.item.template?.price || 0) - Number(a.item.template?.price || 0);
         });
-    return candidates[0] || null;
+    const requiredRank = recipeRank || gradeForLevel(state.level);
+    // A C-grade character should upgrade in affordable steps rather than
+    // commit all of its material gathering to the final C weapon immediately.
+    // Keep the top tier available from level 50, shortly before B-grade.
+    const affordable = requiredRank === 'c'
+        ? candidates.filter(({ item }) => Number(item.template?.price || 0) <= cGradePriceCap(state.level))
+        : candidates;
+    // At a C-tier cap, wait for the next level band instead of silently
+    // falling through to a top-C weapon once the current band is complete.
+    return requiredRank === 'c' ? affordable[0] || null : candidates[0] || null;
 }
 
 function preferredDropTarget(state = {}) {

--- a/src/GameServer/Bot/AI/States/HuntingState.js
+++ b/src/GameServer/Bot/AI/States/HuntingState.js
@@ -17,6 +17,9 @@ const TARGET_RETRY_COOLDOWN_MS = 15000;
 const TARGET_PROGRESS_DISTANCE = 40;
 const TARGET_SPOT_GRID_SIZE = 6000;
 const TARGET_GEODATA_CHECK_LIMIT = 4;
+const EMERGENCY_RETREAT_HP_RATIO = 0.35;
+const EMERGENCY_RETREAT_MP_RATIO = 0.20;
+const EMERGENCY_RETREAT_DISTANCE = 850;
 
 function isSoloHunter(session) {
     return session.plan === 'hunting' && session.partyCompanion !== true && !session.followPlayerSession;
@@ -147,6 +150,34 @@ function clearTarget(session, bot, targetId, retryCooldown = false) {
     session.targetStallTicks = 0;
     bot.unselect();
     return true;
+}
+
+function needsEmergencyRetreat(bot) {
+    return bot.fetchHp() / Math.max(1, bot.fetchMaxHp()) < EMERGENCY_RETREAT_HP_RATIO
+        || bot.fetchMp() / Math.max(1, bot.fetchMaxMp()) < EMERGENCY_RETREAT_MP_RATIO;
+}
+
+function retreatFromThreat(session, bot, threat) {
+    const from = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
+    const dx = from.locX - threat.fetchLocX();
+    const dy = from.locY - threat.fetchLocY();
+    const length = Math.sqrt(dx * dx + dy * dy) || 1;
+    const to = {
+        locX: Math.round(from.locX + (dx / length) * EMERGENCY_RETREAT_DISTANCE),
+        locY: Math.round(from.locY + (dy / length) * EMERGENCY_RETREAT_DISTANCE),
+        locZ: from.locZ
+    };
+
+    if (bot.state.fetchSeated()) {
+        bot.state.setSeated(false);
+        session.dataSendToOthers(ServerResponse.sitAndStand(bot), bot);
+    }
+    clearTarget(session, bot, session.currentTargetId);
+    session.plan = 'fleeing';
+    session.fleeStart = Date.now();
+    session.incomingThreatId = undefined;
+    session.incomingThreatAt = undefined;
+    bot.moveTo({ from, to });
 }
 
 function targetProgressing(session, bot, target) {
@@ -299,6 +330,10 @@ module.exports = {
         // actively hitting the bot only turns the recovery state into a death loop.
         const incomingMonster = PartyAwareness.recentIncomingNpc(session);
         if (incomingMonster) {
+            if (needsEmergencyRetreat(bot)) {
+                retreatFromThreat(session, bot, incomingMonster);
+                return;
+            }
             assignTarget(session, bot, incomingMonster);
             if (bot.state.fetchSeated()) {
                 bot.state.setSeated(false);

--- a/src/GameServer/Bot/AI/States/RestingState.js
+++ b/src/GameServer/Bot/AI/States/RestingState.js
@@ -4,6 +4,9 @@ const BotRoles       = invoke('GameServer/Bot/AI/BotRoles');
 const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
 
 const REST_FOLLOW_WAKE_DISTANCE = 600;
+const RECOVERY_HP_RATIO = 0.35;
+const RECOVERY_MP_RATIO = 0.20;
+const EMERGENCY_RETREAT_DISTANCE = 850;
 
 function point(actor) {
     return new SpeckMath.Point3D(actor.fetchLocX(), actor.fetchLocY(), actor.fetchLocZ());
@@ -24,6 +27,37 @@ function recordWakeDecision(session, bot, action, reason, extra = {}) {
         at: Date.now(),
         ...extra
     };
+}
+
+function needsRecovery(bot) {
+    return bot.fetchHp() / Math.max(1, bot.fetchMaxHp()) < RECOVERY_HP_RATIO
+        || bot.fetchMp() / Math.max(1, bot.fetchMaxMp()) < RECOVERY_MP_RATIO;
+}
+
+function retreatFromThreat(session, bot, threat) {
+    const from = { locX: bot.fetchLocX(), locY: bot.fetchLocY(), locZ: bot.fetchLocZ() };
+    const dx = from.locX - threat.fetchLocX();
+    const dy = from.locY - threat.fetchLocY();
+    const length = Math.sqrt(dx * dx + dy * dy) || 1;
+    const to = {
+        locX: Math.round(from.locX + (dx / length) * EMERGENCY_RETREAT_DISTANCE),
+        locY: Math.round(from.locY + (dy / length) * EMERGENCY_RETREAT_DISTANCE),
+        locZ: from.locZ
+    };
+
+    standUp(session, bot);
+    session.plan = 'fleeing';
+    session.fleeStart = Date.now();
+    session.currentTargetId = undefined;
+    session.incomingThreatId = undefined;
+    session.incomingThreatAt = undefined;
+    bot.unselect?.();
+    bot.moveTo?.({ from, to });
+    recordWakeDecision(session, bot, 'retreat', 'critical_resources_under_attack', {
+        targetId: threat.fetchId(),
+        hpRatio: bot.fetchHp() / Math.max(1, bot.fetchMaxHp()),
+        mpRatio: bot.fetchMp() / Math.max(1, bot.fetchMaxMp())
+    });
 }
 
 module.exports = {
@@ -47,7 +81,13 @@ module.exports = {
             const mpRatio = bot.fetchMp() / bot.fetchMaxMp();
             const recovered = hpRatio >= 0.95 && mpRatio >= 0.95;
 
-            if (threat || leaderTargetId || distance > REST_FOLLOW_WAKE_DISTANCE || (!leaderSeated && recovered)) {
+            // A recovering companion must stay seated even when its leader is
+            // far away.  Otherwise RestingState stands it up to follow, then
+            // FollowingState immediately seats it again for low HP/MP.
+            const shouldFollowLeader = recovered && (
+                distance > REST_FOLLOW_WAKE_DISTANCE || !leaderSeated
+            );
+            if (threat || leaderTargetId || shouldFollowLeader) {
                 session.plan = 'following';
                 session.currentTargetId = threat?.actor?.fetchId?.() || leaderTargetId || undefined;
                 session.townGossip = false;
@@ -68,6 +108,10 @@ module.exports = {
         if (!session.followPlayerSession && session.partyCompanion !== true) {
             const threat = PartyAwareness.recentIncomingNpc(session);
             if (threat) {
+                if (needsRecovery(bot)) {
+                    retreatFromThreat(session, bot, threat);
+                    return;
+                }
                 session.plan = 'hunting';
                 session.currentTargetId = threat.fetchId();
                 session.townGossip = false;

--- a/src/GameServer/Bot/AI/States/RestingState.js
+++ b/src/GameServer/Bot/AI/States/RestingState.js
@@ -2,11 +2,13 @@ const ServerResponse = invoke('GameServer/Network/Response');
 const SpeckMath      = invoke('GameServer/SpeckMath');
 const BotRoles       = invoke('GameServer/Bot/AI/BotRoles');
 const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
+const EffectStore    = invoke('GameServer/Effects/EffectStore');
 
 const REST_FOLLOW_WAKE_DISTANCE = 600;
 const RECOVERY_HP_RATIO = 0.35;
 const RECOVERY_MP_RATIO = 0.20;
 const EMERGENCY_RETREAT_DISTANCE = 850;
+const MANA_REGEN_CAST_RETRY_MS = 8000;
 
 function point(actor) {
     return new SpeckMath.Point3D(actor.fetchLocX(), actor.fetchLocY(), actor.fetchLocZ());
@@ -27,6 +29,31 @@ function recordWakeDecision(session, bot, action, reason, extra = {}) {
         at: Date.now(),
         ...extra
     };
+}
+
+function sitDown(session, bot) {
+    if (bot.state.fetchSeated()) return false;
+    bot.state.setSeated(true);
+    session.dataSendToOthers(ServerResponse.sitAndStand(bot), bot);
+    return true;
+}
+
+function maybeCastManaRegeneration(session, bot, Generics) {
+    const mpRatio = bot.fetchMp() / Math.max(1, bot.fetchMaxMp());
+    if (mpRatio >= 0.8 || Date.now() < Number(session.nextManaRegenAt || 0)) return false;
+
+    const skill = (bot.skillset?.fetchSkills?.() || [])
+        .find((entry) => !entry.fetchPassive?.()
+            && entry.fetchSemantic?.()?.effect === 'mana_regeneration'
+            && entry.fetchTargetKind?.() === 'self');
+    if (!skill || EffectStore.remainingMs(bot, 'mana_regeneration') > 0) return false;
+    if (Number(bot.fetchMp()) < Number(skill.fetchConsumedMp?.() || 0) || bot.state.fetchCasts?.()) return false;
+
+    standUp(session, bot);
+    session.nextManaRegenAt = Date.now() + MANA_REGEN_CAST_RETRY_MS;
+    Generics.skillExec(session, bot, { id: bot.fetchId(), selfId: skill.fetchSelfId(), ctrl: false });
+    recordWakeDecision(session, bot, 'cast_mana_regeneration', 'recover_mp', { skillId: skill.fetchSelfId() });
+    return true;
 }
 
 function needsRecovery(bot) {
@@ -61,6 +88,7 @@ function retreatFromThreat(session, bot, threat) {
 }
 
 module.exports = {
+    maybeCastManaRegeneration,
     tick(session, bot, Generics, BotAI) {
         if (session.followPlayerSession && session.partyCompanion === true) {
             const playerSession = session.followPlayerSession;
@@ -151,6 +179,11 @@ module.exports = {
                 BotAI.say(session, "Fully rested! Ready to hunt again.");
             }
         } else {
+            // skillExec marks the actor as casting immediately.  Do not sit
+            // on the next brain tick while the native self-cast is still live.
+            if (bot.state.fetchCasts?.()) return;
+            if (maybeCastManaRegeneration(session, bot, Generics)) return;
+            sitDown(session, bot);
             // 3% chance per tick to attempt conversation when resting near other bots
             if (Math.random() < 0.03) {
                 try {

--- a/src/GameServer/Bot/BotClassProgression.js
+++ b/src/GameServer/Bot/BotClassProgression.js
@@ -1,0 +1,50 @@
+const Database = invoke('Database');
+const Skillset = invoke('GameServer/Actor/Skillset');
+const ClassProgression = invoke('GameServer/ClassProgression');
+
+function stableNumber(value) {
+    return [...String(value || 0)].reduce((sum, character) => sum + character.charCodeAt(0), 0);
+}
+
+function pick(options, seed) {
+    if (!options?.length) return null;
+    return options[Math.abs(stableNumber(seed)) % options.length];
+}
+
+function nextClass(classId, level, seed) {
+    const current = Number(classId);
+    const currentLevel = Number(level || 1);
+    if (currentLevel >= 20 && ClassProgression.firstProfMap[current]) {
+        return pick(ClassProgression.firstProfMap[current], seed);
+    }
+    if (currentLevel >= 40 && ClassProgression.secondProfMap[current]) {
+        return pick(ClassProgression.secondProfMap[current], seed);
+    }
+    if (currentLevel >= 76) {
+        return Number(Object.entries(ClassProgression.thirdClasses)
+            .find(([, entry]) => Number(entry.parentClassId) === current)?.[0]) || null;
+    }
+    return null;
+}
+
+async function reconcile({ characterId, classId, level, seed = characterId } = {}) {
+    const id = Number(characterId);
+    let resolvedClassId = Number(classId);
+    const transitions = [];
+    if (!id || !Number.isFinite(resolvedClassId)) return { classId: resolvedClassId, transitions };
+
+    // The bot may have accumulated levels while cold.  Award its current tree
+    // first, then walk every profession threshold it has already passed.
+    const skillset = new Skillset();
+    await skillset.awardSkills(id, resolvedClassId, level);
+    for (let target = nextClass(resolvedClassId, level, seed); target; target = nextClass(resolvedClassId, level, seed)) {
+        await Database.updateCharacterClassId(id, target);
+        resolvedClassId = target;
+        transitions.push(target);
+        await skillset.awardSkills(id, resolvedClassId, level);
+    }
+
+    return { classId: resolvedClassId, transitions };
+}
+
+module.exports = { nextClass, reconcile };

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -33,11 +33,39 @@ const MERCHANT_BOTS = Object.keys(MerchantConfigs).map(name => {
 
 const merchantConfigFor = (botData, characterName) => MerchantConfigs[botData.merchantConfigName || characterName];
 
+function isOnGiranMarketPlaza(loc = {}) {
+    return Number(loc.locX) >= 80911 && Number(loc.locX) <= 83750
+        && Number(loc.locY) >= 147662 && Number(loc.locY) <= 149550;
+}
+
+function stableSpawnLocation(botData = {}) {
+    const spawns = BotAI.newbieSpawnCoords(botData.spawnClassId || botData.classId);
+    const seed = [...String(botData.username || botData.name || '')]
+        .reduce((sum, character) => sum + character.charCodeAt(0), 0);
+    const spawn = spawns[seed % spawns.length] || spawns[0];
+    const offsetX = ((seed * 37) % 301) - 150;
+    const offsetY = ((seed * 71) % 301) - 150;
+    return {
+        locX: Number(spawn.locX) + offsetX,
+        locY: Number(spawn.locY) + offsetY,
+        locZ: Number(spawn.locZ)
+    };
+}
+
+function recoverStarterSpawn(botData = {}, character = {}) {
+    // Static starters are reloaded directly by BotManager, outside the cold
+    // population activation path.  A historical Giran location therefore
+    // used to respawn every starter on top of the craft station after restart.
+    if (botData.merchantConfigName || !botData.homeRegion || !isOnGiranMarketPlaza(character)) return botData;
+    return { ...botData, ...stableSpawnLocation(botData) };
+}
+
 const BotManager = {
     sessions: [],
     pkEncounterTimer: null,
     pkEncounterPending: new Set(),
     pkEncounterBots: [],
+    recoverStarterSpawn,
 
     findSessionByName(name) {
         const lookup = String(name || '').toLowerCase();
@@ -364,9 +392,15 @@ const BotManager = {
     provisionCharacter(username, botData, idx) {
         Database.fetchCharacters(username).then((characters) => {
             if (characters[0]) {
-                this.applyProfileLevel(characters[0], botData)
-                    .then(() => this.awardProfileSkills(characters[0].id, botData))
-                    .then(() => this.loadAndSpawnBot(username, botData));
+                const existing = characters[0];
+                const recoveredBotData = recoverStarterSpawn(botData, existing);
+                const recoveredLoc = recoveredBotData.locX === undefined
+                    ? Promise.resolve()
+                    : Database.updateCharacterLocation(existing.id, recoveredBotData);
+                recoveredLoc
+                    .then(() => this.applyProfileLevel(existing, recoveredBotData))
+                    .then(() => this.awardProfileSkills(existing.id, recoveredBotData))
+                    .then(() => this.loadAndSpawnBot(username, recoveredBotData));
                 return;
             }
 

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -21,6 +21,7 @@ const SimulationKernel = invoke('GameServer/Bot/Simulation/SimulationKernel');
 const GoalService = invoke('GameServer/Bot/Goals/GoalService');
 const BotConversation = invoke('GameServer/Bot/AI/BotConversation');
 const BotSupportPlanner = invoke('GameServer/Bot/AI/BotSupportPlanner');
+const BotClassProgression = invoke('GameServer/Bot/BotClassProgression');
 
 const BOTS_TO_SPAWN = BotPopulation.buildStarterBots();
 const DIRECT_SUPPORT_RANGE = 900;
@@ -399,7 +400,7 @@ const BotManager = {
                     : Database.updateCharacterLocation(existing.id, recoveredBotData);
                 recoveredLoc
                     .then(() => this.applyProfileLevel(existing, recoveredBotData))
-                    .then(() => this.awardProfileSkills(existing.id, recoveredBotData))
+                    .then(() => this.awardProfileSkills(existing.id, recoveredBotData, existing.classId))
                     .then(() => this.loadAndSpawnBot(username, recoveredBotData));
                 return;
             }
@@ -462,19 +463,19 @@ const BotManager = {
         if (!character?.id || level <= 1) return Promise.resolve(false);
         const exp = Number(DataCache.experience?.[level - 1] || 0);
         const sp = Math.round(level * level * 3);
-        const classChanged = Number(character.classId) > 0 && Number(character.classId) !== Number(botData.classId);
-        const classReady = classChanged
-            ? Database.deleteSkills(character.id).then(() => Database.updateCharacterClassId(character.id, botData.classId))
-            : Promise.resolve();
-        return classReady.then(() => Database.updateCharacterExperience(character.id, level, exp, sp))
+        return Database.updateCharacterExperience(character.id, level, exp, sp)
             .then(() => true);
     },
 
-    awardProfileSkills(characterId, botData = {}) {
+    awardProfileSkills(characterId, botData = {}, currentClassId = botData.classId) {
         const level = Number(botData.level || 1);
         if (level <= 1) return Promise.resolve();
-        const Skillset = invoke('GameServer/Actor/Skillset');
-        return new Skillset().awardSkills(characterId, botData.classId, level);
+        return BotClassProgression.reconcile({
+            characterId,
+            classId: currentClassId,
+            level,
+            seed: botData.name || characterId
+        });
     },
 
     prepareBotForSpawn(session, botData = {}) {
@@ -507,15 +508,20 @@ const BotManager = {
             const skillsReady = this.awardProfileSkills(firstCharacter.id, {
                 classId: firstCharacter.classId,
                 level: firstCharacter.level
-            });
-            const gearReady = skillsReady.then(() => (firstStoreCfg
-                ? Promise.resolve()
-                : BotGear.ensureCharacterGear(firstCharacter, botData))
-                .then(() => ShotStock.ensureCharacterStock(firstCharacter.id, {
-                    classId: firstCharacter.classId,
+            }, firstCharacter.classId);
+            const gearReady = skillsReady.then(() => Shared.fetchCharacters(username))
+                .then((reconciledCharacters) => {
+                    const reconciledCharacter = reconciledCharacters[0];
+                    if (!reconciledCharacter) return null;
+                    return (firstStoreCfg
+                        ? Promise.resolve()
+                        : BotGear.ensureCharacterGear(reconciledCharacter, botData))
+                        .then(() => ShotStock.ensureCharacterStock(reconciledCharacter.id, {
+                    classId: reconciledCharacter.classId,
                     targetAmount: ShotStock.DEFAULT_TARGET_AMOUNT
                 }))
-                .then(() => Shared.fetchCharacters(username)));
+                        .then(() => Shared.fetchCharacters(username));
+                });
 
             gearReady.then((readyCharacters) => {
                 const character = readyCharacters[0];

--- a/src/GameServer/Bot/Economy/CraftShopService.js
+++ b/src/GameServer/Bot/Economy/CraftShopService.js
@@ -4,20 +4,25 @@ const Database = invoke('Database');
 const BotEconomyPricing = invoke('GameServer/Bot/Economy/BotEconomyPricing');
 
 const MAX_PUBLIC_RECIPES = 16;
-const GIRAN_CRAFT_ROWS = [147780, 148130, 149120, 149470, 149820];
-const GIRAN_CRAFT_COLUMNS = [81020, 81380, 81740, 82100, 82460];
-const GiranCraftGrid = GIRAN_CRAFT_ROWS.flatMap((locY) => (
-    GIRAN_CRAFT_COLUMNS.map((locX) => Object.freeze({ locX, locY, locZ: -3466 }))
-));
-// The final three services sit beside, rather than beyond, the normal grid.
-// These are open Giran market-square points, separated from the grid and the
-// permanent Giran merchants so their models never stack.
-const GiranCraftOverflowStalls = Object.freeze([
-    Object.freeze({ locX: 82820, locY: 147780, locZ: -3466 }),
-    Object.freeze({ locX: 83180, locY: 147780, locZ: -3466 }),
-    Object.freeze({ locX: 83540, locY: 147780, locZ: -3466 })
-]);
-const GiranCraftStalls = Object.freeze([...GiranCraftGrid, ...GiranCraftOverflowStalls]);
+const CRAFT_LOC_Z = -3466;
+const craftLoc = (locX, locY) => Object.freeze({ locX, locY, locZ: CRAFT_LOC_Z });
+// These are the captured sellable limits of the Giran plaza, inset by the
+// normal 60-unit store margin.  Keep service crafters on this outer frame:
+// the large central column remains completely free for player movement.
+const GIRAN_CRAFT_OUTER = Object.freeze({ minX: 80971, maxX: 82887, minY: 147722, maxY: 149490 });
+
+function perimeterStalls(bounds, count) {
+    const width = bounds.maxX - bounds.minX;
+    const height = bounds.maxY - bounds.minY;
+    const perimeter = 2 * (width + height);
+    return Object.freeze(Array.from({ length: count }, (_, index) => {
+        const distance = (perimeter * index) / count;
+        if (distance < width) return craftLoc(Math.round(bounds.minX + distance), bounds.minY);
+        if (distance < width + height) return craftLoc(bounds.maxX, Math.round(bounds.minY + distance - width));
+        if (distance < 2 * width + height) return craftLoc(Math.round(bounds.maxX - (distance - width - height)), bounds.maxY);
+        return craftLoc(bounds.minX, Math.round(bounds.maxY - (distance - 2 * width - height)));
+    }));
+}
 
 const STATION_LAYOUT = [
     ['d', 'heavy', 'D Heavy: Brigandine Set', [79, 263, 266, 268, 271]],
@@ -28,7 +33,7 @@ const STATION_LAYOUT = [
     ['c', 'heavy', 'C Heavy: Full Plate Set', [124, 303, 305, 307]],
     ['c', 'robe', 'C Robes: Karmian & Divine', [100, 92, 282, 288, 126, 127, 302, 309]],
     ['c', 'light', 'C Light: Plated Leather Set', [104, 105, 283]],
-    ['c', 'weapons', 'C Grade Weapons'],
+    ['c', 'weapons', 'C Weapons: Top', [246, 247, 248, 249, 250, 252, 313], 'c_weapons_top'],
     ['c', 'jewelry', 'C Jewelry', [59, 63, 261]],
     ['b', 'heavy', 'B Heavy: Blue Wolf & Doom', [386, 390, 406, 410, 422, 392, 408, 412, 428, 384]],
     ['b', 'robe', 'B Robes: Avadon, Blue Wolf & Doom', [372, 374, 376, 426, 398, 402, 400, 404]],
@@ -47,17 +52,45 @@ const STATION_LAYOUT = [
     ['s', 'weapons', 'S Grade: Core Weapons', [627, 631, 633, 639, 641, 643, 645, 775]],
     ['s', 'jewelry', 'S Jewelry: Tateossian', [647, 649, 651]],
     ['resource', 'core', 'Resources: Molds & Alloys', [27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 497]],
-    ['resource', 'master', 'Resources: Maestro Components', [474, 475, 476, 477, 607, 608, 609, 610, 611, 612]]
+    ['resource', 'master', 'Resources: Maestro Components', [474, 475, 476, 477, 607, 608, 609, 610, 611, 612]],
+    // Append new services only: generated service slots are persisted, so
+    // inserting these before an existing station would repurpose its bot.
+    // C has a long progression window.  Publishing only each weapon kind's
+    // strongest recipe made a fresh level-40 bot aim at a 6.13m weapon, so
+    // the catalogue intentionally mirrors the entry, mid and late tiers.
+    ['c', 'weapons', 'C Weapons: Entry', [191, 192, 198, 199, 201, 205], 'c_weapons_entry'],
+    ['c', 'weapons', 'C Weapons: Mid', [208, 209, 213, 214, 216, 217, 312], 'c_weapons_mid'],
+    ['c', 'weapons', 'C Weapons: Late', [220, 222, 223, 228, 230, 234, 237, 238, 240], 'c_weapons_late']
 ];
 
-const CraftStations = Object.freeze(STATION_LAYOUT.map(([grade, category, title, recipeIds, stationId], index) => Object.freeze({
-    id: stationId || `${grade}_${category}`,
-    grade,
-    category,
-    title,
-    recipeIds: recipeIds ? Object.freeze([...recipeIds]) : null,
-    loc: Object.freeze({ ...GiranCraftStalls[index] })
-})));
+// Position groups independently from generated account slots.  Existing craft
+// accounts retain their slot identity while the visible market can be ordered
+// by grade: D, C (including all C weapon tiers), B, A, S, then resources.
+const STATION_LOCATION_ORDER = Object.freeze([
+    'd_heavy', 'd_robe', 'd_light', 'd_weapons', 'd_jewelry',
+    'c_heavy', 'c_robe', 'c_light', 'c_weapons_entry', 'c_weapons_mid', 'c_weapons_late', 'c_weapons_top', 'c_jewelry',
+    'b_heavy', 'b_robe', 'b_light', 'b_weapons', 'b_jewelry',
+    'a_heavy', 'a_robe', 'a_light', 'a_weapons', 'a_jewelry', 'a_heavy_elite',
+    's_heavy', 's_robe', 's_light', 's_weapons', 's_jewelry',
+    'resource_core', 'resource_master'
+]);
+// 31 offers fit on the outer frame at a regular 238-unit interval.  If the
+// catalogue grows beyond this compact ring, add a second full perimeter around
+// the central column rather than filling its interior in partial rows.
+const GiranCraftStalls = perimeterStalls(GIRAN_CRAFT_OUTER, STATION_LOCATION_ORDER.length);
+const stationLocations = new Map(STATION_LOCATION_ORDER.map((stationId, index) => [stationId, GiranCraftStalls[index]]));
+
+const CraftStations = Object.freeze(STATION_LAYOUT.map(([grade, category, title, recipeIds, stationId], index) => {
+    const id = stationId || `${grade}_${category}`;
+    return Object.freeze({
+        id,
+        grade,
+        category,
+        title,
+        recipeIds: recipeIds ? Object.freeze([...recipeIds]) : null,
+        loc: Object.freeze({ ...(stationLocations.get(id) || GiranCraftStalls[index]) })
+    });
+}));
 
 function isServiceCrafter(state = {}) {
     const classId = Number(state.classId || state.stats?.classId || 0);

--- a/src/GameServer/Bot/Population/BackgroundPartyResolver.js
+++ b/src/GameServer/Bot/Population/BackgroundPartyResolver.js
@@ -1,5 +1,6 @@
 const ProgressionRates = invoke('GameServer/ProgressionRates');
 const BackgroundDropResolver = invoke('GameServer/Bot/Population/BackgroundDropResolver');
+const BackgroundResolver = invoke('GameServer/Bot/Population/BackgroundResolver');
 const PartyAffinity = invoke('GameServer/Bot/Population/BackgroundPartyAffinity');
 
 const MAX_DROPS_PER_RESOLVE = 4;
@@ -86,7 +87,7 @@ function distributeRewards({ members, spot, wins, pressure, rng }) {
 }
 
 const BackgroundPartyResolver = {
-    resolve({ party, members, spot, pressure = {}, elapsedMs = 60000, rng = Math.random }) {
+    resolve({ party, members, spot, pressure = {}, elapsedMs = 60000, rng = Math.random, timestamp = Date.now() }) {
         if (!party || !members?.length || !spot) {
             return {
                 memberResults: [],
@@ -94,6 +95,47 @@ const BackgroundPartyResolver = {
                 partyPatch: {},
                 nextResolveAt: Date.now() + 60000,
                 debug: { reason: 'missing_party_members_or_spot' }
+            };
+        }
+
+        // A party shares its hunting cadence.  If even one member is resting,
+        // pause the whole group: otherwise the resolver keeps granting fights
+        // and draining the exhausted member on every cold tick.
+        if (members.some((state) => state.activity === 'resting')) {
+            const memberResults = members.map((state) => ({
+                state,
+                result: BackgroundResolver.resolveRest({
+                    ...state,
+                    activity: 'resting'
+                }, elapsedMs, timestamp)
+            }));
+            const resting = memberResults.filter(({ result }) => result.patch.activity === 'resting').length;
+
+            return {
+                memberResults,
+                events: [],
+                partyPatch: {
+                    cohesion: Number(party.cohesion || 0.65),
+                    risk: Number(party.risk || 0.25),
+                    stats: {
+                        ...(party.stats || {}),
+                        rests: Number(party.stats?.rests || 0) + 1,
+                        lastResolveAt: timestamp
+                    }
+                },
+                nextResolveAt: timestamp + (resting > 0 ? 30000 : 45000),
+                debug: {
+                    activity: resting > 0 ? 'resting' : 'recovered',
+                    fights: 0,
+                    wins: 0,
+                    losses: 0,
+                    deaths: 0,
+                    resting,
+                    dropsRolled: 0,
+                    dropsAwarded: 0,
+                    spotId: spot.id,
+                    route: spot.route || null
+                }
             };
         }
 
@@ -205,10 +247,10 @@ const BackgroundPartyResolver = {
                     fightsWon: Number(party.stats?.fightsWon || 0) + wins,
                     deaths: Number(party.stats?.deaths || 0) + deaths,
                     rests: Number(party.stats?.rests || 0) + resting,
-                    lastResolveAt: Date.now()
+                        lastResolveAt: timestamp
                 }
             },
-            nextResolveAt: Date.now() + 45000 + Math.round(rng() * 90000),
+            nextResolveAt: timestamp + 45000 + Math.round(rng() * 90000),
             debug: {
                 fights,
                 wins,

--- a/src/GameServer/Bot/Population/BackgroundResolver.js
+++ b/src/GameServer/Bot/Population/BackgroundResolver.js
@@ -1,5 +1,8 @@
 const ProgressionRates = invoke('GameServer/ProgressionRates');
 const BackgroundDropResolver = invoke('GameServer/Bot/Population/BackgroundDropResolver');
+const DataCache = invoke('GameServer/DataCache');
+const Formulas = invoke('GameServer/Formulas');
+const C4SkillRules = invoke('GameServer/Skills/C4SkillRules');
 
 function clamp(value, min, max) {
     return Math.max(min, Math.min(max, value));
@@ -68,15 +71,83 @@ function botCombatStats(state, role) {
     };
 }
 
-function estimateRestMs(vitals, stats) {
-    const missingHp = Math.max(0, stats.maxHp - Number(vitals.hp || 0));
-    const missingMp = Math.max(0, stats.maxMp - Number(vitals.mp || 0));
-    const hpRegenPerSecond = Math.max(2, stats.maxHp * 0.035);
-    const mpRegenPerSecond = Math.max(1, stats.maxMp * 0.028);
-    const hpSeconds = missingHp / hpRegenPerSecond;
-    const mpSeconds = missingMp / mpRegenPerSecond;
+function coldPassiveRegenAdd(state, skillId, stat) {
+    const classId = Number(state.stats?.classId ?? state.classId);
+    const skill = (DataCache.skillTree || []).find((tree) => Number(tree.classId) === classId)?.skills
+        ?.find((entry) => Number(entry.selfId) === skillId);
+    const level = Number(state.level || midpointBand(state.levelBand));
+    const skillLevel = (skill?.levels || [])
+        .filter((entry) => Number(entry.pLevel) <= level)
+        .reduce((highest, entry) => Math.max(highest, Number(entry.level) || 0), 0);
+    if (!skillLevel) return 0;
+
+    return Number(C4SkillRules.resolve({ selfId: skillId, level: skillLevel }).stats?.[stat]) || 0;
+}
+
+function coldRestRegenPerTick(state) {
+    const level = Math.max(1, Number(state.level || midpointBand(state.levelBand)) || 1);
+    const classId = Number(state.stats?.classId ?? state.classId);
+    const template = (DataCache.classTemplates || []).find((entry) => Number(entry.classId) === classId) || {};
+    const baseStats = template.base || {};
+    const hpBase = Number(DataCache.revitalize?.hp?.[level]) || 0;
+    const mpBase = Number(DataCache.revitalize?.mp?.[level]) || 0;
+    const hp = ((hpBase * Formulas.calcLevelMod(level) * Formulas.calcBaseMod.CON(Number(baseStats.con) || 1))
+        + coldPassiveRegenAdd(state, 212, 'regHpAdd')) * 1.5;
+    const mp = ((mpBase * Formulas.calcLevelMod(level) * Formulas.calcBaseMod.MEN(Number(baseStats.men) || 1))
+        + coldPassiveRegenAdd(state, 229, 'regMpAdd')) * 1.5;
+
+    return { hp: Math.max(0, hp), mp: Math.max(0, mp) };
+}
+
+function estimateRestMs(state, vitals) {
+    const maxHp = Number(vitals.maxHp || vitals.hp || 1);
+    const maxMp = Number(vitals.maxMp || vitals.mp || 1);
+    const missingHp = Math.max(0, maxHp - Number(vitals.hp || 0));
+    const missingMp = Math.max(0, maxMp - Number(vitals.mp || 0));
+    const regen = coldRestRegenPerTick(state);
+    const hpSeconds = missingHp / Math.max(0.01, regen.hp / 3);
+    const mpSeconds = missingMp / Math.max(0.01, regen.mp / 3);
 
     return Math.round(Math.max(hpSeconds, mpSeconds, 8) * 1000);
+}
+
+function resolveRest(state, elapsedMs, timestamp) {
+    const combat = botCombatStats(state, roleProfile(state));
+    const vitals = {
+        hp: Math.max(0, Number(state.vitals?.hp || 0)),
+        maxHp: combat.maxHp,
+        mp: Math.max(0, Number(state.vitals?.mp || 0)),
+        maxMp: combat.maxMp
+    };
+    const regen = coldRestRegenPerTick(state);
+    const ticks = Math.max(0, Number(elapsedMs) || 0) / 3000;
+    vitals.hp = Math.min(vitals.maxHp, vitals.hp + regen.hp * ticks);
+    vitals.mp = Math.min(vitals.maxMp, vitals.mp + regen.mp * ticks);
+
+    const hpReady = vitals.hp / Math.max(1, vitals.maxHp) >= 0.95;
+    const mpReady = vitals.mp / Math.max(1, vitals.maxMp) >= 0.95;
+    const scheduledRemainingMs = Math.max(0, Number(state.stats?.restUntil || 0) - timestamp);
+    const remainingMs = Math.max(estimateRestMs(state, vitals), scheduledRemainingMs);
+    const resting = !hpReady || !mpReady || scheduledRemainingMs > 0;
+    const restUntil = resting ? timestamp + remainingMs : null;
+
+    return {
+        patch: {
+            activity: resting ? 'resting' : 'hunting',
+            vitals,
+            stats: { ...(state.stats || {}), restUntil }
+        },
+        events: resting ? [] : [{
+            type: 'recovered',
+            summary: `${state.name || 'Bot'} finished recovering and returned to hunting`,
+            weight: 1
+        }],
+        materialize: { exp: 0, sp: 0, adena: 0, items: [] },
+        nextResolveAt: resting
+            ? timestamp + Math.max(3000, Math.min(30000, remainingMs || 30000))
+            : timestamp + 30000,
+        debug: { activity: resting ? 'resting' : 'recovered', regen, remainingMs }
+    };
 }
 
 function resolveTravel(state, timestamp = Date.now()) {
@@ -237,7 +308,8 @@ function resolveFight({ state, spot, pressure, rng }) {
 }
 
 const BackgroundResolver = {
-    resolveSolo({ state, spot, pressure = {}, elapsedMs = 60000, rng = Math.random }) {
+    resolveRest,
+    resolveSolo({ state, spot, pressure = {}, elapsedMs = 60000, rng = Math.random, timestamp = Date.now() }) {
         if (!state) {
             return {
                 patch: {},
@@ -305,7 +377,11 @@ const BackgroundResolver = {
 
         const reportedHp = Number(state.vitals?.hp);
         if (state.activity === 'dead' || (Number.isFinite(reportedHp) && reportedHp <= 0)) {
-            return resolveDeathRecovery(state);
+            return resolveDeathRecovery(state, timestamp);
+        }
+
+        if (state.activity === 'resting') {
+            return resolveRest(state, elapsedMs, timestamp);
         }
 
         if (!spot) {
@@ -359,7 +435,10 @@ const BackgroundResolver = {
             const mpPct = patch.vitals.mp / Math.max(1, patch.vitals.maxMp || patch.vitals.mp || 1);
             if (hpPct < 0.35 || mpPct < 0.2) {
                 patch.activity = 'resting';
-                patch.restUntil = Date.now() + estimateRestMs(patch.vitals, botCombatStats(fightState, roleProfile(fightState)));
+                patch.stats = {
+                    ...(state.stats || {}),
+                    restUntil: timestamp + estimateRestMs(fightState, patch.vitals)
+                };
                 events.push({
                     type: 'rest',
                     summary: `${state.name || 'Bot'} sat down to recover near ${spot.name}`,

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -225,6 +225,11 @@ function recordFromSession(session, phase, reason = '') {
     const stats = {
         role: session.botStatus?.role || null,
         classId: actor.fetchClassId ? Number(actor.fetchClassId()) : null,
+        // A freshly spawned bot may cool before it has gone through a cold
+        // resolve. Persist the completed profile here so it is never picked
+        // up by the one-off legacy migration on a later restart.
+        classProgressionLevel: actor.fetchLevel(),
+        classProgressionClassId: actor.fetchClassId ? Number(actor.fetchClassId()) : null,
         clanId: actor.fetchClanId ? Number(actor.fetchClanId()) || 0 : 0,
         route: currentSpot?.route || null,
         build: GearSkillHints.forCharacter(actor, { role: session.botStatus?.role || null }),
@@ -404,6 +409,48 @@ function hydrateCache() {
             cache.set(state.characterId, state);
         });
         return rows.length;
+    });
+}
+
+function classProgressionNeeded(state, classId, level) {
+    const knownLevel = Number(state.stats?.classProgressionLevel || 0);
+    const knownClassId = Number(state.stats?.classProgressionClassId ?? state.stats?.classId);
+    return knownLevel < Number(level || 1) || knownClassId !== Number(classId);
+}
+
+function applyClassProgression(state, profile = {}) {
+    const level = Number(profile.level || state.level || 1);
+    const currentClassId = Number(profile.classId ?? state.stats?.classId ?? 0);
+    if (!classProgressionNeeded(state, currentClassId, level)) return Promise.resolve(state);
+
+    return BotClassProgression.reconcile({
+        characterId: state.characterId,
+        classId: currentClassId,
+        level,
+        seed: state.name || state.characterId
+    }).then((resolved) => {
+        const classId = Number(resolved.classId || currentClassId);
+        const role = BotRoles.inferRole(classId);
+        const progressedState = {
+            ...state,
+            level,
+            exp: profile.exp ?? state.exp,
+            sp: profile.sp ?? state.sp,
+            party: { ...(state.party || {}), role },
+            stats: {
+                ...(state.stats || {}),
+                classId,
+                role,
+                build: GearSkillHints.forCharacter({ classId, level }, { role }),
+                classProgressionLevel: level,
+                classProgressionClassId: classId,
+                classTransitions: resolved.transitions?.length
+                    ? [...(state.stats?.classTransitions || []), ...resolved.transitions]
+                    : state.stats?.classTransitions || []
+            }
+        };
+        if (resolved.transitions?.length) delete progressedState.stats.equipmentPlan;
+        return progressedState;
     });
 }
 
@@ -867,6 +914,45 @@ const BotLifeState = {
             utils.infoWarn('BotLife', 'failed to fetch due cold states: %s', err.message);
             return [];
         });
+    },
+
+    migrateLegacyClassProgression(limit = 5) {
+        if (!initialized) return Promise.resolve([]);
+        const safeLimit = Math.max(1, Math.min(20, Number(limit) || 5));
+        const candidates = Array.from(cache.values())
+            // Hot bots own a live Actor instance. Their class is reconciled
+            // through activation/level-up, not behind that actor's back.
+            .filter((state) => state.phase === 'cold')
+            .filter((state) => !pendingWrites.has(state.characterId))
+            .filter((state) => classProgressionNeeded(
+                state,
+                Number(state.stats?.classId || 0),
+                Number(state.level || 1)
+            ))
+            .sort((a, b) => Number(a.updatedAt || 0) - Number(b.updatedAt || 0))
+            .slice(0, safeLimit);
+
+        return candidates.reduce((chain, state) => chain.then((migrated) => (
+            Database.execute([
+                'SELECT id, classId, level, exp, sp FROM characters WHERE id = ? LIMIT 1',
+                [state.characterId]
+            ]).then((rows) => {
+                const character = rows[0];
+                if (!character) return migrated;
+                return applyClassProgression(state, character).then((progressedState) => {
+                    if (progressedState === state) return migrated;
+                    const row = rowFromState(progressedState);
+                    return save(row).then(() => {
+                        const snapshot = normalize(row);
+                        cache.set(snapshot.characterId, snapshot);
+                        return [...migrated, snapshot];
+                    });
+                });
+            }).catch((err) => {
+                utils.infoWarn('BotLife', 'legacy class progression failed for %s: %s', state.name, err.message);
+                return migrated;
+            })
+        )), Promise.resolve([]));
     },
 
     statesForParty(partyId) {

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -7,6 +7,8 @@ const SpotService = invoke('GameServer/Bot/AI/SpotService');
 
 const TABLE = 'bot_life_state';
 const GearSkillHints = invoke('GameServer/Bot/AI/GearSkillHints');
+const BotClassProgression = invoke('GameServer/Bot/BotClassProgression');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 const cache = new Map();
 const pendingWrites = new Map();
 let initialized = false;
@@ -1039,12 +1041,44 @@ const BotLifeState = {
             inventory,
             updatedAt: timestamp
         };
-        const row = rowFromState(nextState);
+        const knownProfileLevel = Number(nextState.stats?.classProgressionLevel || 0);
+        const knownProfileClassId = Number(nextState.stats?.classProgressionClassId ?? nextState.stats?.classId);
+        const currentClassId = Number(nextState.stats?.classId || 0);
+        const needsClassProgression = knownProfileLevel < level || knownProfileClassId !== currentClassId;
+        const progression = needsClassProgression
+            ? BotClassProgression.reconcile({
+                characterId: nextState.characterId,
+                classId: currentClassId,
+                level,
+                seed: nextState.name || nextState.characterId
+            })
+            : Promise.resolve({ classId: currentClassId, transitions: [] });
 
-        return save(row)
+        return progression.then((resolved) => {
+            const classId = Number(resolved.classId || currentClassId);
+            const role = BotRoles.inferRole(classId);
+            const progressedState = {
+                ...nextState,
+                party: { ...(nextState.party || {}), role },
+                stats: {
+                    ...(nextState.stats || {}),
+                    classId,
+                    role,
+                    build: GearSkillHints.forCharacter({ classId, level }, { role }),
+                    classProgressionLevel: level,
+                    classProgressionClassId: classId,
+                    classTransitions: resolved.transitions?.length
+                        ? [...(nextState.stats?.classTransitions || []), ...resolved.transitions]
+                        : nextState.stats?.classTransitions || []
+                }
+            };
+            if (resolved.transitions?.length) delete progressedState.stats.equipmentPlan;
+            const row = rowFromState(progressedState);
+
+            return save(row)
             .then(() => Database.updateCharacterExperience(row.characterId, row.level, row.exp, row.sp))
             .then(() => Database.updateCharacterVitals(row.characterId, row.hp, row.maxHp, row.mp, row.maxMp))
-            .then(() => syncInventorySummary(row.characterId, nextState.inventory))
+            .then(() => syncInventorySummary(row.characterId, progressedState.inventory))
             .then(() => {
                 const snapshot = normalize(row);
                 cache.set(snapshot.characterId, snapshot);
@@ -1054,6 +1088,7 @@ const BotLifeState = {
                 utils.infoWarn('BotLife', 'failed to apply resolve for %s: %s', state.name, err.message);
                 return null;
             });
+        });
     },
 
     marketGoalCandidates(limit = 8) {

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -462,8 +462,27 @@ function mergeSessionIntoLifeState(session, state, phase, reason = '', options =
     };
 }
 
+// A stale cold snapshot can retain the previous hunting region while its
+// physical coordinate is still on the Giran trading square.  Coordinates are
+// authoritative here: currentRegion is plan context, not a location proof.
+const GIRAN_MARKET_PLAZA = Object.freeze({
+    minX: 80911,
+    // Public stations and the north-east edge of the actual trading square
+    // extend beyond the conservative stall-placement rectangle.
+    maxX: 83750,
+    minY: 147662,
+    maxY: 149550
+});
+
+function isOnGiranMarketPlaza(loc = {}) {
+    return Number(loc.locX) >= GIRAN_MARKET_PLAZA.minX
+        && Number(loc.locX) <= GIRAN_MARKET_PLAZA.maxX
+        && Number(loc.locY) >= GIRAN_MARKET_PLAZA.minY
+        && Number(loc.locY) <= GIRAN_MARKET_PLAZA.maxY;
+}
+
 function shouldRecoverOrphanedGiranState(state = {}) {
-    if (state.phase !== 'cold' || state.currentRegion !== 'Giran' || !state.spotId) return false;
+    if (!state.spotId || !isOnGiranMarketPlaza(state.loc)) return false;
     if (['traveling', 'shopping', 'merchant', 'crafting'].includes(state.activity)) return false;
     const stats = state.stats || {};
     // An ordinary bot may be in Giran only while traveling, shopping, or
@@ -548,9 +567,21 @@ const BotLifeState = {
             const repairs = [...cache.values()]
                 .map(recoverOrphanedGiranState)
                 .filter((state) => state !== cache.get(state.characterId));
-            return repairs.reduce((chain, state) => chain.then(() => save(rowFromState(state)).then(() => {
-                cache.set(state.characterId, state);
-            })), Promise.resolve()).then(() => count);
+            return repairs.reduce((chain, state) => chain.then(() => {
+                const row = rowFromState(state);
+                // The next activation reads characters.loc*, not only the
+                // lifecycle row.  Repair both stores or an old Giran
+                // coordinate brings the visible bot pile back after restart.
+                return save(row)
+                    .then(() => Database.updateCharacterLocation(row.characterId, {
+                        locX: row.locX,
+                        locY: row.locY,
+                        locZ: row.locZ
+                    }))
+                    .then(() => {
+                        cache.set(state.characterId, state);
+                    });
+            }), Promise.resolve()).then(() => count);
         }).then((count) => {
             initialized = true;
             utils.infoSuccess('BotLife', 'state table ready states=%d', count);

--- a/src/GameServer/Bot/Population/GeneratedColdSeeder.js
+++ b/src/GameServer/Bot/Population/GeneratedColdSeeder.js
@@ -7,7 +7,7 @@ const SpotProfiles = invoke('GameServer/Bot/Population/SpotProfiles');
 const LevelingRoutes = invoke('GameServer/Bot/AI/LevelingRoutes');
 const GearSkillHints = invoke('GameServer/Bot/AI/GearSkillHints');
 const ShotStock = invoke('GameServer/Inventory/ShotStock');
-const Skillset = invoke('GameServer/Actor/Skillset');
+const BotClassProgression = invoke('GameServer/Bot/BotClassProgression');
 const CraftShopService = invoke('GameServer/Bot/Economy/CraftShopService');
 
 const CLASS_POOL = [
@@ -167,7 +167,7 @@ function awardBaseSkills(characterId, classId) {
 function awardProfileSkills(characterId, classId, level) {
     const targetLevel = Math.max(1, Number(level) || 1);
     if (targetLevel <= 1) return Promise.resolve();
-    return new Skillset().awardSkills(characterId, classId, targetLevel);
+    return BotClassProgression.reconcile({ characterId, classId, level: targetLevel });
 }
 
 function ensureAdena(characterId, amount) {
@@ -300,6 +300,8 @@ function stateFor(character, index, seedMeta = {}) {
             classId,
             route: spot?.route || null,
             build: GearSkillHints.forCharacter({ classId, level }, { role: base.role }),
+            classProgressionLevel: level,
+            classProgressionClassId: classId,
             generatedCold: true,
             generatedIndex: index,
             levelBand: profileForIndex(index, base).band

--- a/src/GameServer/Bot/Population/PopulationConfig.js
+++ b/src/GameServer/Bot/Population/PopulationConfig.js
@@ -6,6 +6,10 @@ const DEFAULTS = {
     directorEnabled: true,
     summaryIntervalMs: 30000,
     schedulerIntervalMs: 5000,
+    // Existing cold population predates full class progression. Reconcile it
+    // in small batches so restart never becomes a database migration spike.
+    classProgressionMigrationIntervalMs: 10000,
+    classProgressionMigrationBatchSize: 5,
     partyFormationIntervalMs: 45000,
     phasePolicyIntervalMs: 10000,
     directorIntervalMs: 30000,

--- a/src/GameServer/Bot/Population/PopulationService.js
+++ b/src/GameServer/Bot/Population/PopulationService.js
@@ -108,7 +108,9 @@ const PopulationService = {
     partyFormationTimer: null,
     phasePolicyTimer: null,
     seedTimer: null,
+    classProgressionMigrationTimer: null,
     resolving: false,
+    classProgressionMigrationRunning: false,
     partyFormationRunning: false,
     phasePolicyRunning: false,
 
@@ -155,6 +157,14 @@ const PopulationService = {
             if (typeof this.schedulerTimer.unref === 'function') {
                 this.schedulerTimer.unref();
             }
+        }
+
+        this.classProgressionMigrationTimer = setInterval(() => {
+            this.migrateLegacyClassProgression();
+        }, Config.classProgressionMigrationIntervalMs);
+
+        if (typeof this.classProgressionMigrationTimer.unref === 'function') {
+            this.classProgressionMigrationTimer.unref();
         }
 
         if (Config.backgroundPartyEnabled !== false) {
@@ -207,6 +217,10 @@ const PopulationService = {
             clearTimeout(this.seedTimer);
             this.seedTimer = null;
         }
+        if (this.classProgressionMigrationTimer) {
+            clearInterval(this.classProgressionMigrationTimer);
+            this.classProgressionMigrationTimer = null;
+        }
         Director.stop();
         Metrics.stopEventLoopMonitor();
         this.started = false;
@@ -237,6 +251,28 @@ const PopulationService = {
         if (typeof this.seedTimer.unref === 'function') {
             this.seedTimer.unref();
         }
+    },
+
+    migrateLegacyClassProgression() {
+        // Database uses one ordered connection. Never queue a migration behind
+        // an active resolver: a skipped migration tick is harmless, but a
+        // queued one can stretch the normal world loop into a long backlog.
+        if (this.classProgressionMigrationRunning || this.resolving || Config.enabled === false) return Promise.resolve([]);
+        this.classProgressionMigrationRunning = true;
+        return LifeState.migrateLegacyClassProgression(Config.classProgressionMigrationBatchSize)
+            .then((migrated) => {
+                if (migrated.length) {
+                    console.info('BotPopulation :: migrated class progression for %d cold bot(s)', migrated.length);
+                }
+                return migrated;
+            })
+            .catch((err) => {
+                utils.infoWarn('BotPopulation', 'legacy class progression migration failed: %s', err.message);
+                return [];
+            })
+            .finally(() => {
+                this.classProgressionMigrationRunning = false;
+            });
     },
 
     recordHotTick(session) {
@@ -551,8 +587,8 @@ const PopulationService = {
     },
 
     tickBudgeted() {
-        if (this.resolving || Config.enabled === false || Config.backgroundResolverEnabled === false) {
-            if (this.resolving) {
+        if (this.resolving || this.classProgressionMigrationRunning || Config.enabled === false || Config.backgroundResolverEnabled === false) {
+            if (this.resolving || this.classProgressionMigrationRunning) {
                 Metrics.recordSchedulerSkip();
             }
             return Promise.resolve([]);

--- a/src/GameServer/ClassProgression.js
+++ b/src/GameServer/ClassProgression.js
@@ -32,6 +32,39 @@ const thirdClasses = {
     118: { parentClassId: 57, name: 'Maestro', cp: { baseCpMax: 2634.5, lvlCpAdd: 55.68, lvlCpMod: 0.22 } }
 };
 
+const firstProfMap = {
+    0: [1, 4, 7],
+    10: [11, 15],
+    18: [19, 22],
+    25: [26, 29],
+    31: [32, 35],
+    38: [39, 42],
+    44: [45, 47],
+    49: [50],
+    53: [54, 56]
+};
+
+const secondProfMap = {
+    1: [2, 3],
+    4: [5, 6],
+    7: [8, 9],
+    11: [12, 13, 14],
+    15: [16, 17],
+    19: [20, 21],
+    22: [23, 24],
+    26: [27, 28],
+    29: [30],
+    32: [33, 34],
+    35: [36, 37],
+    39: [40, 41],
+    42: [43],
+    45: [46],
+    47: [48],
+    50: [51, 52],
+    54: [55],
+    56: [57]
+};
+
 function getThirdClass(classId) {
     return thirdClasses[Number(classId)] || null;
 }
@@ -51,4 +84,4 @@ function expandTemplates(templates) {
     });
 }
 
-module.exports = { thirdClasses, getThirdClass, expandTemplates };
+module.exports = { thirdClasses, firstProfMap, secondProfMap, getThirdClass, expandTemplates };

--- a/src/GameServer/Skills/C4SkillRules.js
+++ b/src/GameServer/Skills/C4SkillRules.js
@@ -158,6 +158,8 @@ const RULES = {
     176: { skillType: EFFECT, trait: 'buff', effect: 'frenzy', effectType: 'buff', target: 'self', baseLandRate: 100, statsByLevel: { pAtkMul: [2.0, 2.5, 3.0] }, condition: { actorHpPercentAtMost: 30 } },
     181: { skillType: HEAL_STATIC, trait: 'heal', target: 'self', ssBoost: 0, healPowerByLevel: [1685], condition: { actorHpPercentAtMost: 10 } },
     190: { skillType: DAMAGE, trait: 'physical', target: 'enemy', ssBoost: 1, overHit: true, requires: { weaponsAllowed: 18444 }, castRange: 40, effectRange: 400 },
+    212: { skillType: PASSIVE, trait: 'passive', target: 'self', statsByLevel: { regHpAdd: [1.1, 1.6, 1.7, 2.1, 2.6, 2.7, 3.4, 4.0] } },
+    229: { skillType: PASSIVE, trait: 'passive', target: 'self', statsByLevel: { regMpAdd: [1.1, 1.5, 1.9, 2.3, 2.7, 3.1, 3.4] } },
     223: { skillType: DAMAGE_EFFECT, trait: 'bleed', effect: 'bleed', effectType: 'debuff', target: 'enemy', ssBoost: 1, overHit: true, baseLandRate: 50, levelDepend: 1, requires: { weaponsAllowed: 532 }, castRange: 40, effectRange: 400, dot: { count: 7, intervalMs: 3000, damageByLevel: [13, 13, 13, 13, 13, 13, 17, 17, 17, 17, 17, 17, 17, 17, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 27, 27, 27, 27, 27, 27, 27, 27, 27, 33, 33, 33, 33, 33, 33, 33, 33, 38, 38, 38, 38, 38, 38, 38, 38] } },
     245: { skillType: DAMAGE, trait: 'physical', target: 'enemy', sourceTarget: 'area', radius: 150, ssBoost: 1, overHit: true, requires: { weaponsAllowed: 64 }, castRange: 40, effectRange: 400 },
     246: { skillType: TAKE_CASTLE, trait: 'siege', target: 'holy', ssBoost: 0, castRange: 85, effectRange: 400, staticReuse: true, staticHitTime: true, mpInitialConsume: 50, condition: { clanLeader: true, siegeAttacker: true } },

--- a/src/GameServer/World/Generics/NpcBypasses/ChangeClass.js
+++ b/src/GameServer/World/Generics/NpcBypasses/ChangeClass.js
@@ -38,39 +38,7 @@ module.exports = async function(session, parts) {
     const currentClassId = actor.fetchClassId();
     const currentLevel = actor.fetchLevel();
 
-    // Define transition mappings
-    const firstProfMap = {
-        0: [1, 4, 7],
-        10: [11, 15],
-        18: [19, 22],
-        25: [26, 29],
-        31: [32, 35],
-        38: [39, 42],
-        44: [45, 47],
-        49: [50],
-        53: [54, 56]
-    };
-
-    const secondProfMap = {
-        1: [2, 3],
-        4: [5, 6],
-        7: [8, 9],
-        11: [12, 13, 14],
-        15: [16, 17],
-        19: [20, 21],
-        22: [23, 24],
-        26: [27, 28],
-        29: [30],
-        32: [33, 34],
-        35: [36, 37],
-        39: [40, 41],
-        42: [43],
-        45: [46],
-        47: [48],
-        50: [51, 52],
-        54: [55],
-        56: [57]
-    };
+    const { firstProfMap, secondProfMap } = ClassProgression;
 
     const thirdClass = ClassProgression.getThirdClass(targetClassId);
 

--- a/tests/test_automation_regeneration.js
+++ b/tests/test_automation_regeneration.js
@@ -79,6 +79,31 @@ assert.strictEqual(
     'Additive MP regeneration must receive the C4 sitting multiplier'
 );
 
+const passiveRecovery = actor({ seated: true });
+passiveRecovery.skillset = {
+    fetchSkills: () => [{
+        fetchPassive: () => true,
+        fetchSelfId: () => 212,
+        fetchName: () => 'Fast HP Recovery',
+        fetchLevel: () => 2
+    }, {
+        fetchPassive: () => true,
+        fetchSelfId: () => 229,
+        fetchName: () => 'Fast Mana Recovery',
+        fetchLevel: () => 2
+    }]
+};
+assert.strictEqual(
+    automation.fetchRevHpAmount(passiveRecovery),
+    ((5.4 * Formulas.calcLevelMod(40) * Formulas.calcBaseMod.CON(30)) + 1.6) * 1.5,
+    'Fast HP Recovery must add its C4 passive value before the sitting multiplier'
+);
+assert.strictEqual(
+    automation.fetchRevMpAmount(passiveRecovery),
+    ((2.1 * Formulas.calcLevelMod(40) * Formulas.calcBaseMod.MEN(30)) + 1.5) * 1.5,
+    'Fast Mana Recovery must add its C4 passive value before the sitting multiplier'
+);
+
 const result = automation.replenishVitalsTick(seated);
 assert(result.hp > 100 && result.mp > 100, 'A regeneration tick must restore both HP and MP while seated');
 

--- a/tests/test_automation_regeneration.js
+++ b/tests/test_automation_regeneration.js
@@ -1,0 +1,85 @@
+require('../src/Global');
+
+const assert = require('assert');
+const Automation = invoke('GameServer/Automation');
+const Formulas = invoke('GameServer/Formulas');
+const EffectStore = invoke('GameServer/Effects/EffectStore');
+
+function actor({ seated = false, moving = false, con = 30, men = 30 } = {}) {
+    return {
+        hp: 100,
+        mp: 100,
+        maxHp: 1000,
+        maxMp: 1000,
+        effects: {},
+        fetchClassId: () => 0,
+        fetchLevel: () => 40,
+        fetchCon: () => con,
+        fetchMen: () => men,
+        fetchHp() { return this.hp; },
+        fetchMp() { return this.mp; },
+        fetchMaxHp() { return this.maxHp; },
+        fetchMaxMp() { return this.maxMp; },
+        setHp(value) { this.hp = value; },
+        setMp(value) { this.mp = value; },
+        statusUpdateVitals() {},
+        state: {
+            fetchSeated: () => seated,
+            inMotion: () => moving
+        }
+    };
+}
+
+const automation = new Automation();
+automation.setRevHp(5.4);
+automation.setRevMp(2.1);
+
+const standing = actor();
+const seated = actor({ seated: true });
+const moving = actor({ moving: true });
+
+const standingHp = automation.fetchRevHpAmount(standing);
+const standingMp = automation.fetchRevMpAmount(standing);
+assert.strictEqual(
+    standingHp,
+    5.4 * Formulas.calcLevelMod(40) * Formulas.calcBaseMod.CON(30) * 1.1,
+    'Standing player HP regeneration must use the C4 level, CON, and idle multipliers'
+);
+assert.strictEqual(
+    standingMp,
+    2.1 * Formulas.calcLevelMod(40) * Formulas.calcBaseMod.MEN(30) * 1.1,
+    'Standing player MP regeneration must use the C4 level, MEN, and idle multipliers'
+);
+assert.strictEqual(
+    automation.fetchRevHpAmount(seated),
+    standingHp / 1.1 * 1.5,
+    'Sitting must grant the C4 1.5x HP regeneration bonus'
+);
+assert.strictEqual(
+    automation.fetchRevMpAmount(seated),
+    standingMp / 1.1 * 1.5,
+    'Sitting must grant the C4 1.5x MP regeneration bonus'
+);
+assert.strictEqual(
+    automation.fetchRevMpAmount(moving),
+    standingMp / 1.1 * 0.7,
+    'Running must apply the C4 0.7x MP regeneration penalty'
+);
+
+EffectStore.apply(seated, {
+    id: 1047,
+    key: 'mana_regeneration',
+    type: 'buff',
+    stats: { regMpAdd: 3.09 },
+    durationMs: 60000
+});
+assert.strictEqual(
+    automation.fetchRevMpAmount(seated),
+    ((2.1 * Formulas.calcLevelMod(40) * Formulas.calcBaseMod.MEN(30)) + 3.09) * 1.5,
+    'Additive MP regeneration must receive the C4 sitting multiplier'
+);
+
+const result = automation.replenishVitalsTick(seated);
+assert(result.hp > 100 && result.mp > 100, 'A regeneration tick must restore both HP and MP while seated');
+
+console.log('Automation regeneration checks passed');

--- a/tests/test_bot_background_party_rest.js
+++ b/tests/test_bot_background_party_rest.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const BackgroundPartyResolver = invoke('GameServer/Bot/Population/BackgroundPartyResolver');
+invoke('GameServer/DataCache').init();
+
+const now = 1_750_000_000_000;
+const members = [
+    {
+        characterId: 81,
+        name: 'TiredTank',
+        level: 40,
+        levelBand: '38-42',
+        activity: 'resting',
+        vitals: { hp: 200, maxHp: 1500, mp: 50, maxMp: 500 },
+        stats: { classId: 1, role: 'tank', restUntil: now + 600000 },
+        party: { role: 'tank' }
+    },
+    {
+        characterId: 82,
+        name: 'ReadyDps',
+        level: 40,
+        levelBand: '38-42',
+        activity: 'grouped',
+        vitals: { hp: 1300, maxHp: 1300, mp: 500, maxMp: 500 },
+        stats: { classId: 1, role: 'dps' },
+        party: { role: 'dps' }
+    }
+];
+
+const result = BackgroundPartyResolver.resolve({
+    party: { partyId: 'rest-party', leaderId: 81, cohesion: 0.7, risk: 0.2, stats: {} },
+    members,
+    spot: { id: 'execution_ground', name: 'Execution Ground', density: 3, avgLevel: 40 },
+    elapsedMs: 30000,
+    timestamp: now + 30000,
+    rng: () => 0
+});
+
+assert.strictEqual(result.debug.fights, 0, 'a party with a resting member must not keep fighting');
+assert.strictEqual(result.events.length, 0, 'a resting party must not emit hunt events');
+assert.strictEqual(result.memberResults.length, members.length);
+assert(result.memberResults[0].result.patch.vitals.hp > members[0].vitals.hp, 'the exhausted member must recover HP');
+assert(result.memberResults[0].result.patch.vitals.mp > members[0].vitals.mp, 'the exhausted member must recover MP');
+result.memberResults.forEach(({ result }) => {
+    assert.deepStrictEqual(result.materialize, { exp: 0, sp: 0, adena: 0, items: [] }, 'party recovery must not award combat rewards');
+});
+
+console.log('Bot background party rest checks passed');

--- a/tests/test_bot_background_rest.js
+++ b/tests/test_bot_background_rest.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const BackgroundResolver = invoke('GameServer/Bot/Population/BackgroundResolver');
+invoke('GameServer/DataCache').init();
+
+const now = 1_750_000_000_000;
+const state = {
+    characterId: 72,
+    name: 'RecoveringHunter',
+    level: 40,
+    levelBand: '38-42',
+    activity: 'resting',
+    spotId: 'execution_ground',
+    vitals: { hp: 200, maxHp: 1200, mp: 50, maxMp: 650 },
+    stats: { classId: 1, role: 'dps', restUntil: now + 600000 },
+    party: { role: 'dps' }
+};
+
+const recovering = BackgroundResolver.resolveSolo({
+    state,
+    spot: { id: 'execution_ground' },
+    elapsedMs: 30000,
+    timestamp: now + 30000
+});
+
+assert.strictEqual(recovering.patch.activity, 'resting', 'a cold bot must not fight before it has recovered');
+assert(recovering.patch.vitals.hp > state.vitals.hp, 'cold resting must restore HP with C4 ticks');
+assert(recovering.patch.vitals.mp > state.vitals.mp, 'cold resting must restore MP with C4 ticks');
+assert.strictEqual(recovering.materialize.exp, 0, 'cold resting must not award combat XP');
+assert(recovering.patch.stats.restUntil > now + 30000, 'cold recovery deadline must remain persisted in stats');
+
+const ready = BackgroundResolver.resolveSolo({
+    state: {
+        ...state,
+        vitals: { hp: 1200, maxHp: 1200, mp: 650, maxMp: 650 },
+        stats: { ...state.stats, restUntil: now - 1 }
+    },
+    spot: { id: 'execution_ground' },
+    elapsedMs: 3000,
+    timestamp: now
+});
+assert.strictEqual(ready.patch.activity, 'hunting', 'a recovered cold bot should return to hunting after its recovery delay');
+assert.strictEqual(ready.patch.stats.restUntil, null, 'completed recovery must clear its persisted deadline');
+
+console.log('Bot background rest checks passed');

--- a/tests/test_bot_class_progression.js
+++ b/tests/test_bot_class_progression.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const DataCache = invoke('GameServer/DataCache');
+const Database = invoke('Database');
+const BotClassProgression = invoke('GameServer/Bot/BotClassProgression');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
+
+DataCache.init();
+
+const original = {
+    fetchSkill: Database.fetchSkill,
+    fetchSkills: Database.fetchSkills,
+    setSkill: Database.setSkill,
+    updateSkillLevel: Database.updateSkillLevel,
+    updateCharacterClassId: Database.updateCharacterClassId
+};
+const stored = new Map();
+const classes = new Map();
+
+function skillsFor(characterId) {
+    if (!stored.has(characterId)) stored.set(characterId, []);
+    return stored.get(characterId);
+}
+
+try {
+    Database.fetchSkill = (characterId, selfId) => Promise.resolve(skillsFor(characterId).filter((skill) => skill.selfId === selfId));
+    Database.fetchSkills = (characterId) => Promise.resolve(skillsFor(characterId));
+    Database.setSkill = (skill, characterId) => {
+        skillsFor(characterId).push({ selfId: skill.selfId, name: skill.name, level: skill.level, passive: skill.passive });
+        return Promise.resolve();
+    };
+    Database.updateSkillLevel = (characterId, selfId, level) => {
+        const skill = skillsFor(characterId).find((entry) => entry.selfId === selfId);
+        if (skill) skill.level = level;
+        return Promise.resolve();
+    };
+    Database.updateCharacterClassId = (characterId, classId) => {
+        classes.set(characterId, classId);
+        return Promise.resolve();
+    };
+
+    Promise.all([
+        BotClassProgression.reconcile({ characterId: 1, classId: 31, level: 42, seed: 'Halen1183' }),
+        BotClassProgression.reconcile({ characterId: 2, classId: 49, level: 42, seed: 'Bren1465' }),
+        BotClassProgression.reconcile({ characterId: 3, classId: 2, level: 76, seed: 'Veteran' })
+    ]).then(([darkFighter, orcMystic, veteran]) => {
+        assert.ok([36, 37].includes(darkFighter.classId), 'a level 42 Dark Fighter must pass both profession transfers');
+        assert.ok([51, 52].includes(orcMystic.classId), 'a level 42 Orc Mystic must pass both profession transfers');
+        assert.strictEqual(veteran.classId, 88, 'a level 76 second-class bot must take its third profession');
+        assert.strictEqual(skillsFor(1).find((skill) => skill.selfId === 239)?.level, 2, 'a C-grade bot must receive Expertise C through its real profession tree');
+        assert.strictEqual(skillsFor(2).find((skill) => skill.selfId === 239)?.level, 2, 'all promoted C-grade paths must receive Expertise C');
+        skillsFor(1).forEach((skill) => {
+            const defined = DataCache.skills.find((entry) => entry.selfId === skill.selfId)?.levels || [];
+            assert.ok(defined.some((entry) => entry.level === skill.level), `bot skills must use a defined datapack level (${skill.selfId}:${skill.level})`);
+        });
+        assert.strictEqual(classes.get(3), 88, 'the third profession must be persisted');
+        assert.strictEqual(BotRoles.inferRole(97), 'healer', 'Cardinal must retain its healer role');
+        assert.strictEqual(BotRoles.inferRole(98), 'buffer', 'Hierophant must retain its buffer role');
+        assert.strictEqual(BotRoles.inferRole(118), 'crafter', 'Maestro must retain its crafter role');
+        console.log('Bot class progression checks passed');
+    }).catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    }).finally(() => {
+        Object.assign(Database, original);
+    });
+} catch (error) {
+    Object.assign(Database, original);
+    throw error;
+}

--- a/tests/test_bot_cold_state_context.js
+++ b/tests/test_bot_cold_state_context.js
@@ -72,9 +72,13 @@ async function run() {
     SpotService.randomPointNear = () => ({ locX: -7900, locY: 11100, locZ: -3100 });
     session.coldLifeState = {
         ...session.coldLifeState,
-        phase: 'cold',
+        // markCold receives a still-hot snapshot, so this regression covers
+        // the exact cooldown path that used to reintroduce plaza stacks.
+        phase: 'hot',
         activity: 'resting',
-        currentRegion: 'Giran',
+        // The old hunting-region label was what let this exact stale plaza
+        // coordinate bypass the previous Giran-only repair.
+        currentRegion: 'Talking Island',
         loc: { locX: 83180, locY: 147780, locZ: -3466 },
         stats: {
             ...session.coldLifeState.stats,

--- a/tests/test_bot_craft_shop.js
+++ b/tests/test_bot_craft_shop.js
@@ -8,6 +8,7 @@ const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 const CraftShopService = invoke('GameServer/Bot/Economy/CraftShopService');
 const GeneratedColdSeeder = invoke('GameServer/Bot/Population/GeneratedColdSeeder');
 const C4RecipeItems = invoke('GameServer/Items/C4RecipeItems');
+const ColdMarketListingService = invoke('GameServer/Bot/Economy/ColdMarketListingService');
 
 DataCache.init();
 
@@ -57,20 +58,25 @@ async function run() {
     assert.notStrictEqual(invalid.entries[0]?.recipeId, 999999, 'persisted offers must be revalidated against craft level and recipe data');
     assert.strictEqual(invalid.title, 'Custom smith');
 
-    assert.strictEqual(CraftShopService.CraftStations.length, 28, 'Giran must expose the full D/C/B/A/S market plus dedicated resource crafting');
-    assert.strictEqual(new Set(CraftShopService.GiranCraftStalls.map((loc) => `${loc.locX}:${loc.locY}:${loc.locZ}`)).size, 28, 'every craft station must have its own stall');
-    assert(CraftShopService.GiranCraftStalls.every((loc) => (
-        loc.locX >= 81020 && loc.locX <= 83540 && loc.locY >= 147780 && loc.locY <= 149820
-    )), 'every craft station must remain inside the Giran plaza footprint');
-    assert.deepStrictEqual(
-        CraftShopService.GiranCraftStalls.slice(-3),
-        [
-            { locX: 82820, locY: 147780, locZ: -3466 },
-            { locX: 83180, locY: 147780, locZ: -3466 },
-            { locX: 83540, locY: 147780, locZ: -3466 }
-        ],
-        'the three overflow craft services must sit beside the market grid, not south of the plaza'
-    );
+    assert.strictEqual(CraftShopService.CraftStations.length, 31, 'Giran must expose the full D/C/B/A/S market, resources and progressive C weapons');
+    assert.strictEqual(new Set(CraftShopService.GiranCraftStalls.map((loc) => `${loc.locX}:${loc.locY}:${loc.locZ}`)).size, 31, 'every craft station must have its own stall');
+    assert(CraftShopService.GiranCraftStalls.every((loc) => ColdMarketListingService.isGiranPlazaStallLocation(loc)), 'every craft station must remain in the actual sellable Giran plaza footprint');
+    const outer = { minX: 80971, maxX: 82887, minY: 147722, maxY: 149490 };
+    const width = outer.maxX - outer.minX;
+    const height = outer.maxY - outer.minY;
+    const perimeter = 2 * (width + height);
+    const perimeterPosition = (loc) => {
+        if (Number(loc.locY) === outer.minY) return Number(loc.locX) - outer.minX;
+        if (Number(loc.locX) === outer.maxX) return width + Number(loc.locY) - outer.minY;
+        if (Number(loc.locY) === outer.maxY) return width + height + outer.maxX - Number(loc.locX);
+        return 2 * width + height + outer.maxY - Number(loc.locY);
+    };
+    const positions = CraftShopService.GiranCraftStalls.map(perimeterPosition);
+    const adjacentDistances = positions.map((position, index) => {
+        const next = positions[(index + 1) % positions.length];
+        return (next - position + perimeter) % perimeter;
+    });
+    assert(Math.max(...adjacentDistances) - Math.min(...adjacentDistances) <= 2, 'craft stations must be evenly spaced around the outer Giran perimeter');
     CraftShopService.CraftStations.forEach((station, index) => {
         assert.strictEqual(
             CraftShopService.stationForSlot(10000 + index).id,
@@ -124,10 +130,17 @@ async function run() {
         assert.notStrictEqual(staleProfile.entries[0]?.recipeId, 999999, `${station.id} must refresh a persisted station catalogue`);
     });
 
-    ['a_heavy_elite', 's_heavy', 's_robe', 's_light', 's_weapons', 's_jewelry', 'resource_core', 'resource_master'].forEach((stationId) => {
+    ['a_heavy_elite', 's_heavy', 's_robe', 's_light', 's_weapons', 's_jewelry', 'resource_core', 'resource_master', 'c_weapons_entry', 'c_weapons_mid', 'c_weapons_late'].forEach((stationId) => {
         const station = CraftShopService.CraftStations.find((entry) => entry.id === stationId);
         assert(station, `${stationId} must have a dedicated Giran station`);
     });
+    const cWeaponStations = ['c_weapons_entry', 'c_weapons_mid', 'c_weapons_late', 'c_weapons_top']
+        .map((stationId) => CraftShopService.CraftStations.find((station) => station.id === stationId));
+    assert(cWeaponStations.every(Boolean), 'every C weapon progression tier must have a visible station');
+    assert(cWeaponStations.slice(1).every((station, index) => {
+        const previous = cWeaponStations[index];
+        return Math.hypot(Number(station.loc.locX) - Number(previous.loc.locX), Number(station.loc.locY) - Number(previous.loc.locY)) < 250;
+    }), 'C weapon progression must remain a contiguous group on the outer market perimeter');
 
     const nonDroppableResources = [1883, 1886, 1887, 1888, 1890, 1891, 1892, 1893, 5220, 5550, 5551, 4045, 4046, 4047, 4048, 5552, 5553, 5554];
     const resourceRecipeIds = new Set(CraftShopService.CraftStations

--- a/tests/test_bot_gear_acquisition.js
+++ b/tests/test_bot_gear_acquisition.js
@@ -61,8 +61,31 @@ const mage = { level: 40, stats: { classId: 10, role: 'mage' }, inventory: {} };
 const target = GearAcquisitionPlanner.preferredTarget(mage);
 assert(target, 'a C-grade mage without gear must receive a craftable target');
 assert(['Weapon.Sword', 'Weapon.Blunt'].includes(target.item.template.kind), 'mage target must use a caster weapon family');
+assert(Number(target.item.template.price) <= 2290000, 'a new C-grade bot must begin with an entry-tier weapon target');
 const station = ColdCraftingService.stationForRecipe(target.recipe.recipeId);
 assert(station, 'a selected equipment recipe must be published by a Giran crafting station');
+const entryWeaponOnly = {
+    [target.item.selfId]: { selfId: target.item.selfId, amount: 1 }
+};
+const afterEntryWeapon = GearAcquisitionPlanner.preferredTarget({ ...mage, inventory: entryWeaponOnly });
+assert(!['Weapon.Sword', 'Weapon.Blunt'].includes(afterEntryWeapon.item.template.kind), 'a C-grade mage must gear another slot after its entry weapon instead of crafting alternate weapons');
+let entryBandInventory = {};
+for (;;) {
+    const entryBandTarget = GearAcquisitionPlanner.preferredTarget({ ...mage, inventory: entryBandInventory });
+    if (!entryBandTarget) break;
+    assert(Number(entryBandTarget.item.template.price) <= 2290000, 'level-40 bots must stop after their entry C band instead of falling through to top C gear');
+    entryBandInventory = {
+        ...entryBandInventory,
+        [entryBandTarget.item.selfId]: { selfId: entryBandTarget.item.selfId, amount: 1 }
+    };
+}
+const midCMageTarget = GearAcquisitionPlanner.preferredTarget({ ...mage, level: 44 });
+assert(Number(midCMageTarget.item.template.price) <= 2870000, 'mid-C bots must not skip straight to the expensive endgame C weapons');
+const lateCMageTarget = GearAcquisitionPlanner.preferredTarget({ ...mage, level: 48 });
+assert(Number(lateCMageTarget.item.template.price) <= 4300000, 'late-C bots must receive a progression target below top C gear');
+for (const recipeId of [191, 192, 198, 199, 201, 205, 208, 209, 213, 214, 216, 217, 312, 220, 222, 223, 228, 230, 234, 237, 238, 240]) {
+    assert(ColdCraftingService.stationForRecipe(recipeId), `C progression recipe ${recipeId} must be available from a Giran craft station`);
+}
 
 const missing = GearAcquisitionPlanner.missingMaterials(target.recipe, {
     [target.recipe.materials[0].selfId]: { selfId: target.recipe.materials[0].selfId, amount: target.recipe.materials[0].amount - 1 }

--- a/tests/test_bot_giran_starter_recovery.js
+++ b/tests/test_bot_giran_starter_recovery.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const DataCache = invoke('GameServer/DataCache');
+const BotManager = invoke('GameServer/Bot/BotManager');
+
+DataCache.init();
+
+const starter = {
+    username: 'bot_ti_01',
+    name: 'Aldren',
+    homeRegion: 'Talking Island',
+    spawnClassId: 0,
+    classId: 0
+};
+const stacked = { locX: 83180, locY: 147780, locZ: -3466 };
+const recovered = BotManager.recoverStarterSpawn(starter, stacked);
+
+assert.notStrictEqual(recovered.locX, stacked.locX, 'a starter retained at the old Giran stack must receive a home spawn');
+assert.notStrictEqual(recovered.locY, stacked.locY, 'a starter retained at the old Giran stack must receive a home spawn');
+assert.deepStrictEqual(
+    BotManager.recoverStarterSpawn(starter, stacked),
+    recovered,
+    'starter recovery must be stable across restarts rather than reshuffling the town on every boot'
+);
+assert.strictEqual(
+    BotManager.recoverStarterSpawn({ ...starter, merchantConfigName: 'GiranWeapons', locX: 70000, locY: 50000, locZ: -1500 }, stacked).locX,
+    70000,
+    'configured merchant locations must never be moved by the starter recovery'
+);
+assert.strictEqual(
+    BotManager.recoverStarterSpawn({ ...starter, merchantConfigName: 'GiranWeapons', locX: 70000, locY: 50000, locZ: -1500 }, stacked).locY,
+    50000,
+    'configured merchant locations must never be moved by the starter recovery'
+);
+
+console.log('Bot Giran starter recovery checks passed');

--- a/tests/test_bot_hunting_self_defense.js
+++ b/tests/test_bot_hunting_self_defense.js
@@ -107,13 +107,15 @@ HuntingState.tick(woundedSession, woundedBot, {}, {
     }
 });
 
-assert.strictEqual(woundedSession.plan, 'hunting', 'wounded solo hunter should not sit while under attack');
-assert.strictEqual(woundedAttackId, threatNpc.fetchId(), 'wounded solo hunter should defend itself before resting');
+assert.strictEqual(woundedSession.plan, 'fleeing', 'critically wounded solo hunter should retreat instead of re-entering combat');
+assert.strictEqual(woundedAttackId, null, 'critically wounded solo hunter should not start a futile counterattack');
 
 let seated = true;
 woundedBot.state.fetchSeated = () => seated;
 woundedBot.state.setSeated = (value) => { seated = value; };
 woundedSession.plan = 'resting';
+woundedSession.incomingThreatId = threatNpc.fetchId();
+woundedSession.incomingThreatAt = Date.now();
 woundedAttackId = null;
 const RestingState = invoke('GameServer/Bot/AI/States/RestingState');
 
@@ -124,9 +126,9 @@ RestingState.tick(woundedSession, woundedBot, {}, {
     }
 });
 
-assert.strictEqual(woundedSession.plan, 'hunting', 'resting solo hunter should wake when attacked');
-assert.strictEqual(seated, false, 'resting solo hunter should stand before defending itself');
-assert.strictEqual(woundedAttackId, threatNpc.fetchId(), 'resting solo hunter should counterattack immediately');
+assert.strictEqual(woundedSession.plan, 'fleeing', 'resting solo hunter with critical HP should retreat when attacked');
+assert.strictEqual(seated, false, 'resting solo hunter should stand before retreating');
+assert.strictEqual(woundedAttackId, null, 'resting solo hunter with critical HP should not counterattack immediately');
 
 const exhaustedBot = actor(2000013);
 exhaustedBot.fetchMp = () => 10;

--- a/tests/test_bot_mana_regeneration.js
+++ b/tests/test_bot_mana_regeneration.js
@@ -1,0 +1,68 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const RestingState = invoke('GameServer/Bot/AI/States/RestingState');
+
+let seated = true;
+let casts = 0;
+const manaRegeneration = {
+    fetchPassive: () => false,
+    fetchSemantic: () => ({ effect: 'mana_regeneration' }),
+    fetchTargetKind: () => 'self',
+    fetchConsumedMp: () => 12,
+    fetchSelfId: () => 1047
+};
+const bot = {
+    effects: {},
+    fetchId: () => 17,
+    fetchHp: () => 800,
+    fetchMaxHp: () => 1000,
+    fetchMp: () => 20,
+    fetchMaxMp: () => 200,
+    fetchLocX: () => 0,
+    fetchLocY: () => 0,
+    fetchLocZ: () => 0,
+    state: {
+        fetchSeated: () => seated,
+        setSeated: (value) => { seated = value; },
+        fetchCasts: () => false
+    },
+    skillset: { fetchSkills: () => [manaRegeneration] }
+};
+const session = {
+    dataSendToOthers: () => {},
+    roleDecision: null
+};
+const Generics = {
+    skillExec: (_session, actor, data) => {
+        casts += 1;
+        assert.strictEqual(actor, bot);
+        assert.deepStrictEqual(data, { id: 17, selfId: 1047, ctrl: false });
+    }
+};
+
+assert.strictEqual(RestingState.maybeCastManaRegeneration(session, bot, Generics), true, 'a resting bot with Mana Regeneration should cast it for low MP');
+assert.strictEqual(casts, 1);
+assert.strictEqual(seated, false, 'the bot must stand before the native self-cast');
+assert.strictEqual(session.roleDecision.action, 'cast_mana_regeneration');
+assert.strictEqual(RestingState.maybeCastManaRegeneration(session, bot, Generics), false, 'the cast retry guard must prevent spam while the skill is pending');
+
+let seatedDuringCast = false;
+const castingBot = {
+    ...bot,
+    state: {
+        fetchSeated: () => seatedDuringCast,
+        setSeated: (value) => { seatedDuringCast = value; },
+        fetchCasts: () => true
+    }
+};
+RestingState.tick(
+    { dataSendToOthers: () => {} },
+    castingBot,
+    { skillExec: () => assert.fail('a live cast must not start another Mana Regeneration action') },
+    { say: () => assert.fail('a casting bot must not leave recovery') }
+);
+assert.strictEqual(seatedDuringCast, false, 'a bot must remain standing while Mana Regeneration is casting');
+
+console.log('Bot Mana Regeneration checks passed');

--- a/tests/test_bot_population_state.js
+++ b/tests/test_bot_population_state.js
@@ -3,6 +3,9 @@ const assert = require('assert');
 require('../src/Global');
 
 const Database = invoke('Database');
+const DataCache = invoke('GameServer/DataCache');
+
+DataCache.init();
 
 const originalExecute = Database.execute;
 const statements = [];
@@ -10,6 +13,9 @@ const statements = [];
 try {
     Database.execute = ([sql, params]) => {
         statements.push({ sql: String(sql), params });
+        if (String(sql).startsWith('SELECT id, classId, level, exp, sp FROM characters')) {
+            return Promise.resolve([{ id: 42, classId: 31, level: 42, exp: 0, sp: 0 }]);
+        }
         if (String(sql).startsWith('UPDATE bot_life_state')) {
             return Promise.resolve({ affectedRows: 2 });
         }
@@ -34,15 +40,21 @@ try {
         assert(craftRecovery.sql.includes("AND activity = 'crafting'"), 'only stale station waits should be recovered as hunters');
         assert.strictEqual(craftRecovery.params[1], craftRecovery.params[0], 'recovered craft waits must be due immediately for their replan');
         return BotLifeState.upsertState({
-            characterId: 42, name: 'PersistenceProbe', phase: 'cold', activity: 'hunting',
+            characterId: 42, name: 'PersistenceProbe', level: 42, phase: 'cold', activity: 'hunting',
             timing: { activityStartedAt: 1, nextResolveAt: 2, lastResolvedAt: 1 },
-            vitals: {}, stats: {}, inventory: {}
+            vitals: {}, stats: { classId: 31 }, inventory: {}
         }, 'persistence_probe').then(() => {
             const save = statements.find((entry) => entry.sql.includes('ON DUPLICATE KEY UPDATE'));
             assert(save.sql.includes('nextResolveAt = VALUES(nextResolveAt)'), 'persisted cold resolve timing must advance after every tick');
             assert(save.sql.includes('lastResolvedAt = VALUES(lastResolvedAt)'), 'persisted cold resolve history must survive an upsert');
             assert(save.sql.includes('inventorySummary = VALUES(inventorySummary)'), 'background drop rewards must persist after an upsert');
-            return BotLifeState.dueCold(5, 1000);
+            return BotLifeState.migrateLegacyClassProgression(1).then((migrated) => {
+                assert.strictEqual(migrated.length, 1, 'legacy cold bots without progression markers must be migrated');
+                const classUpdate = statements.filter((entry) => entry.sql.includes('classId')).at(-1);
+                assert(classUpdate, 'migration must persist the profession on the physical character');
+                assert.ok([36, 37].includes(classUpdate.params[0]), 'migration must use the physical character class as its source of truth');
+                return BotLifeState.dueCold(5, 1000);
+            });
         }).then(() => {
             const due = statements.find((entry) => entry.sql.includes("WHEN activity IN ('traveling', 'crafting') THEN 0"));
             assert(due.sql.includes('rateModelVersion'), 'due cold states must prioritize persisted plans from an older drop-rate model');

--- a/tests/test_grade_penalty.js
+++ b/tests/test_grade_penalty.js
@@ -31,6 +31,16 @@ const qualified = actor([item('C')], 2);
 assert.strictEqual(C4GradePenalty.sync(qualified), false);
 assert.strictEqual(EffectStore.list(qualified).length, 0);
 
+// Login first calculates the actor before the asynchronous skillbook load.
+// Once Expertise arrives, the second calculation must remove that temporary
+// penalty instead of leaving movement speed at the penalized value.
+const loginActor = actor([item('C')]);
+assert.strictEqual(C4GradePenalty.sync(loginActor), true);
+loginActor.skillset.fetchSkill = (id) => id === 239 ? { fetchLevel: () => 2 } : null;
+assert.strictEqual(C4GradePenalty.sync(loginActor), true);
+assert.strictEqual(loginActor.fetchExpertisePenalty(), 0);
+assert.strictEqual(EffectStore.list(loginActor).length, 0);
+
 const mixedEquipment = actor([item('D'), item('A'), item('S', false)], 1);
 assert.strictEqual(C4GradePenalty.penalty(mixedEquipment), 3, 'C4 uses the highest equipped item grade');
 C4GradePenalty.sync(mixedEquipment);

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -337,6 +337,22 @@ try {
 
     assert.strictEqual(recoveringCampBot.state.fetchSeated(), true, 'recovering companion should stay seated when leader stands without combat');
 
+    const distantRecoveringBot = fakeActor(2000018, { locX: 1200, locY: 0, hp: 20, maxHp: 100, mp: 10, maxMp: 100 });
+    distantRecoveringBot.state.setSeated(true);
+    const distantRecoveringSession = fakeSession('bot_distant_recovering_companion', distantRecoveringBot);
+    distantRecoveringSession.followPlayerSession = leaderSession;
+    distantRecoveringSession.partyCompanion = true;
+    distantRecoveringSession.plan = 'resting';
+    leader.destId = undefined;
+    World.user = { sessions: [leaderSession, distantRecoveringSession] };
+    World.npc = { spawns: [] };
+    World.fetchNpcsInRadius = () => [];
+
+    RestingState.tick(distantRecoveringSession, distantRecoveringBot, {}, { say() {} });
+
+    assert.strictEqual(distantRecoveringSession.plan, 'resting', 'recovering companion should not stand merely because its leader is far away');
+    assert.strictEqual(distantRecoveringBot.state.fetchSeated(), true, 'recovering companion should remain seated until it can actually follow');
+
     const unknownMoveBot = fakeActor(2000008, { locX: 500, locY: 0 });
     unknownMoveBot.state.setTowards('move');
     const unknownMoveSession = fakeSession('bot_unknown_move_follow', unknownMoveBot);

--- a/tests/test_skill_semantics.js
+++ b/tests/test_skill_semantics.js
@@ -7284,6 +7284,10 @@ assert.strictEqual(restrictedSkillAttack.skillUseConditionFailure(starterFistUse
 const dualFistUser = creature({ id: 2000311 });
 dualFistUser.backpack.fetchTotalWeaponKind = () => 'Weapon.DualFist';
 assert.strictEqual(restrictedSkillAttack.skillUseConditionFailure(dualFistUser, ironPunch), null, 'Iron Punch must allow C4 dual-fist weapons such as Spiked Gloves');
+const shieldUser = creature({ id: 2000312 });
+shieldUser.backpack.fetchTotalWeaponKind = () => 'Weapon.Blunt';
+shieldUser.backpack.fetchEquippedArmors = () => [{ fetchKind: () => 'Armor.Shield' }];
+assert.strictEqual(restrictedSkillAttack.skillUseConditionFailure(shieldUser, shieldStun), null, 'Shield Stun must allow a shield equipped with a one-handed weapon');
 const focusAttack = C4SkillRules.resolve({ selfId: 317, name: 'Focus Attack', level: 1 });
 assert.deepStrictEqual(focusAttack.stats, { pAccuracyCombatAdd: 5, hitMainTarget: true }, 'Focus Attack must preserve its pole accuracy and main-target behavior');
 assert.strictEqual(focusAttack.toggleMpConsume, 7, 'Focus Attack must consume 7 MP every two seconds');

--- a/tests/test_skill_semantics.js
+++ b/tests/test_skill_semantics.js
@@ -6692,7 +6692,11 @@ assert.strictEqual(sealDisease.fetchTargetKind(), 'enemy', 'Seal of Disease shou
 assert.strictEqual(sealDiseaseOutcome.effect.key, 'seal_of_disease', 'Seal of Disease should apply a structured regen debuff');
 assert.strictEqual(EffectStats.multiplier(sealDiseaseTarget, 'regHp'), 0.5, 'Seal of Disease should use sourced gainHp 0.5');
 assert.strictEqual(EffectStats.multiplier(sealDiseaseTarget, 'cancelVuln'), 1.3, 'Seal of Disease should use sourced cancelVuln 1.3');
-assert.strictEqual(regenAutomation.fetchRevHpAmount(sealDiseaseTarget), 5, 'Seal of Disease should halve runtime HP regeneration');
+assert.strictEqual(
+    regenAutomation.fetchRevHpAmount(sealDiseaseTarget),
+    regenAutomation.fetchRevHpAmount(statActor()) * 0.5,
+    'Seal of Disease should halve the fully calculated C4 HP regeneration rate'
+);
 
 const curseDiseaseData = activeSkills.find((entry) => entry.selfId === 1269);
 assert(curseDiseaseData, 'Curse Disease should be present in active skills data');
@@ -6707,7 +6711,11 @@ const curseDiseaseOutcome = SkillEffects.execute(session(), caster, diseaseTarge
 });
 assert.strictEqual(curseDiseaseOutcome.effect.key, 'curse_disease', 'Curse Disease should apply a structured regen debuff');
 assert.strictEqual(EffectStats.multiplier(diseaseTarget, 'regHp'), 0.5, 'Curse Disease should use sourced regHp 0.5');
-assert.strictEqual(regenAutomation.fetchRevHpAmount(diseaseTarget), 5, 'Curse Disease should halve runtime HP regeneration');
+assert.strictEqual(
+    regenAutomation.fetchRevHpAmount(diseaseTarget),
+    regenAutomation.fetchRevHpAmount(statActor()) * 0.5,
+    'Curse Disease should halve the fully calculated C4 HP regeneration rate'
+);
 
 const vampiricRageData = activeSkills.find((entry) => entry.selfId === 1268);
 assert(vampiricRageData, 'Vampiric Rage should be present in active skills data');
@@ -6773,7 +6781,11 @@ assert.strictEqual(EffectStats.multiplier(regenerationTarget, 'regHp'), 1.2, 'Re
 const regenBuffAutomation = new Automation();
 regenBuffAutomation.setRevHp(10);
 regenBuffAutomation.setRevMp(10);
-assert.strictEqual(regenBuffAutomation.fetchRevHpAmount(regenerationTarget), 12, 'Regeneration should increase runtime HP regeneration by sourced multiplier');
+assert.strictEqual(
+    regenBuffAutomation.fetchRevHpAmount(regenerationTarget),
+    regenBuffAutomation.fetchRevHpAmount(statActor()) * 1.2,
+    'Regeneration should multiply the fully calculated C4 HP regeneration rate'
+);
 
 const manaRegenTarget = statActor();
 const manaRegeneration = skill({ selfId: 1047, name: 'Mana Regeneration', spell: true, power: 1, level: 4, distance: -1, buff: 1200000 });
@@ -6784,7 +6796,11 @@ const manaRegenOutcome = SkillEffects.execute(session(), caster, manaRegenTarget
 });
 assert.strictEqual(manaRegenOutcome.effect.key, 'mana_regeneration', 'Mana Regeneration should apply a structured MP regen buff');
 assert.strictEqual(EffectStats.add(manaRegenTarget, 'regMpAdd'), 3.09, 'Mana Regeneration level 4 should use sourced regMp +3.09');
-assert.strictEqual(regenBuffAutomation.fetchRevMpAmount(manaRegenTarget), 13, 'Mana Regeneration should increase runtime MP regeneration by sourced addition');
+assert.strictEqual(
+    regenBuffAutomation.fetchRevMpAmount(manaRegenTarget),
+    regenBuffAutomation.fetchRevMpAmount(statActor()) + (3.09 * 1.1),
+    'Mana Regeneration should add its sourced rate before the C4 idle-state multiplier'
+);
 
 const magicBarrierTarget = statActor();
 const magicBarrier = skill({ selfId: 1036, name: 'Magic Barrier', spell: true, power: 1, level: 2, buff: 1200000 });


### PR DESCRIPTION
## Summary
- restores reliable HP/MP recovery and removes recovery loops that could leave bots stalled
- gives bots the correct profession progression, skills, and grade access as they level
- fixes shield skills when a shield is equipped alongside a weapon
- safely upgrades existing cold bots in small batches, while new bots start with complete progression state

## Player impact
Bots recover, level, equip, and use their class abilities more consistently. Existing populations will gradually receive the same progression without interrupting active bots.

## Validation
- `npm run check`
- `npm test`
- targeted bot class progression and population-state checks