### PR TITLE
Distribute bot markets across towns

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -30,6 +30,7 @@ const tests = [
     'tests/test_bot_craft_telemetry.js',
     'tests/test_bot_cold_market_purchase.js',
     'tests/test_bot_cold_market_listing.js',
+    'tests/test_bot_market_town_routing.js',
     'tests/test_bot_craft_shop.js',
     'tests/test_bot_warehouse.js',
     'tests/test_bot_cold_market_trade_chat.js',

--- a/src/GameServer/Bot/Economy/ColdMarketListingService.js
+++ b/src/GameServer/Bot/Economy/ColdMarketListingService.js
@@ -4,9 +4,13 @@ const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
 const MarketOpportunity = invoke('GameServer/Bot/Economy/MarketOpportunity');
 const { marketStoreTitle } = invoke('GameServer/Bot/Economy/MarketStoreTitle');
 const TownPathfinder = invoke('GameServer/Bot/AI/TownPathfinder');
+const MarketTownPolicy = invoke('GameServer/Bot/Economy/MarketTownPolicy');
+const MerchantStoreConfigs = invoke('GameServer/Bot/MerchantStoreConfigs');
+const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
 
 const DEFAULT_LISTING_MS = 20 * 60 * 1000;
 const SELL_RETRY_DELAY_MS = 30 * 60 * 1000;
+const MARKET_TOWN_ROUTING_VERSION = 4;
 // Captured in-game from the Giran trading square. The inner rectangle is the
 // central column: it is walkable around, but a private store cannot sit there.
 const GIRAN_MARKET_PLAZA = Object.freeze({
@@ -17,16 +21,96 @@ const GIRAN_MARKET_PLAZA = Object.freeze({
 const GIRAN_STALL_EDGE_PADDING = 60;
 const GIRAN_COLUMN_CLEARANCE = 80;
 const GIRAN_STALL_MIN_DISTANCE = 40;
+// Captured from the Gludio D-grade trading square. Dynamic stalls use its
+// north, level ground; the south edge changes elevation and stays clear for
+// the fixed perimeter traders.
+const GLUDIO_D_MARKET_PLAZA = Object.freeze({
+    outer: Object.freeze({ minX: -14710, maxX: -14200, minY: 122620, maxY: 123820 }),
+    locZ: -3117
+});
+const GLUDIO_D_STALL_EDGE_PADDING = 60;
+const GLUDIO_D_STALL_MIN_DISTANCE = 60;
+const DION_D_MARKET_PLAZA = Object.freeze({
+    boundary: Object.freeze([
+        [15575, 143050], [16665, 144618], [17082, 145399], [18101, 146231],
+        [18564, 145810], [17813, 145422], [17129, 144877], [16364, 142984]
+    ]),
+    bounds: Object.freeze({ minX: 15575, maxX: 18564, minY: 142984, maxY: 146231 }),
+    locZ: -2900
+});
+const DION_D_STALL_EDGE_PADDING = 55;
+const DION_D_STALL_MIN_DISTANCE = 60;
+const TALKING_ISLAND_NO_GRADE_PLAZA = Object.freeze({
+    boundary: Object.freeze([
+        [-84242, 245018], [-83965, 244591], [-84553, 243951],
+        [-84801, 244105], [-85256, 243540], [-85494, 243762]
+    ]),
+    bounds: Object.freeze({ minX: -85494, maxX: -83965, minY: 243540, maxY: 245018 }),
+    locZ: -3730
+});
+const TALKING_ISLAND_STALL_EDGE_PADDING = 55;
+const TALKING_ISLAND_STALL_MIN_DISTANCE = 60;
+const ELVEN_VILLAGE_NO_GRADE_PLAZA = Object.freeze({
+    boundary: Object.freeze([
+        [46644, 50600], [47041, 49427], [46867, 48783],
+        [46384, 49055], [46230, 50247]
+    ]),
+    bounds: Object.freeze({ minX: 46230, maxX: 47041, minY: 48783, maxY: 50600 }),
+    locZ: -3060
+});
+const ELVEN_VILLAGE_STALL_EDGE_PADDING = 55;
+const ELVEN_VILLAGE_STALL_MIN_DISTANCE = 60;
+const DARK_ELVEN_VILLAGE_NO_GRADE_PLAZA = Object.freeze({
+    boundary: Object.freeze([
+        [12112, 16364], [13160, 16121], [13286, 16756], [12230, 17001]
+    ]),
+    bounds: Object.freeze({ minX: 12112, maxX: 13286, minY: 16121, maxY: 17001 }),
+    locZ: -4585
+});
+const DARK_ELVEN_VILLAGE_STALL_EDGE_PADDING = 55;
+const DARK_ELVEN_VILLAGE_STALL_MIN_DISTANCE = 60;
+const ORC_VILLAGE_NO_GRADE_PLAZA = Object.freeze({
+    boundary: Object.freeze([
+        [-45219, -112854], [-45219, -111851], [-44647, -111993], [-43825, -112855]
+    ]),
+    bounds: Object.freeze({ minX: -45219, maxX: -43825, minY: -112854, maxY: -111851 }),
+    locZ: -240
+});
+const ORC_VILLAGE_STALL_EDGE_PADDING = 55;
+const ORC_VILLAGE_STALL_MIN_DISTANCE = 60;
+const DWARVEN_VILLAGE_NO_GRADE_PLAZA = Object.freeze({
+    boundary: Object.freeze([
+        [115570, -178085], [115871, -179190], [115235, -179361], [115099, -177873]
+    ]),
+    bounds: Object.freeze({ minX: 115099, maxX: 115871, minY: -179361, maxY: -177873 }),
+    locZ: -920
+});
+const DWARVEN_VILLAGE_STALL_EDGE_PADDING = 55;
+const DWARVEN_VILLAGE_STALL_MIN_DISTANCE = 60;
 
 function marketTown(name) {
     return TownPathfinder.towns.find((town) => town.name === name)
+        || MarketTownPolicy.marketTown(name)
         || TownPathfinder.towns.find((town) => town.name === 'Giran')
         || null;
 }
 
+const targetMarketTownName = MarketTownPolicy.targetTownForItems;
+
 function isInRect(loc, rect) {
     return Number(loc?.locX) >= rect.minX && Number(loc?.locX) <= rect.maxX
         && Number(loc?.locY) >= rect.minY && Number(loc?.locY) <= rect.maxY;
+}
+
+function isInsidePolygon(loc, boundary = []) {
+    const x = Number(loc?.locX);
+    const y = Number(loc?.locY);
+    return boundary.reduce((inside, point, index) => {
+        const previous = boundary[(index + boundary.length - 1) % boundary.length];
+        const [xi, yi] = point;
+        const [xj, yj] = previous;
+        return ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi) / (yj - yi)) + xi) ? !inside : inside;
+    }, false);
 }
 
 function isGiranPlazaStallLocation(loc) {
@@ -52,20 +136,328 @@ function distance2d(a, b) {
     return Math.sqrt(dx * dx + dy * dy);
 }
 
+function staticMerchantStalls(townName, isValidStall) {
+    return Object.values(MerchantStoreConfigs)
+        .filter((store) => store.town === townName)
+        .map((store) => ({ locX: store.locX, locY: store.locY, locZ: store.locZ }))
+        .filter(isValidStall);
+}
+
 function isFreeGiranPlazaStall(loc, occupied) {
     return isGiranPlazaStallLocation(loc)
         && !occupied.some((other) => distance2d(loc, other) < GIRAN_STALL_MIN_DISTANCE);
 }
 
 function occupiedGiranPlazaStalls(characterId) {
-    return LifeState.allStates(2000)
+    return [
+        ...staticMerchantStalls('Giran', isGiranPlazaStallLocation),
+        ...LifeState.allStates(2000)
         .filter((state) => Number(state.characterId) !== Number(characterId)
             && (
                 (state.activity === 'merchant' && state.stats?.marketStore?.town === 'Giran')
                 || (state.activity === 'crafting' && state.stats?.craftShop?.town === 'Giran')
             )
             && isGiranPlazaStallLocation(state.stats.marketStore?.loc || state.stats.craftShop?.loc || state.loc))
-        .map((state) => state.stats.marketStore?.loc || state.stats.craftShop?.loc || state.loc);
+        .map((state) => state.stats.marketStore?.loc || state.stats.craftShop?.loc || state.loc)
+    ];
+}
+
+function isGludioDMarketStallLocation(loc) {
+    const { outer } = GLUDIO_D_MARKET_PLAZA;
+    return isInRect(loc, {
+        minX: outer.minX + GLUDIO_D_STALL_EDGE_PADDING,
+        maxX: outer.maxX - GLUDIO_D_STALL_EDGE_PADDING,
+        minY: outer.minY + GLUDIO_D_STALL_EDGE_PADDING,
+        maxY: outer.maxY - GLUDIO_D_STALL_EDGE_PADDING
+    });
+}
+
+function occupiedGludioDStalls(characterId) {
+    return [
+        ...staticMerchantStalls('Gludio', isGludioDMarketStallLocation),
+        ...LifeState.allStates(2000)
+        .filter((state) => Number(state.characterId) !== Number(characterId)
+            && state.activity === 'merchant'
+            && state.stats?.marketStore?.town === 'Gludio'
+            && isGludioDMarketStallLocation(state.stats.marketStore?.loc || state.loc))
+        .map((state) => state.stats.marketStore?.loc || state.loc)
+    ];
+}
+
+function chooseGludioDMarketStall(random = Math.random, occupied = []) {
+    const { outer, locZ } = GLUDIO_D_MARKET_PLAZA;
+    const minX = outer.minX + GLUDIO_D_STALL_EDGE_PADDING;
+    const maxX = outer.maxX - GLUDIO_D_STALL_EDGE_PADDING;
+    const minY = outer.minY + GLUDIO_D_STALL_EDGE_PADDING;
+    const maxY = outer.maxY - GLUDIO_D_STALL_EDGE_PADDING;
+    for (let attempt = 0; attempt < 96; attempt++) {
+        const loc = {
+            locX: Math.round(minX + random() * (maxX - minX)),
+            locY: Math.round(minY + random() * (maxY - minY)),
+            locZ
+        };
+        if (isGludioDMarketStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < GLUDIO_D_STALL_MIN_DISTANCE)) return loc;
+    }
+    for (let locX = minX; locX <= maxX; locX += GLUDIO_D_STALL_MIN_DISTANCE) {
+        for (let locY = minY; locY <= maxY; locY += GLUDIO_D_STALL_MIN_DISTANCE) {
+            const loc = { locX, locY, locZ };
+            if (!occupied.some((other) => distance2d(loc, other) < GLUDIO_D_STALL_MIN_DISTANCE)) return loc;
+        }
+    }
+    return null;
+}
+
+function isDionDMarketStallLocation(loc) {
+    const { bounds, boundary } = DION_D_MARKET_PLAZA;
+    return isInRect(loc, {
+        minX: bounds.minX + DION_D_STALL_EDGE_PADDING,
+        maxX: bounds.maxX - DION_D_STALL_EDGE_PADDING,
+        minY: bounds.minY + DION_D_STALL_EDGE_PADDING,
+        maxY: bounds.maxY - DION_D_STALL_EDGE_PADDING
+    }) && isInsidePolygon(loc, boundary);
+}
+
+function occupiedDionDStalls(characterId) {
+    return [
+        ...staticMerchantStalls('Dion', isDionDMarketStallLocation),
+        ...LifeState.allStates(2000)
+            .filter((state) => Number(state.characterId) !== Number(characterId)
+                && state.activity === 'merchant'
+                && state.stats?.marketStore?.town === 'Dion'
+                && isDionDMarketStallLocation(state.stats.marketStore?.loc || state.loc))
+            .map((state) => state.stats.marketStore?.loc || state.loc)
+    ];
+}
+
+function dionGroundLocation(locX, locY) {
+    return { locX, locY, locZ: GeodataEngine.getHeight(locX, locY, DION_D_MARKET_PLAZA.locZ) };
+}
+
+function chooseDionDMarketStall(random = Math.random, occupied = []) {
+    const { bounds } = DION_D_MARKET_PLAZA;
+    const minX = bounds.minX + DION_D_STALL_EDGE_PADDING;
+    const maxX = bounds.maxX - DION_D_STALL_EDGE_PADDING;
+    const minY = bounds.minY + DION_D_STALL_EDGE_PADDING;
+    const maxY = bounds.maxY - DION_D_STALL_EDGE_PADDING;
+    for (let attempt = 0; attempt < 128; attempt++) {
+        const loc = dionGroundLocation(
+            Math.round(minX + random() * (maxX - minX)),
+            Math.round(minY + random() * (maxY - minY))
+        );
+        if (isDionDMarketStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < DION_D_STALL_MIN_DISTANCE)) return loc;
+    }
+    for (let locX = minX; locX <= maxX; locX += DION_D_STALL_MIN_DISTANCE) {
+        for (let locY = minY; locY <= maxY; locY += DION_D_STALL_MIN_DISTANCE) {
+            const loc = dionGroundLocation(locX, locY);
+            if (isDionDMarketStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < DION_D_STALL_MIN_DISTANCE)) return loc;
+        }
+    }
+    return null;
+}
+
+function isTalkingIslandNoGradeStallLocation(loc) {
+    const { bounds, boundary } = TALKING_ISLAND_NO_GRADE_PLAZA;
+    return isInRect(loc, {
+        minX: bounds.minX + TALKING_ISLAND_STALL_EDGE_PADDING,
+        maxX: bounds.maxX - TALKING_ISLAND_STALL_EDGE_PADDING,
+        minY: bounds.minY + TALKING_ISLAND_STALL_EDGE_PADDING,
+        maxY: bounds.maxY - TALKING_ISLAND_STALL_EDGE_PADDING
+    }) && isInsidePolygon(loc, boundary);
+}
+
+function occupiedTalkingIslandNoGradeStalls(characterId) {
+    return [
+        ...staticMerchantStalls('Talking Island', isTalkingIslandNoGradeStallLocation),
+        ...LifeState.allStates(2000)
+        .filter((state) => Number(state.characterId) !== Number(characterId)
+            && state.activity === 'merchant'
+            && state.stats?.marketStore?.town === 'Talking Island'
+            && isTalkingIslandNoGradeStallLocation(state.stats.marketStore?.loc || state.loc))
+        .map((state) => state.stats.marketStore?.loc || state.loc)
+    ];
+}
+
+function chooseTalkingIslandNoGradeStall(random = Math.random, occupied = []) {
+    const { bounds, locZ } = TALKING_ISLAND_NO_GRADE_PLAZA;
+    const minX = bounds.minX + TALKING_ISLAND_STALL_EDGE_PADDING;
+    const maxX = bounds.maxX - TALKING_ISLAND_STALL_EDGE_PADDING;
+    const minY = bounds.minY + TALKING_ISLAND_STALL_EDGE_PADDING;
+    const maxY = bounds.maxY - TALKING_ISLAND_STALL_EDGE_PADDING;
+    for (let attempt = 0; attempt < 96; attempt++) {
+        const loc = { locX: Math.round(minX + random() * (maxX - minX)), locY: Math.round(minY + random() * (maxY - minY)), locZ };
+        if (isTalkingIslandNoGradeStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < TALKING_ISLAND_STALL_MIN_DISTANCE)) return loc;
+    }
+    for (let locX = minX; locX <= maxX; locX += TALKING_ISLAND_STALL_MIN_DISTANCE) {
+        for (let locY = minY; locY <= maxY; locY += TALKING_ISLAND_STALL_MIN_DISTANCE) {
+            const loc = { locX, locY, locZ };
+            if (isTalkingIslandNoGradeStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < TALKING_ISLAND_STALL_MIN_DISTANCE)) return loc;
+        }
+    }
+    return null;
+}
+
+function isElvenVillageNoGradeStallLocation(loc) {
+    const { bounds, boundary } = ELVEN_VILLAGE_NO_GRADE_PLAZA;
+    return isInRect(loc, {
+        minX: bounds.minX + ELVEN_VILLAGE_STALL_EDGE_PADDING,
+        maxX: bounds.maxX - ELVEN_VILLAGE_STALL_EDGE_PADDING,
+        minY: bounds.minY + ELVEN_VILLAGE_STALL_EDGE_PADDING,
+        maxY: bounds.maxY - ELVEN_VILLAGE_STALL_EDGE_PADDING
+    }) && isInsidePolygon(loc, boundary);
+}
+
+function occupiedElvenVillageNoGradeStalls(characterId) {
+    return [
+        ...staticMerchantStalls('Elven Village', isElvenVillageNoGradeStallLocation),
+        ...LifeState.allStates(2000)
+        .filter((state) => Number(state.characterId) !== Number(characterId)
+            && state.activity === 'merchant'
+            && state.stats?.marketStore?.town === 'Elven Village'
+            && isElvenVillageNoGradeStallLocation(state.stats.marketStore?.loc || state.loc))
+        .map((state) => state.stats.marketStore?.loc || state.loc)
+    ];
+}
+
+function chooseElvenVillageNoGradeStall(random = Math.random, occupied = []) {
+    const { bounds, locZ } = ELVEN_VILLAGE_NO_GRADE_PLAZA;
+    const minX = bounds.minX + ELVEN_VILLAGE_STALL_EDGE_PADDING;
+    const maxX = bounds.maxX - ELVEN_VILLAGE_STALL_EDGE_PADDING;
+    const minY = bounds.minY + ELVEN_VILLAGE_STALL_EDGE_PADDING;
+    const maxY = bounds.maxY - ELVEN_VILLAGE_STALL_EDGE_PADDING;
+    for (let attempt = 0; attempt < 96; attempt++) {
+        const loc = { locX: Math.round(minX + random() * (maxX - minX)), locY: Math.round(minY + random() * (maxY - minY)), locZ };
+        if (isElvenVillageNoGradeStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < ELVEN_VILLAGE_STALL_MIN_DISTANCE)) return loc;
+    }
+    for (let locX = minX; locX <= maxX; locX += ELVEN_VILLAGE_STALL_MIN_DISTANCE) {
+        for (let locY = minY; locY <= maxY; locY += ELVEN_VILLAGE_STALL_MIN_DISTANCE) {
+            const loc = { locX, locY, locZ };
+            if (isElvenVillageNoGradeStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < ELVEN_VILLAGE_STALL_MIN_DISTANCE)) return loc;
+        }
+    }
+    return null;
+}
+
+function isDarkElvenVillageNoGradeStallLocation(loc) {
+    const { bounds, boundary } = DARK_ELVEN_VILLAGE_NO_GRADE_PLAZA;
+    return isInRect(loc, {
+        minX: bounds.minX + DARK_ELVEN_VILLAGE_STALL_EDGE_PADDING,
+        maxX: bounds.maxX - DARK_ELVEN_VILLAGE_STALL_EDGE_PADDING,
+        minY: bounds.minY + DARK_ELVEN_VILLAGE_STALL_EDGE_PADDING,
+        maxY: bounds.maxY - DARK_ELVEN_VILLAGE_STALL_EDGE_PADDING
+    }) && isInsidePolygon(loc, boundary);
+}
+
+function occupiedDarkElvenVillageNoGradeStalls(characterId) {
+    return [
+        ...staticMerchantStalls('Dark Elven Village', isDarkElvenVillageNoGradeStallLocation),
+        ...LifeState.allStates(2000)
+        .filter((state) => Number(state.characterId) !== Number(characterId)
+            && state.activity === 'merchant'
+            && state.stats?.marketStore?.town === 'Dark Elven Village'
+            && isDarkElvenVillageNoGradeStallLocation(state.stats.marketStore?.loc || state.loc))
+        .map((state) => state.stats.marketStore?.loc || state.loc)
+    ];
+}
+
+function chooseDarkElvenVillageNoGradeStall(random = Math.random, occupied = []) {
+    const { bounds, locZ } = DARK_ELVEN_VILLAGE_NO_GRADE_PLAZA;
+    const minX = bounds.minX + DARK_ELVEN_VILLAGE_STALL_EDGE_PADDING;
+    const maxX = bounds.maxX - DARK_ELVEN_VILLAGE_STALL_EDGE_PADDING;
+    const minY = bounds.minY + DARK_ELVEN_VILLAGE_STALL_EDGE_PADDING;
+    const maxY = bounds.maxY - DARK_ELVEN_VILLAGE_STALL_EDGE_PADDING;
+    for (let attempt = 0; attempt < 96; attempt++) {
+        const loc = { locX: Math.round(minX + random() * (maxX - minX)), locY: Math.round(minY + random() * (maxY - minY)), locZ };
+        if (isDarkElvenVillageNoGradeStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < DARK_ELVEN_VILLAGE_STALL_MIN_DISTANCE)) return loc;
+    }
+    for (let locX = minX; locX <= maxX; locX += DARK_ELVEN_VILLAGE_STALL_MIN_DISTANCE) {
+        for (let locY = minY; locY <= maxY; locY += DARK_ELVEN_VILLAGE_STALL_MIN_DISTANCE) {
+            const loc = { locX, locY, locZ };
+            if (isDarkElvenVillageNoGradeStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < DARK_ELVEN_VILLAGE_STALL_MIN_DISTANCE)) return loc;
+        }
+    }
+    return null;
+}
+
+function isOrcVillageNoGradeStallLocation(loc) {
+    const { bounds, boundary } = ORC_VILLAGE_NO_GRADE_PLAZA;
+    return isInRect(loc, {
+        minX: bounds.minX + ORC_VILLAGE_STALL_EDGE_PADDING,
+        maxX: bounds.maxX - ORC_VILLAGE_STALL_EDGE_PADDING,
+        minY: bounds.minY + ORC_VILLAGE_STALL_EDGE_PADDING,
+        maxY: bounds.maxY - ORC_VILLAGE_STALL_EDGE_PADDING
+    }) && isInsidePolygon(loc, boundary);
+}
+
+function occupiedOrcVillageNoGradeStalls(characterId) {
+    return [
+        ...staticMerchantStalls('Orc Village', isOrcVillageNoGradeStallLocation),
+        ...LifeState.allStates(2000)
+        .filter((state) => Number(state.characterId) !== Number(characterId)
+            && state.activity === 'merchant'
+            && state.stats?.marketStore?.town === 'Orc Village'
+            && isOrcVillageNoGradeStallLocation(state.stats.marketStore?.loc || state.loc))
+        .map((state) => state.stats.marketStore?.loc || state.loc)
+    ];
+}
+
+function chooseOrcVillageNoGradeStall(random = Math.random, occupied = []) {
+    const { bounds, locZ } = ORC_VILLAGE_NO_GRADE_PLAZA;
+    const minX = bounds.minX + ORC_VILLAGE_STALL_EDGE_PADDING;
+    const maxX = bounds.maxX - ORC_VILLAGE_STALL_EDGE_PADDING;
+    const minY = bounds.minY + ORC_VILLAGE_STALL_EDGE_PADDING;
+    const maxY = bounds.maxY - ORC_VILLAGE_STALL_EDGE_PADDING;
+    for (let attempt = 0; attempt < 96; attempt++) {
+        const loc = { locX: Math.round(minX + random() * (maxX - minX)), locY: Math.round(minY + random() * (maxY - minY)), locZ };
+        if (isOrcVillageNoGradeStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < ORC_VILLAGE_STALL_MIN_DISTANCE)) return loc;
+    }
+    for (let locX = minX; locX <= maxX; locX += ORC_VILLAGE_STALL_MIN_DISTANCE) {
+        for (let locY = minY; locY <= maxY; locY += ORC_VILLAGE_STALL_MIN_DISTANCE) {
+            const loc = { locX, locY, locZ };
+            if (isOrcVillageNoGradeStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < ORC_VILLAGE_STALL_MIN_DISTANCE)) return loc;
+        }
+    }
+    return null;
+}
+
+function isDwarvenVillageNoGradeStallLocation(loc) {
+    const { bounds, boundary } = DWARVEN_VILLAGE_NO_GRADE_PLAZA;
+    return isInRect(loc, {
+        minX: bounds.minX + DWARVEN_VILLAGE_STALL_EDGE_PADDING,
+        maxX: bounds.maxX - DWARVEN_VILLAGE_STALL_EDGE_PADDING,
+        minY: bounds.minY + DWARVEN_VILLAGE_STALL_EDGE_PADDING,
+        maxY: bounds.maxY - DWARVEN_VILLAGE_STALL_EDGE_PADDING
+    }) && isInsidePolygon(loc, boundary);
+}
+
+function occupiedDwarvenVillageNoGradeStalls(characterId) {
+    return [
+        ...staticMerchantStalls('Dwarven Village', isDwarvenVillageNoGradeStallLocation),
+        ...LifeState.allStates(2000)
+        .filter((state) => Number(state.characterId) !== Number(characterId)
+            && state.activity === 'merchant'
+            && state.stats?.marketStore?.town === 'Dwarven Village'
+            && isDwarvenVillageNoGradeStallLocation(state.stats.marketStore?.loc || state.loc))
+        .map((state) => state.stats.marketStore?.loc || state.loc)
+    ];
+}
+
+function chooseDwarvenVillageNoGradeStall(random = Math.random, occupied = []) {
+    const { bounds, locZ } = DWARVEN_VILLAGE_NO_GRADE_PLAZA;
+    const minX = bounds.minX + DWARVEN_VILLAGE_STALL_EDGE_PADDING;
+    const maxX = bounds.maxX - DWARVEN_VILLAGE_STALL_EDGE_PADDING;
+    const minY = bounds.minY + DWARVEN_VILLAGE_STALL_EDGE_PADDING;
+    const maxY = bounds.maxY - DWARVEN_VILLAGE_STALL_EDGE_PADDING;
+    for (let attempt = 0; attempt < 96; attempt++) {
+        const loc = { locX: Math.round(minX + random() * (maxX - minX)), locY: Math.round(minY + random() * (maxY - minY)), locZ };
+        if (isDwarvenVillageNoGradeStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < DWARVEN_VILLAGE_STALL_MIN_DISTANCE)) return loc;
+    }
+    for (let locX = minX; locX <= maxX; locX += DWARVEN_VILLAGE_STALL_MIN_DISTANCE) {
+        for (let locY = minY; locY <= maxY; locY += DWARVEN_VILLAGE_STALL_MIN_DISTANCE) {
+            const loc = { locX, locY, locZ };
+            if (isDwarvenVillageNoGradeStallLocation(loc) && !occupied.some((other) => distance2d(loc, other) < DWARVEN_VILLAGE_STALL_MIN_DISTANCE)) return loc;
+        }
+    }
+    return null;
 }
 
 function chooseGiranPlazaStall(random = Math.random, occupied = []) {
@@ -96,6 +488,13 @@ function chooseGiranPlazaStall(random = Math.random, occupied = []) {
 
 function marketLocation(town, options) {
     if (town?.name === 'Giran') return chooseGiranPlazaStall(options.random, occupiedGiranPlazaStalls(options.state?.characterId));
+    if (town?.name === 'Gludio') return chooseGludioDMarketStall(options.random, occupiedGludioDStalls(options.state?.characterId));
+    if (town?.name === 'Dion') return chooseDionDMarketStall(options.random, occupiedDionDStalls(options.state?.characterId));
+    if (town?.name === 'Talking Island') return chooseTalkingIslandNoGradeStall(options.random, occupiedTalkingIslandNoGradeStalls(options.state?.characterId));
+    if (town?.name === 'Elven Village') return chooseElvenVillageNoGradeStall(options.random, occupiedElvenVillageNoGradeStalls(options.state?.characterId));
+    if (town?.name === 'Dark Elven Village') return chooseDarkElvenVillageNoGradeStall(options.random, occupiedDarkElvenVillageNoGradeStalls(options.state?.characterId));
+    if (town?.name === 'Orc Village') return chooseOrcVillageNoGradeStall(options.random, occupiedOrcVillageNoGradeStalls(options.state?.characterId));
+    if (town?.name === 'Dwarven Village') return chooseDwarvenVillageNoGradeStall(options.random, occupiedDwarvenVillageNoGradeStalls(options.state?.characterId));
     return town?.center ? { ...town.center } : { ...(options.state?.loc || {}) };
 }
 
@@ -107,7 +506,7 @@ function open(state, options = {}) {
     if (!items.length) return Promise.resolve({ state, listed: false, reason: 'nothing_to_sell' });
 
     const timestamp = Number(options.now) || Date.now();
-    const town = marketTown(options.town || state.currentRegion || 'Giran');
+    const town = marketTown(options.town || targetMarketTownName(state, items));
     const storeLoc = marketLocation(town, { ...options, state });
     if (!storeLoc) return Promise.resolve({ state, listed: false, reason: 'giran_plaza_full' });
     const nextState = {
@@ -126,6 +525,7 @@ function open(state, options = {}) {
                 sellerName: state.name,
                 title: options.title || marketStoreTitle(items),
                 autoTitle: !options.title,
+                marketTownRoutingVersion: MARKET_TOWN_ROUTING_VERSION,
                 town: town?.name || options.town || state.currentRegion,
                 loc: storeLoc,
                 items,
@@ -152,6 +552,25 @@ function open(state, options = {}) {
 function resolve(state, timestamp = Date.now()) {
     const store = state?.stats?.marketStore;
     if (!state || state.activity !== 'merchant' || !store) return Promise.resolve({ state, closed: false });
+    const targetTownName = targetMarketTownName(state, store.items || []);
+    if (store.town !== targetTownName) {
+        const town = marketTown(targetTownName);
+        const loc = marketLocation(town, { state });
+        if (!loc) return Promise.resolve({ state, closed: false, reason: 'market_plaza_full' });
+        const relocated = {
+            ...state,
+            currentRegion: town.name,
+            loc,
+            stats: {
+                ...(state.stats || {}),
+                marketStore: { ...store, marketTownRoutingVersion: MARKET_TOWN_ROUTING_VERSION, town: town.name, loc }
+            }
+        };
+        return LifeState.upsertState(relocated, 'cold_market_town_rebalanced').then((saved) => {
+            if (saved) MarketOpportunity.indexColdStore(saved);
+            return { state: saved || relocated, closed: false, relocated: true };
+        });
+    }
     const hasStock = (store.items || []).some((item) => Number(item.count) > 0);
     if (hasStock && Number(store.expiresAt || 0) > timestamp) {
         MarketOpportunity.indexColdStore(state);
@@ -193,6 +612,61 @@ function resolve(state, timestamp = Date.now()) {
                 warehouseCount,
                 liquidatedCount: liquidated.reduce((sum, item) => sum + Number(item.count || 0), 0)
             })));
+}
+
+// Stores created before town-based routing all lived in Giran.  Move that
+// bounded legacy set outside the normal cold-resolve queue, which prioritises
+// finite travel transitions and may otherwise starve passive merchant states.
+function legacyMarketTownCandidates(states = [], limit = 10) {
+    const safeLimit = Math.max(1, Math.min(25, Number(limit) || 10));
+    return states
+        .filter((state) => state.phase === 'cold' && state.activity === 'merchant')
+        .filter((state) => state.stats?.marketStore)
+        .filter((state) => Number(state.stats.marketStore.marketTownRoutingVersion || 0) < MARKET_TOWN_ROUTING_VERSION)
+        .sort((a, b) => Number(a.updatedAt || 0) - Number(b.updatedAt || 0))
+        .slice(0, safeLimit);
+}
+
+function migrateLegacyMarketTowns(limit = 10) {
+    return LifeState.legacyMarketTownCandidates(limit, MARKET_TOWN_ROUTING_VERSION).then((states) => {
+        const candidates = legacyMarketTownCandidates(states, limit);
+        return candidates.reduce((chain, state) => chain.then((migrated) => {
+        const store = state.stats.marketStore;
+        const targetTownName = targetMarketTownName(state, store.items || []);
+        if (store.town === targetTownName) {
+            const checked = {
+                ...state,
+                stats: {
+                    ...(state.stats || {}),
+                    marketStore: { ...store, marketTownRoutingVersion: MARKET_TOWN_ROUTING_VERSION }
+                }
+            };
+            return LifeState.upsertState(checked, 'cold_market_town_migration_checked').then((saved) => {
+                migrated.push({ state: saved || checked, relocated: false });
+                return migrated;
+            });
+        }
+
+        const town = marketTown(targetTownName);
+        const loc = marketLocation(town, { state });
+        if (!loc) return migrated;
+        const relocated = {
+            ...state,
+            currentRegion: town.name,
+            loc,
+            stats: {
+                ...(state.stats || {}),
+                marketStore: { ...store, marketTownRoutingVersion: MARKET_TOWN_ROUTING_VERSION, town: town.name, loc }
+            }
+        };
+        return LifeState.upsertState(relocated, 'cold_market_town_rebalanced').then((saved) => {
+            const resolved = saved || relocated;
+            MarketOpportunity.indexColdStore(resolved);
+            migrated.push({ state: resolved, relocated: true });
+            return migrated;
+        });
+        }), Promise.resolve([]));
+    });
 }
 
 function reconcileInventory(state) {
@@ -248,11 +722,44 @@ function settle(offer, qty = 1) {
 module.exports = {
     DEFAULT_LISTING_MS,
     SELL_RETRY_DELAY_MS,
+    MARKET_TOWN_ROUTING_VERSION,
     GIRAN_MARKET_PLAZA,
     GIRAN_STALL_MIN_DISTANCE,
+    GLUDIO_D_MARKET_PLAZA,
+    GLUDIO_D_STALL_MIN_DISTANCE,
+    DION_D_MARKET_PLAZA,
+    DION_D_STALL_MIN_DISTANCE,
+    TALKING_ISLAND_NO_GRADE_PLAZA,
+    TALKING_ISLAND_STALL_MIN_DISTANCE,
+    ELVEN_VILLAGE_NO_GRADE_PLAZA,
+    ELVEN_VILLAGE_STALL_MIN_DISTANCE,
+    DARK_ELVEN_VILLAGE_NO_GRADE_PLAZA,
+    DARK_ELVEN_VILLAGE_STALL_MIN_DISTANCE,
+    ORC_VILLAGE_NO_GRADE_PLAZA,
+    ORC_VILLAGE_STALL_MIN_DISTANCE,
+    DWARVEN_VILLAGE_NO_GRADE_PLAZA,
+    DWARVEN_VILLAGE_STALL_MIN_DISTANCE,
     marketStoreTitle,
+    staticMerchantStalls,
+    targetMarketTownName,
+    legacyMarketTownCandidates,
+    migrateLegacyMarketTowns,
     chooseGiranPlazaStall,
+    chooseGludioDMarketStall,
+    chooseDionDMarketStall,
+    chooseTalkingIslandNoGradeStall,
+    chooseElvenVillageNoGradeStall,
+    chooseDarkElvenVillageNoGradeStall,
+    chooseOrcVillageNoGradeStall,
+    chooseDwarvenVillageNoGradeStall,
     isGiranPlazaStallLocation,
+    isGludioDMarketStallLocation,
+    isDionDMarketStallLocation,
+    isTalkingIslandNoGradeStallLocation,
+    isElvenVillageNoGradeStallLocation,
+    isDarkElvenVillageNoGradeStallLocation,
+    isOrcVillageNoGradeStallLocation,
+    isDwarvenVillageNoGradeStallLocation,
     open,
     reconcileInventory,
     resolve,

--- a/src/GameServer/Bot/Economy/ColdMarketListingService.js
+++ b/src/GameServer/Bot/Economy/ColdMarketListingService.js
@@ -552,27 +552,28 @@ function open(state, options = {}) {
 function resolve(state, timestamp = Date.now()) {
     const store = state?.stats?.marketStore;
     if (!state || state.activity !== 'merchant' || !store) return Promise.resolve({ state, closed: false });
-    const targetTownName = targetMarketTownName(state, store.items || []);
-    if (store.town !== targetTownName) {
-        const town = marketTown(targetTownName);
-        const loc = marketLocation(town, { state });
-        if (!loc) return Promise.resolve({ state, closed: false, reason: 'market_plaza_full' });
-        const relocated = {
-            ...state,
-            currentRegion: town.name,
-            loc,
-            stats: {
-                ...(state.stats || {}),
-                marketStore: { ...store, marketTownRoutingVersion: MARKET_TOWN_ROUTING_VERSION, town: town.name, loc }
-            }
-        };
-        return LifeState.upsertState(relocated, 'cold_market_town_rebalanced').then((saved) => {
-            if (saved) MarketOpportunity.indexColdStore(saved);
-            return { state: saved || relocated, closed: false, relocated: true };
-        });
-    }
     const hasStock = (store.items || []).some((item) => Number(item.count) > 0);
-    if (hasStock && Number(store.expiresAt || 0) > timestamp) {
+    const isActive = hasStock && Number(store.expiresAt || 0) > timestamp;
+    if (isActive) {
+        const targetTownName = targetMarketTownName(state, store.items || []);
+        if (store.town !== targetTownName) {
+            const town = marketTown(targetTownName);
+            const loc = marketLocation(town, { state });
+            if (!loc) return Promise.resolve({ state, closed: false, reason: 'market_plaza_full' });
+            const relocated = {
+                ...state,
+                currentRegion: town.name,
+                loc,
+                stats: {
+                    ...(state.stats || {}),
+                    marketStore: { ...store, marketTownRoutingVersion: MARKET_TOWN_ROUTING_VERSION, town: town.name, loc }
+                }
+            };
+            return LifeState.upsertState(relocated, 'cold_market_town_rebalanced').then((saved) => {
+                if (saved) MarketOpportunity.indexColdStore(saved);
+                return { state: saved || relocated, closed: false, relocated: true };
+            });
+        }
         MarketOpportunity.indexColdStore(state);
         return Promise.resolve({ state, closed: false });
     }
@@ -669,6 +670,15 @@ function migrateLegacyMarketTowns(limit = 10) {
     });
 }
 
+function expireStaleMarketStores(limit = 10, timestamp = Date.now()) {
+    return LifeState.expiredMarketStoreCandidates(limit, timestamp).then((states) => states.reduce((chain, state) => (
+        chain.then((expired) => resolve(state, timestamp).then((result) => {
+            if (result.closed) expired.push(result);
+            return expired;
+        }))
+    ), Promise.resolve([])));
+}
+
 function reconcileInventory(state) {
     const store = state?.stats?.marketStore;
     if (!state || state.activity !== 'merchant' || !store) return Promise.resolve({ state, reconciled: false });
@@ -744,6 +754,7 @@ module.exports = {
     targetMarketTownName,
     legacyMarketTownCandidates,
     migrateLegacyMarketTowns,
+    expireStaleMarketStores,
     chooseGiranPlazaStall,
     chooseGludioDMarketStall,
     chooseDionDMarketStall,

--- a/src/GameServer/Bot/Economy/ColdMarketService.js
+++ b/src/GameServer/Bot/Economy/ColdMarketService.js
@@ -7,6 +7,33 @@ const GoalExecutor = invoke('GameServer/Bot/Goals/GoalExecutor');
 
 const RETRY_DELAY_MS = 15 * 60 * 1000;
 
+function retryAfterFailedPurchase(state, goal, reason) {
+    const timestamp = Date.now();
+    const retryState = {
+        ...state,
+        stats: {
+            ...(state.stats || {}),
+            marketRetryAfter: timestamp + RETRY_DELAY_MS,
+            marketWanted: {
+                ...(state.stats?.marketWanted || {}),
+                itemId: goal.target.itemId,
+                itemName: goal.target.itemName,
+                lastMissingAt: timestamp
+            },
+            marketLead: null
+        }
+    };
+    const wanted = TradeChat.maybeAnnounceWanted(retryState, goal);
+    const returnState = GoalExecutor.finishMarketVisit(wanted.state) || wanted.state;
+    return LifeState.upsertState(returnState, 'market_no_offer_return').then((saved) => ({
+        state: saved || returnState,
+        purchased: false,
+        reason,
+        wanted: wanted.announced,
+        remoteOffer: null
+    }));
+}
+
 const ColdMarketService = {
     tryPurchase(state, goal) {
         if (!state || state.phase === 'hot' || state.activity !== 'shopping') return Promise.resolve({ state, purchased: false, reason: 'not_shopping' });
@@ -18,30 +45,18 @@ const ColdMarketService = {
             buyerCharacterId: state.characterId
         });
         if (!offer) {
-            const retryState = {
-                ...state,
-                stats: { ...(state.stats || {}), marketRetryAfter: Date.now() + RETRY_DELAY_MS,
-                    marketWanted: { ...(state.stats?.marketWanted || {}), itemId: goal.target.itemId, itemName: goal.target.itemName, lastMissingAt: Date.now() },
-                    marketLead: null }
-            };
-            const wanted = TradeChat.maybeAnnounceWanted(retryState, goal);
             // A wanted ad is not a reason to idle in Giran.  Keep the demand
             // and retry window, then return to the material route until the
             // next market attempt is due.
-            const returnState = GoalExecutor.finishMarketVisit(wanted.state) || wanted.state;
-            return LifeState.upsertState(returnState, 'market_no_offer_return').then((saved) => ({
-                state: saved || returnState,
-                purchased: false,
-                reason: 'no_affordable_offer', wanted: wanted.announced, remoteOffer: null
-            }));
+            return retryAfterFailedPurchase(state, goal, 'no_affordable_offer');
         }
-        if (!MarketOpportunity.reserve(offer, 1)) return Promise.resolve({ state, purchased: false, reason: 'offer_changed' });
+        if (!MarketOpportunity.reserve(offer, 1)) return retryAfterFailedPurchase(state, goal, 'offer_changed');
         offer.buyerCharacterId = Number(state.characterId);
 
         return LifeState.applyMarketPurchase(state, offer).then((updated) => {
             if (!updated) {
                 MarketOpportunity.release(offer, 1);
-                return { state, purchased: false, reason: 'persist_failed' };
+                return retryAfterFailedPurchase(state, goal, 'persist_failed');
             }
             const settlement = offer.sourceType === 'cold_store' ? ListingService.settle(offer, 1) : Promise.resolve(null);
             return settlement.then((sellerState) => GoalState.clear(state.characterId, 'completed').then(() => ({
@@ -53,7 +68,7 @@ const ColdMarketService = {
         }).catch((err) => {
             MarketOpportunity.release(offer, 1);
             utils.infoWarn('BotMarket', 'cold purchase failed for %s: %s', state.name, err.message);
-            return { state, purchased: false, reason: 'purchase_failed' };
+            return retryAfterFailedPurchase(state, goal, 'purchase_failed');
         });
     }
 };

--- a/src/GameServer/Bot/Economy/MarketTownPolicy.js
+++ b/src/GameServer/Bot/Economy/MarketTownPolicy.js
@@ -1,0 +1,87 @@
+const ItemDisposition = invoke('GameServer/Bot/Economy/ItemDisposition');
+const DataCache = invoke('GameServer/DataCache');
+
+const GLUDIO_D_GRADE_SHARE_PERCENT = 15;
+let rankIndexSource = null;
+let rankIndexSize = -1;
+let rankBySelfId = new Map();
+
+// Add a town here only after its sellable no-grade plaza has been captured.
+// This prevents cheap local loot from silently falling back to the Giran hub.
+const NO_GRADE_MARKET_TOWNS = new Set(['Talking Island', 'Elven Village', 'Dark Elven Village', 'Orc Village', 'Dwarven Village']);
+const NO_GRADE_MARKETS = Object.freeze([
+    { name: 'Talking Island', locX: -84700, locY: 244200, radius: 12000 },
+    { name: 'Elven Village', locX: 46600, locY: 49700, radius: 12000 },
+    { name: 'Dark Elven Village', locX: 12700, locY: 16600, radius: 12000 },
+    { name: 'Orc Village', locX: -44600, locY: -112400, locZ: -240, radius: 12000 },
+    { name: 'Dwarven Village', locX: 115440, locY: -178580, locZ: -920, radius: 12000 }
+]);
+
+// These starter villages are intentionally not all part of TownPathfinder's
+// geodata atlas yet. Market travel only needs the captured plaza centre: the
+// cold resolver places the actual private store inside its polygon on arrival.
+function marketTown(name) {
+    const market = NO_GRADE_MARKETS.find((candidate) => candidate.name === name);
+    return market && {
+        name: market.name,
+        center: { locX: market.locX, locY: market.locY, locZ: market.locZ || 0 }
+    };
+}
+
+function nearbyNoGradeMarket(loc = {}) {
+    const x = Number(loc.locX || 0);
+    const y = Number(loc.locY || 0);
+    return NO_GRADE_MARKETS
+        .map((market) => ({ ...market, distance: Math.hypot(x - market.locX, y - market.locY) }))
+        .filter((market) => market.distance <= market.radius)
+        .sort((a, b) => a.distance - b.distance)[0] || null;
+}
+
+function rankOf(item) {
+    const selfId = Number(item?.selfId || 0);
+    const items = DataCache.items || [];
+    if (rankIndexSource !== items || rankIndexSize !== items.length) {
+        rankIndexSource = items;
+        rankIndexSize = items.length;
+        rankBySelfId = new Map(items.map((candidate) => [Number(candidate.selfId), candidate?.etc?.rank || 'none']));
+    }
+    return String(item?.rank || rankBySelfId.get(selfId) || 'none').toLowerCase();
+}
+
+function dGradeMarketFor(state = {}) {
+    // Gludio's compact D plaza holds roughly one hundred shops once its
+    // permanent merchants are reserved.  Dion receives the overflow through
+    // a stable character-id split, so bots do not oscillate between towns.
+    const bucket = Math.abs(Number(state.characterId || 0)) % 100;
+    return bucket < GLUDIO_D_GRADE_SHARE_PERCENT ? 'Gludio' : 'Dion';
+}
+
+function targetTownForItems(state, items = []) {
+    const ranks = items.map(rankOf);
+    const hasHigherGrade = ranks.some((rank) => ['c', 'b', 'a', 's'].includes(rank));
+    const hasDGrade = ranks.includes('d');
+    const onlyNoGrade = ranks.length > 0 && ranks.every((rank) => rank === 'none');
+    // A listed bot now stands at the market, so use its saved departure point
+    // to preserve local no-grade routing during legacy-store migrations.
+    const saleOrigin = state?.stats?.marketReturn?.loc || state?.loc;
+    const localTown = nearbyNoGradeMarket(saleOrigin)?.name || null;
+
+    if (onlyNoGrade) return NO_GRADE_MARKET_TOWNS.has(localTown) ? localTown : 'Giran';
+    if (!hasHigherGrade && hasDGrade) return dGradeMarketFor(state);
+    return 'Giran';
+}
+
+function targetTownForSale(state) {
+    return targetTownForItems(state, ItemDisposition.saleCandidates(state));
+}
+
+module.exports = {
+    GLUDIO_D_GRADE_SHARE_PERCENT,
+    NO_GRADE_MARKET_TOWNS,
+    NO_GRADE_MARKETS,
+    dGradeMarketFor,
+    marketTown,
+    nearbyNoGradeMarket,
+    targetTownForItems,
+    targetTownForSale
+};

--- a/src/GameServer/Bot/Goals/GoalExecutor.js
+++ b/src/GameServer/Bot/Goals/GoalExecutor.js
@@ -1,11 +1,15 @@
 const TownPathfinder = invoke('GameServer/Bot/AI/TownPathfinder');
 const TownRespawn = invoke('GameServer/World/TownRespawn');
+const MarketTownPolicy = invoke('GameServer/Bot/Economy/MarketTownPolicy');
 
 const MARKET_TRAVEL_MS = 25 * 1000;
 const GATEKEEPER_SPOT_TRAVEL_MS = 25 * 1000;
 
 function marketTown(name = 'Giran') {
-    return TownPathfinder.towns.find((town) => town.name === name) || TownPathfinder.towns.find((town) => town.name === 'Giran') || null;
+    return TownPathfinder.towns.find((town) => town.name === name)
+        || MarketTownPolicy.marketTown(name)
+        || TownPathfinder.towns.find((town) => town.name === 'Giran')
+        || null;
 }
 
 function beginMarketTravel(state, goal, timestamp = Date.now()) {
@@ -18,9 +22,7 @@ function beginMarketTravel(state, goal, timestamp = Date.now()) {
     if ((buyingGear || buyingMaterial) && Number(state.stats?.marketRetryAfter || 0) > timestamp) return null;
     if (sellingInventory && Number(state.stats?.marketSellRetryAfter || 0) > timestamp) return null;
 
-    // Dynamic bots share one economic hub. Static merchant bots may remain in
-    // other towns, but players and cold bots travel to Giran to trade.
-    const town = marketTown('Giran');
+    const town = sellingInventory ? marketTown(MarketTownPolicy.targetTownForSale(state)) : marketTown('Giran');
     if (!town) return null;
     const from = { ...state.loc };
     const nearestTown = TownRespawn.getClosestTown(from.locX, from.locY);
@@ -91,4 +93,4 @@ function finishMarketVisit(state, timestamp = Date.now()) {
     };
 }
 
-module.exports = { MARKET_TRAVEL_MS, GATEKEEPER_SPOT_TRAVEL_MS, beginMarketTravel, finishMarketVisit };
+module.exports = { MARKET_TRAVEL_MS, GATEKEEPER_SPOT_TRAVEL_MS, beginMarketTravel, finishMarketVisit, marketTownForSale: MarketTownPolicy.targetTownForSale };

--- a/src/GameServer/Bot/Goals/NeedsEvaluator.js
+++ b/src/GameServer/Bot/Goals/NeedsEvaluator.js
@@ -150,7 +150,7 @@ function evaluate(state = {}, options = {}) {
     const wantedMaterial = craftPlan?.marketFallback && craftPlan?.next?.itemId
         ? craftPlan.materials?.find((material) => Number(material.selfId) === Number(craftPlan.next.itemId))
         : null;
-    if (wantedMaterial?.missing > 0) {
+    if (wantedMaterial?.missing > 0 && Number(state.stats?.marketRetryAfter || 0) <= timestamp) {
         candidates.push({
             type: 'buy_craft_material',
             priority: 82,

--- a/src/GameServer/Bot/MerchantStoreConfigs.js
+++ b/src/GameServer/Bot/MerchantStoreConfigs.js
@@ -55,7 +55,7 @@ module.exports = {
         title: "D mats and gear",
         town: "Gludio",
         storeType: 1,
-        locX: -12522, locY: 122926, locZ: -3118,
+        locX: -14590, locY: 123650, locZ: -3117,
         items: [
             s(1867, 0.70, 5000), s(1869, 0.72, 5000), s(1870, 0.70, 4000),
             s(1871, 0.68, 4000), s(1872, 0.70, 5000), s(1873, 0.74, 2500),
@@ -66,7 +66,7 @@ module.exports = {
         title: "Gludio stock",
         town: "Gludio",
         storeType: 1,
-        locX: -12470, locY: 123020, locZ: -3118,
+        locX: -14370, locY: 123650, locZ: -3117,
         items: [
             s(22, 0.68, 20), s(24, 0.68, 10), s(31, 0.68, 10),
             s(38, 0.72, 12), s(50, 0.72, 12), s(43, 0.70, 10),
@@ -77,7 +77,7 @@ module.exports = {
         title: "Buy D mats",
         town: "Gludio",
         storeType: 3,
-        locX: -12480, locY: 122950, locZ: -3118,
+        locX: -14590, locY: 123360, locZ: -3117,
         items: [
             b(1867, 0.64), b(1868, 0.62), b(1869, 0.62), b(1870, 0.62),
             b(1871, 0.62), b(1872, 0.64), b(1873, 0.66), b(1880, 0.66),
@@ -88,7 +88,7 @@ module.exports = {
         title: "Buy plains drops",
         town: "Gludio",
         storeType: 3,
-        locX: -12582, locY: 122850, locZ: -3118,
+        locX: -14370, locY: 123360, locZ: -3117,
         items: [
             b(1921, 0.70), b(1922, 0.70), b(1923, 0.70), b(1924, 0.70),
             b(1925, 0.70), b(2011, 0.68), b(2012, 0.68), b(2013, 0.68),

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -717,7 +717,8 @@ const BotLifeState = {
                         ...(marketState.stats.marketStore || {}),
                         loc: { ...storeLoc },
                         items: (store?.items || []).map((item) => ({
-                            selfId: Number(item.selfId), price: Number(item.price), count: Number(item.count), name: item.name || itemName(item.selfId)
+                            selfId: Number(item.selfId), price: Number(item.price), count: Number(item.count), name: item.name || itemName(item.selfId),
+                            rank: item.rank || itemTemplate(item.selfId)?.etc?.rank || 'none'
                         }))
                     }
                 }
@@ -912,6 +913,29 @@ const BotLifeState = {
             return state;
         })).catch((err) => {
             utils.infoWarn('BotLife', 'failed to fetch due cold states: %s', err.message);
+            return [];
+        });
+    },
+
+    legacyMarketTownCandidates(limit = 10, routingVersion = 1) {
+        if (!initialized) return Promise.resolve([]);
+        const safeLimit = Math.max(1, Math.min(25, Number(limit) || 10));
+        const version = Math.max(1, Number(routingVersion) || 1);
+        return Database.execute([
+            `SELECT * FROM ${TABLE}
+            WHERE phase = 'cold'
+            AND activity = 'merchant'
+            AND JSON_EXTRACT(statsJson, '$.marketStore') IS NOT NULL
+            AND COALESCE(CAST(JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.marketStore.marketTownRoutingVersion')) AS UNSIGNED), 0) < ?
+            ORDER BY updatedAt ASC
+            LIMIT ${safeLimit}`,
+            [version]
+        ]).then((rows) => rows.map((row) => {
+            const state = normalize(row);
+            cache.set(state.characterId, state);
+            return state;
+        })).catch((err) => {
+            utils.infoWarn('BotLife', 'failed to fetch legacy market-town candidates: %s', err.message);
             return [];
         });
     },

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -927,15 +927,38 @@ const BotLifeState = {
             AND activity = 'merchant'
             AND JSON_EXTRACT(statsJson, '$.marketStore') IS NOT NULL
             AND COALESCE(CAST(JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.marketStore.marketTownRoutingVersion')) AS UNSIGNED), 0) < ?
+            AND COALESCE(CAST(JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.marketStore.expiresAt')) AS UNSIGNED), 0) > ?
             ORDER BY updatedAt ASC
             LIMIT ${safeLimit}`,
-            [version]
+            [version, Date.now()]
         ]).then((rows) => rows.map((row) => {
             const state = normalize(row);
             cache.set(state.characterId, state);
             return state;
         })).catch((err) => {
             utils.infoWarn('BotLife', 'failed to fetch legacy market-town candidates: %s', err.message);
+            return [];
+        });
+    },
+
+    expiredMarketStoreCandidates(limit = 10, timestamp = Date.now()) {
+        if (!initialized) return Promise.resolve([]);
+        const safeLimit = Math.max(1, Math.min(25, Number(limit) || 10));
+        return Database.execute([
+            `SELECT * FROM ${TABLE}
+            WHERE phase = 'cold'
+            AND activity = 'merchant'
+            AND JSON_EXTRACT(statsJson, '$.marketStore') IS NOT NULL
+            AND COALESCE(CAST(JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.marketStore.expiresAt')) AS UNSIGNED), 0) <= ?
+            ORDER BY updatedAt ASC
+            LIMIT ${safeLimit}`,
+            [Number(timestamp) || Date.now()]
+        ]).then((rows) => rows.map((row) => {
+            const state = normalize(row);
+            cache.set(state.characterId, state);
+            return state;
+        })).catch((err) => {
+            utils.infoWarn('BotLife', 'failed to fetch expired market stores: %s', err.message);
             return [];
         });
     },

--- a/src/GameServer/Bot/Population/PopulationConfig.js
+++ b/src/GameServer/Bot/Population/PopulationConfig.js
@@ -10,6 +10,10 @@ const DEFAULTS = {
     // in small batches so restart never becomes a database migration spike.
     classProgressionMigrationIntervalMs: 10000,
     classProgressionMigrationBatchSize: 5,
+    // One-off migration for stores created before market towns were split.
+    // It is deliberately independent from the normal cold-resolve budget.
+    marketTownMigrationIntervalMs: 10000,
+    marketTownMigrationBatchSize: 10,
     partyFormationIntervalMs: 45000,
     phasePolicyIntervalMs: 10000,
     directorIntervalMs: 30000,

--- a/src/GameServer/Bot/Population/PopulationConfig.js
+++ b/src/GameServer/Bot/Population/PopulationConfig.js
@@ -14,6 +14,8 @@ const DEFAULTS = {
     // It is deliberately independent from the normal cold-resolve budget.
     marketTownMigrationIntervalMs: 10000,
     marketTownMigrationBatchSize: 10,
+    marketExpiryCleanupIntervalMs: 10000,
+    marketExpiryCleanupBatchSize: 10,
     partyFormationIntervalMs: 45000,
     phasePolicyIntervalMs: 10000,
     directorIntervalMs: 30000,

--- a/src/GameServer/Bot/Population/PopulationService.js
+++ b/src/GameServer/Bot/Population/PopulationService.js
@@ -111,9 +111,12 @@ const PopulationService = {
     classProgressionMigrationTimer: null,
     marketTownMigrationTimer: null,
     nextMarketTownMigrationAt: 0,
+    marketExpiryCleanupTimer: null,
+    nextMarketExpiryCleanupAt: 0,
     resolving: false,
     classProgressionMigrationRunning: false,
     marketTownMigrationRunning: false,
+    marketExpiryCleanupRunning: false,
     partyFormationRunning: false,
     phasePolicyRunning: false,
 
@@ -178,6 +181,14 @@ const PopulationService = {
             this.marketTownMigrationTimer.unref();
         }
 
+        this.marketExpiryCleanupTimer = setInterval(() => {
+            this.maybeExpireStaleMarketStores();
+        }, Config.marketExpiryCleanupIntervalMs);
+
+        if (typeof this.marketExpiryCleanupTimer.unref === 'function') {
+            this.marketExpiryCleanupTimer.unref();
+        }
+
         if (Config.backgroundPartyEnabled !== false) {
             this.partyFormationTimer = setInterval(() => {
                 this.formBackgroundParties();
@@ -235,6 +246,10 @@ const PopulationService = {
         if (this.marketTownMigrationTimer) {
             clearInterval(this.marketTownMigrationTimer);
             this.marketTownMigrationTimer = null;
+        }
+        if (this.marketExpiryCleanupTimer) {
+            clearInterval(this.marketExpiryCleanupTimer);
+            this.marketExpiryCleanupTimer = null;
         }
         Director.stop();
         Metrics.stopEventLoopMonitor();
@@ -317,6 +332,29 @@ const PopulationService = {
         if (this.marketTownMigrationRunning || timestamp < this.nextMarketTownMigrationAt) return Promise.resolve([]);
         this.nextMarketTownMigrationAt = timestamp + Config.marketTownMigrationIntervalMs;
         return this.migrateLegacyMarketTowns();
+    },
+
+    expireStaleMarketStores(timestamp = Date.now()) {
+        if (this.marketExpiryCleanupRunning || Config.enabled === false) return Promise.resolve([]);
+        this.marketExpiryCleanupRunning = true;
+        return ColdMarketListingService.expireStaleMarketStores(Config.marketExpiryCleanupBatchSize, timestamp)
+            .then((expired) => {
+                if (expired.length) console.info('BotPopulation :: expired market stores closed=%d', expired.length);
+                return expired;
+            })
+            .catch((err) => {
+                utils.infoWarn('BotPopulation', 'expired market cleanup failed: %s', err.message);
+                return [];
+            })
+            .finally(() => {
+                this.marketExpiryCleanupRunning = false;
+            });
+    },
+
+    maybeExpireStaleMarketStores(timestamp = Date.now()) {
+        if (this.marketExpiryCleanupRunning || timestamp < this.nextMarketExpiryCleanupAt) return Promise.resolve([]);
+        this.nextMarketExpiryCleanupAt = timestamp + Config.marketExpiryCleanupIntervalMs;
+        return this.expireStaleMarketStores(timestamp);
     },
 
     recordHotTick(session) {
@@ -678,6 +716,7 @@ const PopulationService = {
                     );
                 }
                 this.resolving = false;
+                this.maybeExpireStaleMarketStores();
                 // The scheduler is known to run throughout normal operation;
                 // use its post-resolve edge as a reliable fallback for the
                 // bounded legacy-store transition timer.

--- a/src/GameServer/Bot/Population/PopulationService.js
+++ b/src/GameServer/Bot/Population/PopulationService.js
@@ -109,8 +109,11 @@ const PopulationService = {
     phasePolicyTimer: null,
     seedTimer: null,
     classProgressionMigrationTimer: null,
+    marketTownMigrationTimer: null,
+    nextMarketTownMigrationAt: 0,
     resolving: false,
     classProgressionMigrationRunning: false,
+    marketTownMigrationRunning: false,
     partyFormationRunning: false,
     phasePolicyRunning: false,
 
@@ -167,6 +170,14 @@ const PopulationService = {
             this.classProgressionMigrationTimer.unref();
         }
 
+        this.marketTownMigrationTimer = setInterval(() => {
+            this.maybeMigrateLegacyMarketTowns();
+        }, Config.marketTownMigrationIntervalMs);
+
+        if (typeof this.marketTownMigrationTimer.unref === 'function') {
+            this.marketTownMigrationTimer.unref();
+        }
+
         if (Config.backgroundPartyEnabled !== false) {
             this.partyFormationTimer = setInterval(() => {
                 this.formBackgroundParties();
@@ -221,6 +232,10 @@ const PopulationService = {
             clearInterval(this.classProgressionMigrationTimer);
             this.classProgressionMigrationTimer = null;
         }
+        if (this.marketTownMigrationTimer) {
+            clearInterval(this.marketTownMigrationTimer);
+            this.marketTownMigrationTimer = null;
+        }
         Director.stop();
         Metrics.stopEventLoopMonitor();
         this.started = false;
@@ -273,6 +288,35 @@ const PopulationService = {
             .finally(() => {
                 this.classProgressionMigrationRunning = false;
             });
+    },
+
+    migrateLegacyMarketTowns() {
+        // This migration is deliberately bounded and serialized. Do not gate
+        // it on `resolving`: both timers share a 10-second cadence, which can
+        // otherwise starve the transition forever while the resolver is live.
+        if (this.marketTownMigrationRunning || Config.enabled === false) return Promise.resolve([]);
+        this.marketTownMigrationRunning = true;
+        return ColdMarketListingService.migrateLegacyMarketTowns(Config.marketTownMigrationBatchSize)
+            .then((migrated) => {
+                const relocated = migrated.filter((entry) => entry.relocated).length;
+                if (migrated.length) {
+                    console.info('BotPopulation :: migrated market towns checked=%d relocated=%d', migrated.length, relocated);
+                }
+                return migrated;
+            })
+            .catch((err) => {
+                utils.infoWarn('BotPopulation', 'legacy market-town migration failed: %s', err.message);
+                return [];
+            })
+            .finally(() => {
+                this.marketTownMigrationRunning = false;
+            });
+    },
+
+    maybeMigrateLegacyMarketTowns(timestamp = Date.now()) {
+        if (this.marketTownMigrationRunning || timestamp < this.nextMarketTownMigrationAt) return Promise.resolve([]);
+        this.nextMarketTownMigrationAt = timestamp + Config.marketTownMigrationIntervalMs;
+        return this.migrateLegacyMarketTowns();
     },
 
     recordHotTick(session) {
@@ -634,6 +678,10 @@ const PopulationService = {
                     );
                 }
                 this.resolving = false;
+                // The scheduler is known to run throughout normal operation;
+                // use its post-resolve edge as a reliable fallback for the
+                // bounded legacy-store transition timer.
+                this.maybeMigrateLegacyMarketTowns();
             });
     },
 

--- a/tests/test_bot_cold_market_listing.js
+++ b/tests/test_bot_cold_market_listing.js
@@ -114,6 +114,16 @@ async function run() {
     assert.strictEqual(expiredResult.state.adena, 884, 'NPC payout should use the normal 50% sale price');
     assert(Number(expiredResult.state.stats.marketSellRetryAfter) > 62000, 'valuable unsold stock needs a later market retry');
 
+    const misplacedExpired = await ListingService.open(
+        { ...state, characterId: 90, name: 'MisplacedExpiredSeller' },
+        { now: 1000, durationMs: 60000 }
+    );
+    const misplacedExpiredResult = await ListingService.resolve({
+        ...misplacedExpired.state,
+        stats: { ...misplacedExpired.state.stats, marketStore: { ...misplacedExpired.state.stats.marketStore, town: 'Dion' } }
+    }, 62000);
+    assert.strictEqual(misplacedExpiredResult.closed, true, 'an expired store must close instead of being relocated to another market');
+
     assert.strictEqual(
         ListingService.marketStoreTitle([
             { name: 'Animal Bone', count: 20 },

--- a/tests/test_bot_cold_market_purchase.js
+++ b/tests/test_bot_cold_market_purchase.js
@@ -8,6 +8,7 @@ const World = invoke('GameServer/World/World');
 const GoalState = invoke('GameServer/Bot/Goals/GoalState');
 const ColdMarketService = invoke('GameServer/Bot/Economy/ColdMarketService');
 const BotLifeState = invoke('GameServer/Bot/Population/BotLifeState');
+const MarketOpportunity = invoke('GameServer/Bot/Economy/MarketOpportunity');
 
 DataCache.init();
 
@@ -18,7 +19,9 @@ const originals = {
     updateItemEquipState: Database.updateItemEquipState,
     setItem: Database.setItem,
     clearGoal: GoalState.clear,
-    user: World.user
+    user: World.user,
+    bestOffer: MarketOpportunity.bestOffer,
+    reserve: MarketOpportunity.reserve
 };
 
 const calls = [];
@@ -104,6 +107,19 @@ async function run() {
     assert.strictEqual(noOffer.purchased, false);
     assert.strictEqual(noOffer.state.activity, 'traveling', 'a buyer with no offer must return to farming instead of waiting in Giran');
     assert.strictEqual(noOffer.state.stats.travel.arrivalActivity, 'hunting');
+    assert(noOffer.state.stats.marketRetryAfter > Date.now(), 'a buyer with no offer must wait before retrying the same market trip');
+
+    MarketOpportunity.bestOffer = () => ({ selfId: 2, price: 1000, sourceType: 'cold_store', storeItem: { count: 1, price: 1000 } });
+    MarketOpportunity.reserve = () => false;
+    const changedOffer = await ColdMarketService.tryPurchase({
+        ...state,
+        characterId: 80,
+        stats: { ...state.stats, marketReturn: { loc: { locX: 100, locY: 200, locZ: -10 }, regionName: 'Field', spotId: 'field' } },
+        loc: { locX: 80000, locY: 150000, locZ: -3466 }
+    }, { type: 'buy_craft_material', target: { itemId: 2, itemName: 'Changed Offer' } });
+    assert.strictEqual(changedOffer.reason, 'offer_changed');
+    assert.strictEqual(changedOffer.state.activity, 'traveling', 'a stale offer must return the buyer to farming');
+    assert(changedOffer.state.stats.marketRetryAfter > Date.now(), 'a stale offer must also start the retry cooldown');
 
     const armorPurchase = await BotLifeState.applyMarketPurchase({
         ...state,
@@ -143,4 +159,6 @@ run().catch((err) => {
     Database.setItem = originals.setItem;
     GoalState.clear = originals.clearGoal;
     World.user = originals.user;
+    MarketOpportunity.bestOffer = originals.bestOffer;
+    MarketOpportunity.reserve = originals.reserve;
 });

--- a/tests/test_bot_goal_market_priority.js
+++ b/tests/test_bot_goal_market_priority.js
@@ -44,6 +44,24 @@ async function run() {
     NeedsEvaluator.evaluate = () => [{ type: 'progress_level', status: 'active', priority: 35, plan: { expectedBenefit: 'experience_and_sp' } }];
     const cleared = await GoalService.review({ characterId: 9, phase: 'cold' }, { now });
     assert.strictEqual(cleared.current.type, 'progress_level', 'an empty stale market goal must be replaced immediately');
+
+    const waitingForMarket = NeedsEvaluator.evaluate({
+        characterId: 10,
+        level: 30,
+        activity: 'hunting',
+        adena: 100000,
+        inventory: {},
+        vitals: { hp: 100, maxHp: 100, mp: 100, maxMp: 100 },
+        stats: {
+            marketRetryAfter: now + 1,
+            equipmentPlan: {
+                marketFallback: true,
+                next: { itemId: 1880 },
+                materials: [{ selfId: 1880, missing: 20 }]
+            }
+        }
+    }, { now, spot: { id: 'test_spot' } });
+    assert(!waitingForMarket.some((goal) => goal.type === 'buy_craft_material'), 'a failed material purchase must not immediately schedule another market trip');
     console.log('Bot market goal priority checks passed');
 }
 

--- a/tests/test_bot_market_town_routing.js
+++ b/tests/test_bot_market_town_routing.js
@@ -1,0 +1,237 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const DataCache = invoke('GameServer/DataCache');
+const GoalExecutor = invoke('GameServer/Bot/Goals/GoalExecutor');
+const ListingService = invoke('GameServer/Bot/Economy/ColdMarketListingService');
+const MerchantStoreConfigs = invoke('GameServer/Bot/MerchantStoreConfigs');
+const PopulationService = invoke('GameServer/Bot/Population/PopulationService');
+
+DataCache.init();
+
+const dWeapon = DataCache.items.find((item) => item?.etc?.rank === 'd' && item.template?.kind?.startsWith('Weapon.'));
+assert(dWeapon, 'datapack must contain a D-grade weapon for market routing coverage');
+const noGradeSaleItem = DataCache.items.find((item) => item?.template?.kind?.startsWith('Other.Material') && Number(item.template?.price) > 0);
+assert(noGradeSaleItem, 'datapack must contain a sellable no-grade material for local-market routing coverage');
+
+const state = {
+    characterId: 301,
+    name: 'DGradeSeller',
+    level: 25,
+    activity: 'hunting',
+    currentRegion: 'Gludio',
+    loc: { locX: -12736, locY: 122816, locZ: -3114 },
+    inventory: {
+        [dWeapon.selfId]: {
+            selfId: dWeapon.selfId,
+            name: dWeapon.template.name,
+            amount: 1,
+            kind: dWeapon.template.kind,
+            rank: 'd'
+        }
+    },
+    stats: {},
+    timing: {}
+};
+
+const travel = GoalExecutor.beginMarketTravel(state, {
+    type: 'sell_inventory',
+    plan: { expectedBenefit: 'market_sale_inventory' }
+}, 1000);
+
+assert.strictEqual(travel.stats.travel.townName, 'Gludio', 'D-grade sellers must use the Gludio market instead of Giran');
+assert.strictEqual(
+    ListingService.targetMarketTownName(state, [{ rank: 'd' }]),
+    'Gludio',
+    'existing D-grade listings must be rebalanced out of Giran too'
+);
+assert.strictEqual(
+    ListingService.targetMarketTownName(state, [{ selfId: dWeapon.selfId }]),
+    'Gludio',
+    'legacy store rows without a persisted rank must recover the grade from their item id'
+);
+assert(Number.isInteger(ListingService.MARKET_TOWN_ROUTING_VERSION) && ListingService.MARKET_TOWN_ROUTING_VERSION > 0, 'legacy market migration must be versioned and finite');
+const legacyStore = {
+    ...state,
+    phase: 'cold',
+    activity: 'merchant',
+    updatedAt: 1,
+    stats: { marketStore: { town: 'Giran', items: [{ rank: 'd', count: 1 }] } }
+};
+const currentStore = {
+    ...legacyStore,
+    characterId: 399,
+    updatedAt: 0,
+    stats: { marketStore: { ...legacyStore.stats.marketStore, marketTownRoutingVersion: ListingService.MARKET_TOWN_ROUTING_VERSION } }
+};
+assert.deepStrictEqual(
+    ListingService.legacyMarketTownCandidates([currentStore, legacyStore]).map((candidate) => candidate.characterId),
+    [legacyStore.characterId],
+    'only stores created before town routing are eligible for the transition migration'
+);
+const first = ListingService.chooseGludioDMarketStall(() => 0.1, []);
+assert(ListingService.isGludioDMarketStallLocation(first), 'Gludio D-grade listings must remain inside the captured trading square');
+const second = ListingService.chooseGludioDMarketStall(() => 0.1, [first]);
+const dx = second.locX - first.locX;
+const dy = second.locY - first.locY;
+assert(Math.sqrt(dx * dx + dy * dy) >= ListingService.GLUDIO_D_STALL_MIN_DISTANCE, 'Gludio D-grade stalls must not overlap');
+const dionState = {
+    ...state,
+    characterId: 399,
+    loc: { locX: 15600, locY: 143100, locZ: -2707 }
+};
+const dionTravel = GoalExecutor.beginMarketTravel(dionState, {
+    type: 'sell_inventory',
+    plan: { expectedBenefit: 'market_sale_inventory' }
+}, 1000);
+assert.strictEqual(dionTravel.stats.travel.townName, 'Dion', 'D-grade overflow must use the Dion market instead of overfilling Gludio');
+const dionStall = ListingService.chooseDionDMarketStall(() => 0.5, []);
+assert(ListingService.isDionDMarketStallLocation(dionStall), 'Dion D-grade listings must remain inside the captured trading square');
+
+const gludioStaticStalls = ListingService.staticMerchantStalls('Gludio', ListingService.isGludioDMarketStallLocation);
+assert.strictEqual(gludioStaticStalls.length, 4, 'all fixed Gludio merchants must reserve their market stalls');
+const gludioCandidateNearLysa = ListingService.chooseGludioDMarketStall(
+    (() => {
+        const values = [60 / 390, 970 / 1080];
+        return () => values.shift() ?? 0;
+    })(),
+    gludioStaticStalls
+);
+assert(Math.hypot(gludioCandidateNearLysa.locX - MerchantStoreConfigs.Lysa.locX, gludioCandidateNearLysa.locY - MerchantStoreConfigs.Lysa.locY) >= ListingService.GLUDIO_D_STALL_MIN_DISTANCE, 'dynamic Gludio stalls must keep their distance from fixed merchants');
+
+const noGradeState = {
+    ...state,
+    characterId: 302,
+    level: 10,
+    loc: { locX: -84200, locY: 244600, locZ: -3730 },
+    inventory: {
+        [noGradeSaleItem.selfId]: {
+            selfId: noGradeSaleItem.selfId,
+            name: noGradeSaleItem.template.name,
+            amount: 1,
+            kind: noGradeSaleItem.template.kind
+        }
+    }
+};
+const noGradeOverflowState = {
+    ...noGradeState,
+    characterId: 400,
+    level: 25,
+    loc: { locX: 16000, locY: 143500, locZ: -2800 }
+};
+assert.strictEqual(
+    ListingService.targetMarketTownName(noGradeOverflowState, [{ rank: 'none' }]),
+    'Giran',
+    'a level-appropriate no-grade-only listing must not be mistaken for D-grade overflow'
+);
+assert.strictEqual(
+    ListingService.targetMarketTownName({
+        ...noGradeOverflowState,
+        stats: { marketReturn: { loc: { locX: -84200, locY: 244600, locZ: -3730 } } }
+    }, [{ rank: 'none' }]),
+    'Talking Island',
+    'legacy no-grade listings must use their departure point to return to the local starter market'
+);
+assert.strictEqual(
+    ListingService.targetMarketTownName(noGradeState, [{ rank: 'none' }]),
+    'Talking Island',
+    'nearby no-grade sellers must use the captured Talking Island market'
+);
+const talkingIslandStall = ListingService.chooseTalkingIslandNoGradeStall(() => 0.5, []);
+assert(ListingService.isTalkingIslandNoGradeStallLocation(talkingIslandStall), 'Talking Island no-grade listings must remain inside the captured trading square');
+assert.strictEqual(
+    ListingService.staticMerchantStalls('Talking Island', ListingService.isTalkingIslandNoGradeStallLocation).length,
+    4,
+    'fixed Talking Island merchants must reserve their market stalls'
+);
+
+const elvenState = {
+    ...noGradeState,
+    characterId: 303,
+    loc: { locX: 46600, locY: 50000, locZ: -3060 }
+};
+assert.strictEqual(
+    ListingService.targetMarketTownName(elvenState, [{ rank: 'none' }]),
+    'Elven Village',
+    'nearby no-grade sellers must use the captured Elven Village market'
+);
+const elvenStall = ListingService.chooseElvenVillageNoGradeStall(() => 0.5, []);
+assert(ListingService.isElvenVillageNoGradeStallLocation(elvenStall), 'Elven Village no-grade listings must remain inside the captured trading square');
+
+const darkElvenState = {
+    ...noGradeState,
+    characterId: 304,
+    loc: { locX: 12700, locY: 16600, locZ: -4585 }
+};
+assert.strictEqual(
+    ListingService.targetMarketTownName(darkElvenState, [{ rank: 'none' }]),
+    'Dark Elven Village',
+    'nearby no-grade sellers must use the captured Dark Elven Village market'
+);
+const darkElvenStall = ListingService.chooseDarkElvenVillageNoGradeStall(() => 0.5, []);
+assert(ListingService.isDarkElvenVillageNoGradeStallLocation(darkElvenStall), 'Dark Elven Village no-grade listings must remain inside the captured trading square');
+
+const orcState = {
+    ...noGradeState,
+    characterId: 305,
+    loc: { locX: -44600, locY: -112400, locZ: -240 }
+};
+assert.strictEqual(
+    ListingService.targetMarketTownName(orcState, [{ rank: 'none' }]),
+    'Orc Village',
+    'nearby no-grade sellers must use the captured Orc Village market'
+);
+const orcTravel = GoalExecutor.beginMarketTravel(orcState, {
+    type: 'sell_inventory',
+    plan: { expectedBenefit: 'market_sale_inventory' }
+}, 1000);
+assert.strictEqual(orcTravel.stats.travel.townName, 'Orc Village', 'Orc Village sellers must travel to their local market instead of falling back to Giran');
+const orcStall = ListingService.chooseOrcVillageNoGradeStall(() => 0.5, []);
+assert(ListingService.isOrcVillageNoGradeStallLocation(orcStall), 'Orc Village no-grade listings must remain inside the captured trading square');
+
+const dwarvenState = {
+    ...noGradeState,
+    characterId: 306,
+    loc: { locX: 115440, locY: -178580, locZ: -920 }
+};
+assert.strictEqual(
+    ListingService.targetMarketTownName(dwarvenState, [{ rank: 'none' }]),
+    'Dwarven Village',
+    'nearby no-grade sellers must use the captured Dwarven Village market'
+);
+const dwarvenTravel = GoalExecutor.beginMarketTravel(dwarvenState, {
+    type: 'sell_inventory',
+    plan: { expectedBenefit: 'market_sale_inventory' }
+}, 1000);
+assert.strictEqual(dwarvenTravel.stats.travel.townName, 'Dwarven Village', 'Dwarven Village sellers must travel to their local market instead of falling back to Giran');
+const dwarvenStall = ListingService.chooseDwarvenVillageNoGradeStall(() => 0.5, []);
+assert(ListingService.isDwarvenVillageNoGradeStallLocation(dwarvenStall), 'Dwarven Village no-grade listings must remain inside the captured trading square');
+
+const originalMigrateLegacyMarketTowns = PopulationService.migrateLegacyMarketTowns;
+const originalMigrationRunning = PopulationService.marketTownMigrationRunning;
+const originalNextMigrationAt = PopulationService.nextMarketTownMigrationAt;
+let migrationCalls = 0;
+PopulationService.migrateLegacyMarketTowns = () => {
+    migrationCalls++;
+    return Promise.resolve([]);
+};
+PopulationService.marketTownMigrationRunning = false;
+PopulationService.nextMarketTownMigrationAt = 0;
+Promise.resolve()
+    .then(() => PopulationService.maybeMigrateLegacyMarketTowns(1000))
+    .then(() => PopulationService.maybeMigrateLegacyMarketTowns(1001))
+    .then(() => PopulationService.maybeMigrateLegacyMarketTowns(11000))
+    .then(() => {
+        assert.strictEqual(migrationCalls, 2, 'the post-resolve migration fallback must run initially and then respect its cadence');
+        console.log('Bot market town routing checks passed');
+    })
+    .catch((err) => {
+        console.error(err);
+        process.exitCode = 1;
+    })
+    .finally(() => {
+        PopulationService.migrateLegacyMarketTowns = originalMigrateLegacyMarketTowns;
+        PopulationService.marketTownMigrationRunning = originalMigrationRunning;
+        PopulationService.nextMarketTownMigrationAt = originalNextMigrationAt;
+    });

--- a/tests/test_bot_market_town_routing.js
+++ b/tests/test_bot_market_town_routing.js
@@ -211,19 +211,33 @@ assert(ListingService.isDwarvenVillageNoGradeStallLocation(dwarvenStall), 'Dwarv
 const originalMigrateLegacyMarketTowns = PopulationService.migrateLegacyMarketTowns;
 const originalMigrationRunning = PopulationService.marketTownMigrationRunning;
 const originalNextMigrationAt = PopulationService.nextMarketTownMigrationAt;
+const originalExpireStaleMarketStores = PopulationService.expireStaleMarketStores;
+const originalExpiryRunning = PopulationService.marketExpiryCleanupRunning;
+const originalNextExpiryAt = PopulationService.nextMarketExpiryCleanupAt;
 let migrationCalls = 0;
+let expiryCalls = 0;
 PopulationService.migrateLegacyMarketTowns = () => {
     migrationCalls++;
     return Promise.resolve([]);
 };
 PopulationService.marketTownMigrationRunning = false;
 PopulationService.nextMarketTownMigrationAt = 0;
+PopulationService.expireStaleMarketStores = () => {
+    expiryCalls++;
+    return Promise.resolve([]);
+};
+PopulationService.marketExpiryCleanupRunning = false;
+PopulationService.nextMarketExpiryCleanupAt = 0;
 Promise.resolve()
     .then(() => PopulationService.maybeMigrateLegacyMarketTowns(1000))
     .then(() => PopulationService.maybeMigrateLegacyMarketTowns(1001))
     .then(() => PopulationService.maybeMigrateLegacyMarketTowns(11000))
+    .then(() => PopulationService.maybeExpireStaleMarketStores(1000))
+    .then(() => PopulationService.maybeExpireStaleMarketStores(1001))
+    .then(() => PopulationService.maybeExpireStaleMarketStores(11000))
     .then(() => {
         assert.strictEqual(migrationCalls, 2, 'the post-resolve migration fallback must run initially and then respect its cadence');
+        assert.strictEqual(expiryCalls, 2, 'the post-resolve expiry cleanup must run initially and then respect its cadence');
         console.log('Bot market town routing checks passed');
     })
     .catch((err) => {
@@ -234,4 +248,7 @@ Promise.resolve()
         PopulationService.migrateLegacyMarketTowns = originalMigrateLegacyMarketTowns;
         PopulationService.marketTownMigrationRunning = originalMigrationRunning;
         PopulationService.nextMarketTownMigrationAt = originalNextMigrationAt;
+        PopulationService.expireStaleMarketStores = originalExpireStaleMarketStores;
+        PopulationService.marketExpiryCleanupRunning = originalExpiryRunning;
+        PopulationService.nextMarketExpiryCleanupAt = originalNextExpiryAt;
     });


### PR DESCRIPTION
## What changed

Bot trading is now distributed across Giran, Dion, Gludio, and the starter towns instead of concentrating every seller in one place. The market system also keeps town placement up to date, closes expired private stores, and prevents bots from repeating empty material-buying trips.

## Why

Long-running populations accumulated outdated store locations and expired listings, which made trade plazas crowded and left too many bots permanently in merchant mode.

## Player impact

Markets should feel more local and readable, with fewer stacked sellers and less clutter. Bots return to hunting after an unsuccessful material purchase and expired stalls now clear out automatically.

## Validation

- Full automated test suite
- Market routing, cold listing, and market purchase regression checks
- Syntax and diff checks