### PR TITLE
Migrate runtime persistence to SQLite and add hot-bot load testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ Clean C4 client protocol 656
 
 You will need:
 
-- Node.js LTS
-- Docker, unless you run MariaDB yourself
+- Node.js 22.5+ (the bundled SQLite driver is used at runtime)
 - A [Lineage II C4 client](https://drive.google.com/file/d/1u0nW3m9c6Hql8sR9POQAcvglxIno23lv/view?usp=sharing) using protocol 656
 
 ## Quick Start
@@ -118,15 +117,23 @@ The launcher keeps the latest server session log at `tmp/logs/latest-server.log`
 Press `Start` in the launcher to run the normal server bootstrap. That start action will:
 
 - install Node dependencies if `node_modules` is missing;
-- create or start a local `nodel2-mariadb` Docker container when the configured database host is `127.0.0.1` or `localhost`;
-- import `database/sql/database.sql` on first boot if database `nodel2` does not exist;
+- create the embedded SQLite database on first boot;
 - start the auth server on `2106`, the game server on `7777`, and the world observer on `8088`.
 
-If you run MariaDB yourself, set:
+The server has no Docker or database-server prerequisite. The default world file is `tmp/nodel2.sqlite` and is configured in `config/default.ini`:
+
+```ini
+[Database]
+path = tmp/nodel2.sqlite
+```
+
+For an existing MariaDB world, make a copy through the one-time importer before switching over. It writes a new file, validates foreign keys, and never overwrites an existing SQLite world:
 
 ```bash
-L2NODE_SKIP_DOCKER=1 npm start
+node scripts/migrate-mariadb-to-sqlite.js --source-config=path/to/old.ini --target=tmp/nodel2.sqlite
 ```
+
+The import command alone may need `mariadb` installed temporarily (`npm install --no-save mariadb`); the running server does not use that package.
 
 The old direct server command still works:
 
@@ -140,7 +147,7 @@ Use it when dependencies and the database are already prepared, and you want no 
 
 Committed defaults live in `config/default.ini`.
 
-Private local overrides go in ignored `config/local.ini`. This is where API keys and machine-specific database settings belong.
+Private local overrides go in ignored `config/local.ini`. This is where API keys and a machine-specific SQLite path belong.
 
 Example:
 
@@ -152,8 +159,6 @@ model = google/gemini-2.5-flash-lite
 debug = true
 ```
 
-If you use your own database instead of the local Docker container, override the `Database` section there as well.
-
 OpenRouter can also read the key/model from environment variables:
 
 ```bash
@@ -162,9 +167,6 @@ OPENROUTER_API_KEY=sk-or-v1-your-key-here npm start
 
 Useful startup variables:
 
-- `L2NODE_SKIP_DOCKER=1` - skip Docker bootstrap and use the configured database.
-- `L2NODE_DB_CONTAINER=some-name` - override the Docker container name.
-- `L2NODE_DB_IMAGE=mariadb:10.6` - override the MariaDB image.
 - `BOT_STATUS_LOGS=0` - disable periodic bot status log lines.
 
 ## In-Game Commands

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For an existing MariaDB world, make a copy through the one-time importer before 
 node scripts/migrate-mariadb-to-sqlite.js --source-config=path/to/old.ini --target=tmp/nodel2.sqlite
 ```
 
-The import command alone may need `mariadb` installed temporarily (`npm install --no-save mariadb`); the running server does not use that package.
+The import command alone may need `mariadb` installed temporarily (`npm install --no-save mariadb`); it is not a project dependency and the running server never uses it.
 
 The old direct server command still works:
 
@@ -168,6 +168,16 @@ OPENROUTER_API_KEY=sk-or-v1-your-key-here npm start
 Useful startup variables:
 
 - `BOT_STATUS_LOGS=0` - disable periodic bot status log lines.
+
+## Hot Bot Load Test
+
+The isolated load runner provisions real bot characters in a temporary SQLite world, drives the normal hot bot AI and persistence paths, and writes a JSON summary under `tmp/hot-load-tests/`. It does not change the normal server database or its population.
+
+```bash
+node scripts/hot-bot-load-test.js --counts=100,200,300 --duration=60 --tick=1000 --spread=100
+```
+
+The runner starts each scenario with its own database and disabled network ports. It reports AI tick duration, event-loop lag, SQLite queue activity, database failures, and memory use. Use it to compare changes under the same workload; it does not simulate hundreds of connected game clients or the full cold bot scheduler.
 
 ## In-Game Commands
 

--- a/config/default.ini
+++ b/config/default.ini
@@ -1,9 +1,5 @@
 [Database]
-hostname = 127.0.0.1
-port = 3306
-user = root
-password = alosi!$53
-databaseName = nodel2
+path = tmp/nodel2.sqlite
 
 [AuthServer]
 hostname = 0.0.0.0

--- a/database/install.bat
+++ b/database/install.bat
@@ -1,9 +1,2 @@
 @echo off
-
-set PATH=%PATH%;%PROGRAMFILES%\MariaDB 10.6\bin
-
-set HOST="127.0.0.1"
-set USER="root"
-set PASS="alosi!$53"
-
-MYSQL -h %HOST% -u %USER% --password=%PASS% < "sql/database.sql"
+echo SQLite is embedded. The server creates the configured database file on first start.

--- a/database/install.sh
+++ b/database/install.sh
@@ -1,7 +1,4 @@
-#!/bin/bash
+#!/bin/sh
+set -eu
 
-HOST='127.0.0.1'
-USER='root'
-PASS='alosi!$53'
-
-MYSQL -h $HOST -u $USER --password=$PASS < 'sql/database.sql'
+echo "SQLite is embedded. The server creates the configured database file on first start."

--- a/database/sql/sqlite.sql
+++ b/database/sql/sqlite.sql
@@ -1,0 +1,243 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version INTEGER PRIMARY KEY,
+    appliedAt INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS accounts (
+    username TEXT PRIMARY KEY COLLATE NOCASE,
+    password TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS characters (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL COLLATE NOCASE REFERENCES accounts(username) ON DELETE CASCADE,
+    name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+    title TEXT NOT NULL DEFAULT '',
+    classId INTEGER NOT NULL,
+    race INTEGER NOT NULL,
+    level INTEGER NOT NULL DEFAULT 1,
+    hp REAL NOT NULL DEFAULT 50,
+    maxHp REAL NOT NULL,
+    mp REAL NOT NULL DEFAULT 25,
+    maxMp REAL NOT NULL,
+    cp REAL,
+    effects TEXT,
+    exp INTEGER NOT NULL DEFAULT 0,
+    sp INTEGER NOT NULL DEFAULT 0,
+    pk INTEGER NOT NULL DEFAULT 0,
+    pvp INTEGER NOT NULL DEFAULT 0,
+    sex INTEGER NOT NULL,
+    face INTEGER NOT NULL,
+    hair INTEGER NOT NULL,
+    hairColor INTEGER NOT NULL,
+    karma INTEGER NOT NULL DEFAULT 0,
+    evalScore INTEGER NOT NULL DEFAULT 0,
+    recRemain INTEGER NOT NULL DEFAULT 0,
+    clanId INTEGER NOT NULL DEFAULT 0,
+    clanPrivileges INTEGER NOT NULL DEFAULT 0,
+    clanJoinExpiryTime INTEGER NOT NULL DEFAULT 0,
+    clanCreateExpiryTime INTEGER NOT NULL DEFAULT 0,
+    isGM INTEGER NOT NULL DEFAULT 0,
+    isOnline INTEGER NOT NULL DEFAULT 0,
+    isActive INTEGER NOT NULL DEFAULT 1,
+    locX INTEGER NOT NULL,
+    locY INTEGER NOT NULL,
+    locZ INTEGER NOT NULL,
+    head INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS characters_username ON characters(username);
+CREATE INDEX IF NOT EXISTS characters_clanId ON characters(clanId);
+
+CREATE TABLE IF NOT EXISTS clans (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+    level INTEGER NOT NULL DEFAULT 0,
+    leaderId INTEGER NOT NULL,
+    crestId INTEGER NOT NULL DEFAULT 0,
+    crestLargeId INTEGER NOT NULL DEFAULT 0,
+    allyId INTEGER NOT NULL DEFAULT 0,
+    allyName TEXT NOT NULL DEFAULT '',
+    allyCrestId INTEGER NOT NULL DEFAULT 0,
+    dissolvingExpiryTime INTEGER NOT NULL DEFAULT 0,
+    charPenaltyExpiryTime INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS clans_leaderId ON clans(leaderId);
+
+CREATE TABLE IF NOT EXISTS clan_crests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    clanId INTEGER NOT NULL REFERENCES clans(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL DEFAULT 'pledge',
+    data BLOB NOT NULL,
+    createdAt INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS clan_crests_clanId ON clan_crests(clanId);
+
+CREATE TABLE IF NOT EXISTS items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    selfId INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    amount INTEGER NOT NULL DEFAULT 1 CHECK(amount >= 0),
+    equipped INTEGER NOT NULL DEFAULT 0,
+    slot INTEGER NOT NULL DEFAULT 0,
+    petData TEXT,
+    characterId INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS items_characterId ON items(characterId);
+CREATE INDEX IF NOT EXISTS items_characterId_selfId ON items(characterId, selfId);
+
+CREATE TABLE IF NOT EXISTS character_recipes (
+    characterId INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    recipeId INTEGER NOT NULL,
+    type TEXT NOT NULL CHECK(type IN ('dwarven', 'common')),
+    PRIMARY KEY(characterId, recipeId, type)
+);
+
+CREATE TABLE IF NOT EXISTS character_quests (
+    characterId INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    questId INTEGER NOT NULL,
+    state TEXT NOT NULL DEFAULT 'created' CHECK(state IN ('created', 'started', 'completed')),
+    variables TEXT,
+    PRIMARY KEY(characterId, questId)
+);
+
+CREATE TABLE IF NOT EXISTS warehouse_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    selfId INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    amount INTEGER NOT NULL DEFAULT 1 CHECK(amount >= 0),
+    petData TEXT,
+    characterId INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS warehouse_items_characterId ON warehouse_items(characterId);
+CREATE INDEX IF NOT EXISTS warehouse_items_characterId_selfId ON warehouse_items(characterId, selfId);
+
+CREATE TABLE IF NOT EXISTS skills (
+    selfId INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    passive INTEGER NOT NULL,
+    level INTEGER NOT NULL,
+    characterId INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    PRIMARY KEY(characterId, selfId)
+);
+
+CREATE TABLE IF NOT EXISTS shortcuts (
+    id INTEGER NOT NULL,
+    kind INTEGER NOT NULL,
+    slot INTEGER NOT NULL,
+    unknown INTEGER NOT NULL,
+    characterId INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    PRIMARY KEY(characterId, slot)
+);
+CREATE INDEX IF NOT EXISTS shortcuts_characterId_kind_id ON shortcuts(characterId, kind, id);
+
+CREATE TABLE IF NOT EXISTS macros (
+    characterId INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    id INTEGER NOT NULL,
+    icon INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    descr TEXT NOT NULL,
+    acronym TEXT NOT NULL,
+    commands TEXT NOT NULL,
+    PRIMARY KEY(characterId, id)
+);
+
+CREATE TABLE IF NOT EXISTS bot_life_state (
+    characterId INTEGER PRIMARY KEY REFERENCES characters(id) ON DELETE CASCADE,
+    accountName TEXT NOT NULL DEFAULT '',
+    characterName TEXT NOT NULL DEFAULT '',
+    level INTEGER NOT NULL DEFAULT 1,
+    exp INTEGER NOT NULL DEFAULT 0,
+    sp INTEGER NOT NULL DEFAULT 0,
+    adena INTEGER NOT NULL DEFAULT 0,
+    homeRegion TEXT,
+    currentRegion TEXT,
+    spotId TEXT,
+    activity TEXT NOT NULL DEFAULT 'hunting',
+    phase TEXT NOT NULL DEFAULT 'cold',
+    activityStartedAt INTEGER,
+    nextResolveAt INTEGER,
+    lastResolvedAt INTEGER,
+    lastHotAt INTEGER,
+    locX INTEGER NOT NULL DEFAULT 0,
+    locY INTEGER NOT NULL DEFAULT 0,
+    locZ INTEGER NOT NULL DEFAULT 0,
+    hp INTEGER NOT NULL DEFAULT 0,
+    maxHp INTEGER NOT NULL DEFAULT 0,
+    mp INTEGER NOT NULL DEFAULT 0,
+    maxMp INTEGER NOT NULL DEFAULT 0,
+    targetLevelBand TEXT,
+    deathCount INTEGER NOT NULL DEFAULT 0,
+    partyId TEXT,
+    inventorySummary TEXT,
+    statsJson TEXT,
+    updatedAt INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS bot_life_state_phase_nextResolveAt ON bot_life_state(phase, nextResolveAt);
+CREATE INDEX IF NOT EXISTS bot_life_state_phase_partyId ON bot_life_state(phase, partyId);
+CREATE INDEX IF NOT EXISTS bot_life_state_accountName ON bot_life_state(accountName);
+CREATE INDEX IF NOT EXISTS bot_life_state_characterName ON bot_life_state(characterName COLLATE NOCASE);
+
+CREATE TABLE IF NOT EXISTS bot_goal_state (
+    characterId INTEGER PRIMARY KEY REFERENCES characters(id) ON DELETE CASCADE,
+    goalJson TEXT,
+    updatedAt INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS bot_social_memory (
+    playerId INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    botId INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    playerName TEXT NOT NULL DEFAULT '',
+    botName TEXT NOT NULL DEFAULT '',
+    trust INTEGER NOT NULL DEFAULT 0,
+    familiarity INTEGER NOT NULL DEFAULT 0,
+    lastGroupedAt INTEGER,
+    groupRuns INTEGER NOT NULL DEFAULT 0,
+    wipesTogether INTEGER NOT NULL DEFAULT 0,
+    helpedInCombat INTEGER NOT NULL DEFAULT 0,
+    gaveUsefulLoot INTEGER NOT NULL DEFAULT 0,
+    ignoredLootRequests INTEGER NOT NULL DEFAULT 0,
+    tradesCompleted INTEGER NOT NULL DEFAULT 0,
+    insults INTEGER NOT NULL DEFAULT 0,
+    recentlyAbandonedAt INTEGER,
+    notes TEXT,
+    updatedAt INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY(playerId, botId)
+);
+
+CREATE TABLE IF NOT EXISTS bot_life_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    characterId INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    eventType TEXT NOT NULL,
+    summary TEXT NOT NULL DEFAULT '',
+    weight INTEGER NOT NULL DEFAULT 1,
+    createdAt INTEGER NOT NULL DEFAULT 0,
+    metaJson TEXT
+);
+CREATE INDEX IF NOT EXISTS bot_life_events_character_weight_created ON bot_life_events(characterId, weight DESC, createdAt DESC);
+CREATE INDEX IF NOT EXISTS bot_life_events_recent ON bot_life_events(createdAt DESC, weight DESC);
+
+CREATE TABLE IF NOT EXISTS bot_background_parties (
+    partyId TEXT PRIMARY KEY,
+    leaderId INTEGER NOT NULL DEFAULT 0,
+    memberIdsJson TEXT,
+    spotId TEXT,
+    startedAt INTEGER NOT NULL DEFAULT 0,
+    nextResolveAt INTEGER,
+    cohesion REAL NOT NULL DEFAULT 0.65,
+    risk REAL NOT NULL DEFAULT 0.25,
+    status TEXT NOT NULL DEFAULT 'active',
+    roleCoverageJson TEXT,
+    statsJson TEXT,
+    updatedAt INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS bot_background_parties_status_nextResolveAt ON bot_background_parties(status, nextResolveAt);
+CREATE INDEX IF NOT EXISTS bot_background_parties_spotId ON bot_background_parties(spotId);
+
+INSERT OR IGNORE INTO sqlite_sequence(name, seq) VALUES ('characters', 1999999);
+UPDATE sqlite_sequence SET seq = MAX(seq, 1999999) WHERE name = 'characters';
+INSERT OR IGNORE INTO sqlite_sequence(name, seq) VALUES ('clans', 5999999);
+UPDATE sqlite_sequence SET seq = MAX(seq, 5999999) WHERE name = 'clans';
+INSERT OR IGNORE INTO sqlite_sequence(name, seq) VALUES ('items', 3999999);
+UPDATE sqlite_sequence SET seq = MAX(seq, 3999999) WHERE name = 'items';

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "version": "0.0.7",
     "description": "L2 C4 protocol server emulator in NodeJS",
     "author": "Dennis Koluris",
+    "engines": {
+        "node": ">=22.5.0"
+    },
     "scripts": {
         "start": "node scripts/start.js",
         "NodeL2": "node --openssl-legacy-provider src/NodeL2",
@@ -16,8 +19,6 @@
         "explicit-json": "^1.0.5",
         "js-ini": "^1.6.0",
         "jsonschema": "^1.4.1",
-        "like-sql": "^0.1.1",
-        "mariadb": "^3.1.1",
         "objcrush": "^1.0.1",
         "random-point-in-shape": "^1.0.0",
         "rsa-raw": "^1.0.3"

--- a/scripts/hot-bot-load-test.js
+++ b/scripts/hot-bot-load-test.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+const outputDir = path.join(rootDir, 'tmp', 'hot-load-tests');
+const MAX_DIAGNOSTIC_OUTPUT_BYTES = 1024 * 1024;
+
+function appendTail(value, chunk) {
+    const next = `${value}${chunk}`;
+    return next.length > MAX_DIAGNOSTIC_OUTPUT_BYTES ? next.slice(-MAX_DIAGNOSTIC_OUTPUT_BYTES) : next;
+}
+
+function parseArguments(argv) {
+    const args = Object.fromEntries(argv
+        .filter((value) => value.startsWith('--'))
+        .map((value) => {
+            const [key, raw = 'true'] = value.slice(2).split('=', 2);
+            return [key, raw];
+        }));
+    const counts = String(args.counts || '50,100,200,300').split(',')
+        .map(Number).filter((value) => Number.isInteger(value) && value > 0 && value <= 500);
+    if (!counts.length) throw new Error('Use --counts=50,100,200,300 with values from 1 to 500.');
+    const durationSeconds = Number(args.duration || 60);
+    if (!Number.isFinite(durationSeconds) || durationSeconds < 5 || durationSeconds > 1800) {
+        throw new Error('Use --duration=<seconds> from 5 to 1800.');
+    }
+    const tickMs = Number(args.tick || 1000);
+    if (!Number.isFinite(tickMs) || tickMs < 250 || tickMs > 10000) {
+        throw new Error('Use --tick=<milliseconds> from 250 to 10000.');
+    }
+    const spreadMs = Number(args.spread || 100);
+    if (!Number.isFinite(spreadMs) || spreadMs < 25 || spreadMs > tickMs) {
+        throw new Error('Use --spread=<milliseconds> from 25 to the tick interval.');
+    }
+    return { counts, durationMs: Math.round(durationSeconds * 1000), tickMs, spreadMs };
+}
+
+function writeConfig(runId) {
+    fs.mkdirSync(outputDir, { recursive: true });
+    const databasePath = path.join(outputDir, `${runId}.sqlite`);
+    const configPath = path.join(outputDir, `${runId}.ini`);
+    fs.writeFileSync(configPath, [
+        '[Database]',
+        `path = ${path.relative(rootDir, databasePath).replace(/\\/g, '/')}`,
+        '',
+        '[AuthServer]',
+        'port = 0',
+        '',
+        '[GameServer]',
+        'port = 0',
+        '',
+        '[WorldObserver]',
+        'enabled = false',
+        '',
+        '[BotPopulation]',
+        'enabled = false'
+    ].join('\n'), 'utf8');
+    return { configPath, databasePath };
+}
+
+function runScenario(count, settings, sequence) {
+    const runId = `hot-${count}-${Date.now()}-${sequence}`;
+    const files = writeConfig(runId);
+    const args = ['--openssl-legacy-provider', 'src/NodeL2'];
+    const environment = {
+        ...process.env,
+        L2NODE_CONFIG_FILE: files.configPath,
+        L2NODE_HOT_LOAD_TEST: '1',
+        L2NODE_HOT_LOAD_COUNT: String(count),
+        L2NODE_HOT_LOAD_DURATION_MS: String(settings.durationMs),
+        L2NODE_HOT_LOAD_TICK_MS: String(settings.tickMs),
+        L2NODE_HOT_LOAD_SPREAD_MS: String(settings.spreadMs),
+        L2NODE_HOT_LOAD_PROVISION_TIMEOUT_MS: String(Math.max(120000, count * 700)),
+        BOT_POPULATION_ENABLED: '0',
+        BOT_STATUS_LOGS: '0',
+        NODEL2_DEV_CONSOLE: '0'
+    };
+
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, args, { cwd: rootDir, env: environment, stdio: ['ignore', 'pipe', 'pipe'] });
+        let output = '';
+        let errorOutput = '';
+        let stdoutBuffer = '';
+        let result = null;
+        let parseError = null;
+        const consumeLine = (line) => {
+            if (line.startsWith('HotLoad') || line.startsWith('HOT_LOAD_RESULT')) {
+                process.stdout.write(`${line}\n`);
+            }
+            if (!line.startsWith('HOT_LOAD_RESULT ')) return;
+            try {
+                result = JSON.parse(line.slice('HOT_LOAD_RESULT '.length));
+            } catch (error) {
+                parseError = error;
+            }
+        };
+        child.stdout.on('data', (chunk) => {
+            const text = String(chunk);
+            output = appendTail(output, text);
+            stdoutBuffer += text;
+            let newlineIndex;
+            while ((newlineIndex = stdoutBuffer.indexOf('\n')) !== -1) {
+                consumeLine(stdoutBuffer.slice(0, newlineIndex).replace(/\r$/, ''));
+                stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+            }
+        });
+        child.stderr.on('data', (chunk) => {
+            errorOutput = appendTail(errorOutput, String(chunk));
+            process.stderr.write(chunk);
+        });
+        child.on('error', reject);
+        child.on('exit', (code) => {
+            if (stdoutBuffer) consumeLine(stdoutBuffer.replace(/\r$/, ''));
+            if (result) {
+                resolve({ ...result, files, exitCode: code || 0 });
+                return;
+            }
+            if (parseError) {
+                reject(new Error(`load scenario ${count} emitted invalid result JSON: ${parseError.message}`));
+                return;
+            }
+            reject(new Error(`load scenario ${count} exited ${code}: ${(errorOutput || output).slice(-1200)}`));
+        });
+    });
+}
+
+async function main() {
+    const settings = parseArguments(process.argv.slice(2));
+    const results = [];
+    for (const [index, count] of settings.counts.entries()) {
+        results.push(await runScenario(count, settings, index));
+    }
+    const summaryPath = path.join(outputDir, `summary-${Date.now()}.json`);
+    fs.writeFileSync(summaryPath, `${JSON.stringify({ settings, results }, null, 2)}\n`, 'utf8');
+    process.stdout.write(`HOT_LOAD_SUMMARY ${JSON.stringify({ summaryPath, results })}\n`);
+    if (results.some((result) => !result.ok)) process.exitCode = 1;
+}
+
+if (require.main === module) {
+    main().catch((error) => {
+        process.stderr.write(`Hot load test failed: ${error.stack || error}\n`);
+        process.exitCode = 1;
+    });
+}
+
+module.exports = { parseArguments, writeConfig, appendTail };

--- a/scripts/migrate-mariadb-to-sqlite.js
+++ b/scripts/migrate-mariadb-to-sqlite.js
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+// One-time data migration helper. The server itself has no MariaDB runtime
+// dependency; this command only needs the old driver while importing a world.
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { DatabaseSync } = require('node:sqlite');
+
+const rootDir = path.resolve(__dirname, '..');
+const TABLE_ORDER = [
+    'accounts', 'characters', 'clans', 'clan_crests', 'items',
+    'character_recipes', 'character_quests', 'warehouse_items', 'skills',
+    'shortcuts', 'macros', 'bot_life_state', 'bot_goal_state',
+    'bot_social_memory', 'bot_life_events', 'bot_background_parties'
+];
+const SEQUENCE_TABLES = ['characters', 'clans', 'clan_crests', 'items', 'warehouse_items', 'bot_life_events'];
+
+function parseIni(raw = '') {
+    const config = {};
+    let section = config;
+    raw.split(/\r?\n/).forEach((line) => {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith(';') || trimmed.startsWith('#')) return;
+        const match = trimmed.match(/^\[([^\]]+)\]$/);
+        if (match) {
+            section = config[match[1]] = config[match[1]] || {};
+            return;
+        }
+        const separator = trimmed.indexOf('=');
+        if (separator < 0) return;
+        section[trimmed.slice(0, separator).trim()] = trimmed.slice(separator + 1).trim();
+    });
+    return config;
+}
+
+function argumentsMap(argv) {
+    return argv.reduce((result, value) => {
+        const match = value.match(/^--([^=]+)(?:=(.*))?$/);
+        if (match) result[match[1]] = match[2] ?? true;
+        return result;
+    }, {});
+}
+
+function configuredSqlitePath() {
+    const configPath = path.join(rootDir, 'config', 'default.ini');
+    const config = parseIni(fs.readFileSync(configPath, 'utf8'));
+    return path.resolve(rootDir, config.Database?.path || 'tmp/nodel2.sqlite');
+}
+
+function sourceSettings(args) {
+    let config = {};
+    if (args['source-config']) {
+        config = parseIni(fs.readFileSync(path.resolve(rootDir, args['source-config']), 'utf8')).Database || {};
+    } else if (args['legacy-default-from-git']) {
+        // Useful only while upgrading an existing checkout that still has the
+        // MariaDB config in HEAD. It never writes those credentials to disk.
+        config = parseIni(execFileSync('git', ['show', 'HEAD:config/default.ini'], { cwd: rootDir, encoding: 'utf8' })).Database || {};
+    }
+    const setting = (name, fallback) => args[`source-${name}`] || process.env[`L2NODE_LEGACY_DB_${name.toUpperCase()}`] || fallback;
+    return {
+        host: setting('host', config.hostname || config.host),
+        port: Number(setting('port', config.port || 3306)),
+        user: setting('user', config.user),
+        password: setting('password', config.password),
+        database: setting('database', config.databaseName || config.database)
+    };
+}
+
+function requireMariaDb() {
+    try {
+        return require('mariadb');
+    } catch (_) {
+        throw new Error('Legacy import needs the MariaDB driver once. Run "npm install --no-save mariadb" and repeat this command. The game server does not use it.');
+    }
+}
+
+function validateSettings(settings) {
+    if (!settings.host || !settings.user || !settings.database) {
+        throw new Error('MariaDB source is not configured. Pass --source-config=path/to/old.ini, set L2NODE_LEGACY_DB_* variables, or use --legacy-default-from-git during this checkout upgrade.');
+    }
+}
+
+function sqliteTables(db) {
+    return new Set(db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all().map((row) => row.name));
+}
+
+function targetColumns(db, table) {
+    return db.prepare(`PRAGMA table_info("${table}")`).all().map((row) => row.name);
+}
+
+function normalizeValue(value) {
+    if (typeof value === 'bigint') return Number(value);
+    return value;
+}
+
+function sourceSelect(table) {
+    const characterChildren = new Set([
+        'items', 'character_recipes', 'character_quests', 'warehouse_items',
+        'skills', 'shortcuts', 'macros', 'bot_life_state', 'bot_goal_state', 'bot_life_events'
+    ]);
+    if (characterChildren.has(table)) {
+        return `SELECT source.* FROM \`${table}\` source INNER JOIN \`characters\` character_ref ON character_ref.id = source.characterId`;
+    }
+    if (table === 'clan_crests') {
+        return 'SELECT source.* FROM `clan_crests` source INNER JOIN `clans` clan_ref ON clan_ref.id = source.clanId';
+    }
+    if (table === 'bot_social_memory') {
+        return 'SELECT source.* FROM `bot_social_memory` source INNER JOIN `characters` player_ref ON player_ref.id = source.playerId INNER JOIN `characters` bot_ref ON bot_ref.id = source.botId';
+    }
+    return `SELECT * FROM \`${table}\``;
+}
+
+async function importTable(source, target, table) {
+    const existing = await source.query('SHOW TABLES LIKE ?', [table]);
+    if (!existing.length) return { table, rows: 0, skipped: true };
+    const sourceCount = Number((await source.query(`SELECT COUNT(*) AS count FROM \`${table}\``))[0]?.count || 0);
+    const rows = await source.query(sourceSelect(table));
+    if (!rows.length) return { table, rows: 0 };
+    const columns = targetColumns(target, table).filter((column) => Object.hasOwn(rows[0], column));
+    if (!columns.length) return { table, rows: 0, skipped: true };
+    const statement = target.prepare(`INSERT OR REPLACE INTO "${table}" (${columns.map((column) => `"${column}"`).join(', ')}) VALUES (${columns.map(() => '?').join(', ')})`);
+    let imported = 0;
+    rows.forEach((row) => {
+        // Zero stacks were historical garbage from the MariaDB implementation
+        // and are deliberately removed by the SQLite schema/maintenance path.
+        if ((table === 'items' || table === 'warehouse_items') && Number(row.amount) <= 0) return;
+        statement.run(...columns.map((column) => normalizeValue(row[column])));
+        imported += 1;
+    });
+    return { table, rows: imported, skipped: Math.max(0, sourceCount - imported) };
+}
+
+function updateSequences(target) {
+    SEQUENCE_TABLES.forEach((table) => {
+        const columns = targetColumns(target, table);
+        if (!columns.includes('id')) return;
+        const maximum = Number(target.prepare(`SELECT MAX(id) AS id FROM "${table}"`).get()?.id || 0);
+        target.prepare('INSERT OR IGNORE INTO sqlite_sequence(name, seq) VALUES (?, ?)').run(table, maximum);
+        target.prepare('UPDATE sqlite_sequence SET seq = MAX(seq, ?) WHERE name = ?').run(maximum, table);
+    });
+}
+
+async function migrate({ settings, targetPath }) {
+    const mariadb = requireMariaDb();
+    validateSettings(settings);
+    if (fs.existsSync(targetPath)) throw new Error(`Target SQLite file already exists: ${targetPath}. Choose an unused --target path; this command never overwrites a world.`);
+
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+    const stagingPath = `${targetPath}.importing-${process.pid}`;
+    let source;
+    let target;
+    let transactionOpen = false;
+    try {
+        source = await mariadb.createConnection(settings);
+        target = new DatabaseSync(stagingPath, { timeout: 5000 });
+        target.exec('PRAGMA foreign_keys = OFF;');
+        target.exec(fs.readFileSync(path.join(rootDir, 'database', 'sql', 'sqlite.sql'), 'utf8'));
+        target.exec('PRAGMA foreign_keys = OFF;');
+        target.exec('BEGIN IMMEDIATE;');
+        transactionOpen = true;
+        const available = sqliteTables(target);
+        const tables = [];
+        for (const table of TABLE_ORDER) {
+            if (available.has(table)) tables.push(await importTable(source, target, table));
+        }
+        updateSequences(target);
+        target.prepare('INSERT OR REPLACE INTO schema_migrations(version, appliedAt) VALUES (?, ?)').run(1, Date.now());
+        target.exec('COMMIT;');
+        transactionOpen = false;
+        target.exec('PRAGMA foreign_keys = ON;');
+        const violations = target.prepare('PRAGMA foreign_key_check').all();
+        if (violations.length) throw new Error(`Foreign-key validation failed (${violations.length} violations).`);
+        target.exec('VACUUM;');
+        const integrity = target.prepare('PRAGMA integrity_check').all();
+        if (integrity.length !== 1 || integrity[0]?.integrity_check !== 'ok') {
+            throw new Error(`SQLite integrity validation failed: ${integrity.map((row) => row.integrity_check).join('; ') || 'unknown error'}`);
+        }
+        target.close();
+        target = null;
+        await source.end();
+        source = null;
+        fs.renameSync(stagingPath, targetPath);
+        return { targetPath, tables, rows: tables.reduce((sum, entry) => sum + entry.rows, 0) };
+    } catch (error) {
+        if (target && transactionOpen) {
+            try { target.exec('ROLLBACK;'); } catch (_) { /* best effort cleanup */ }
+        }
+        if (target) target.close();
+        if (source) await source.end();
+        if (fs.existsSync(stagingPath)) fs.unlinkSync(stagingPath);
+        throw error;
+    }
+}
+
+module.exports = { parseIni, sourceSettings, migrate };
+
+if (require.main === module) {
+    const args = argumentsMap(process.argv.slice(2));
+    const targetPath = path.resolve(rootDir, args.target || configuredSqlitePath());
+    migrate({ settings: sourceSettings(args), targetPath }).then((result) => {
+        process.stdout.write(`${JSON.stringify(result)}\n`);
+    }).catch((error) => {
+        process.stderr.write(`MariaDB to SQLite migration failed: ${error.message || error}\n`);
+        process.exitCode = 1;
+    });
+}

--- a/scripts/run-server.js
+++ b/scripts/run-server.js
@@ -1,255 +1,15 @@
-#!/usr/bin/env node
 'use strict';
 
-const { spawn, spawnSync } = require('child_process');
-const fs = require('fs');
+const { spawn } = require('child_process');
 const path = require('path');
 
 const rootDir = path.resolve(__dirname, '..');
-const containerName = process.env.L2NODE_DB_CONTAINER || 'nodel2-mariadb';
-const imageName = process.env.L2NODE_DB_IMAGE || 'mariadb:10.6';
 const isWindows = process.platform === 'win32';
-const npmCommand = isWindows ? 'npm.cmd' : 'npm';
-const dockerCommand = isWindows ? 'docker.exe' : 'docker';
-
 let serverChild = null;
 let shuttingDown = false;
 
 function log(message) {
     console.info(`Startup    :: ${message}`);
-}
-
-function warn(message) {
-    console.warn(`Startup    :: ${message}`);
-}
-
-function sleep(ms) {
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function run(command, args, options = {}) {
-    return spawnSync(command, args, {
-        cwd: rootDir,
-        encoding: 'utf8',
-        ...options
-    });
-}
-
-function commandAvailable(command) {
-    const result = run(command, ['--version'], { stdio: 'ignore' });
-    return result.status === 0;
-}
-
-function parseIni(raw) {
-    const config = {};
-    let section = config;
-
-    raw.split(/\r?\n/).forEach((line) => {
-        const trimmed = line.trim();
-        if (!trimmed || trimmed.startsWith(';') || trimmed.startsWith('#')) {
-            return;
-        }
-
-        const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
-        if (sectionMatch) {
-            section = config[sectionMatch[1]] = config[sectionMatch[1]] || {};
-            return;
-        }
-
-        const separator = trimmed.indexOf('=');
-        if (separator === -1) {
-            return;
-        }
-
-        const key = trimmed.slice(0, separator).trim();
-        const value = trimmed.slice(separator + 1).trim();
-        section[key] = value;
-    });
-
-    return config;
-}
-
-function mergeConfig(base, override) {
-    Object.keys(override || {}).forEach((key) => {
-        const baseValue = base[key];
-        const overrideValue = override[key];
-
-        if (
-            baseValue &&
-            overrideValue &&
-            typeof baseValue === 'object' &&
-            typeof overrideValue === 'object' &&
-            !Array.isArray(baseValue) &&
-            !Array.isArray(overrideValue)
-        ) {
-            mergeConfig(baseValue, overrideValue);
-        } else {
-            base[key] = overrideValue;
-        }
-    });
-
-    return base;
-}
-
-function readConfig() {
-    const defaultPath = path.join(rootDir, 'config', 'default.ini');
-    const localPath = path.join(rootDir, 'config', 'local.ini');
-    const config = parseIni(fs.readFileSync(defaultPath, 'utf8'));
-
-    if (fs.existsSync(localPath)) {
-        mergeConfig(config, parseIni(fs.readFileSync(localPath, 'utf8')));
-    }
-
-    return config;
-}
-
-function ensureDependencies() {
-    if (fs.existsSync(path.join(rootDir, 'node_modules'))) {
-        return;
-    }
-
-    log('node_modules not found; running npm install');
-    const result = run(npmCommand, ['install'], { stdio: 'inherit' });
-    if (result.status !== 0) {
-        process.exit(result.status || 1);
-    }
-}
-
-function isLocalDatabase(dbConfig) {
-    const hostname = String(dbConfig.hostname || '').toLowerCase();
-    return hostname === '127.0.0.1' || hostname === 'localhost';
-}
-
-function dockerInspect(format) {
-    return run(dockerCommand, ['inspect', '-f', format, containerName]);
-}
-
-function ensureDockerDatabase(dbConfig) {
-    if (process.env.L2NODE_SKIP_DOCKER === '1') {
-        warn('L2NODE_SKIP_DOCKER=1; assuming MariaDB is already reachable');
-        return;
-    }
-
-    if (!isLocalDatabase(dbConfig)) {
-        warn(`database host is ${dbConfig.hostname}; skipping local Docker bootstrap`);
-        return;
-    }
-
-    if (!commandAvailable(dockerCommand)) {
-        warn('Docker is not available; assuming MariaDB is already reachable');
-        return;
-    }
-
-    const password = dbConfig.password || '';
-    const port = String(dbConfig.port || '3306');
-    const databaseName = dbConfig.databaseName || 'nodel2';
-    let containerCreated = false;
-
-    const exists = dockerInspect('{{.Name}}').status === 0;
-    if (!exists) {
-        log(`creating ${containerName} (${imageName}) on port ${port}`);
-        const result = run(dockerCommand, [
-            'run',
-            '-d',
-            '--name',
-            containerName,
-            '-p',
-            `${port}:3306`,
-            '-e',
-            `MARIADB_ROOT_PASSWORD=${password}`,
-            imageName
-        ], { stdio: 'inherit' });
-
-        if (result.status !== 0) {
-            warn('could not create MariaDB container; server startup will try the configured database anyway');
-            return;
-        }
-
-        containerCreated = true;
-    } else {
-        const running = dockerInspect('{{.State.Running}}');
-        if (String(running.stdout).trim() !== 'true') {
-            log(`starting ${containerName}`);
-            const result = run(dockerCommand, ['start', containerName], { stdio: 'inherit' });
-            if (result.status !== 0) {
-                warn('could not start MariaDB container; server startup will try the configured database anyway');
-                return;
-            }
-        }
-    }
-
-    waitForDatabase(password);
-
-    if (containerCreated || !databaseExists(password, databaseName)) {
-        importDatabase(password);
-    }
-}
-
-function waitForDatabase(password) {
-    const passwordArg = `-p${password}`;
-
-    for (let attempt = 1; attempt <= 30; attempt += 1) {
-        const result = run(dockerCommand, [
-            'exec',
-            containerName,
-            'mariadb',
-            '-u',
-            'root',
-            passwordArg,
-            '-e',
-            'SELECT 1;'
-        ], { stdio: 'ignore' });
-
-        if (result.status === 0) {
-            return;
-        }
-
-        sleep(1000);
-    }
-
-    warn('MariaDB did not become ready in 30s; server startup will continue and report any DB error');
-}
-
-function databaseExists(password, databaseName) {
-    const passwordArg = `-p${password}`;
-    const result = run(dockerCommand, [
-        'exec',
-        containerName,
-        'mariadb',
-        '-u',
-        'root',
-        passwordArg,
-        '-N',
-        '-s',
-        '-e',
-        `SHOW DATABASES LIKE '${databaseName.replace(/'/g, "''")}';`
-    ]);
-
-    return result.status === 0 && String(result.stdout).trim() === databaseName;
-}
-
-function importDatabase(password) {
-    const sqlPath = path.join(rootDir, 'database', 'sql', 'database.sql');
-    const sql = fs.readFileSync(sqlPath, 'utf8');
-    const passwordArg = `-p${password}`;
-
-    log('importing database/sql/database.sql');
-    const result = run(dockerCommand, [
-        'exec',
-        '-i',
-        containerName,
-        'mariadb',
-        '-u',
-        'root',
-        passwordArg
-    ], {
-        input: sql,
-        stdio: ['pipe', 'inherit', 'inherit']
-    });
-
-    if (result.status !== 0) {
-        process.exit(result.status || 1);
-    }
 }
 
 function stopServer(signal) {
@@ -263,47 +23,34 @@ function stopServer(signal) {
 
     serverChild.once('exit', () => process.exit(0));
     serverChild.kill(signal || 'SIGTERM');
-
     setTimeout(() => {
-        if (serverChild && !serverChild.killed) {
-            serverChild.kill('SIGKILL');
-        }
+        if (serverChild && !serverChild.killed) serverChild.kill('SIGKILL');
     }, 5000).unref();
 }
 
 function startServer() {
-    log('starting NodeL2');
+    log('starting NodeL2 with embedded SQLite');
     serverChild = spawn(process.execPath, ['--openssl-legacy-provider', 'src/NodeL2'], {
         cwd: rootDir,
         stdio: 'inherit',
-        env: process.env
+        env: process.env,
+        windowsHide: isWindows
     });
 
     serverChild.on('exit', (code, signal) => {
         serverChild = null;
-
         if (shuttingDown) {
             process.exit(0);
             return;
         }
-
         if (signal) {
             process.kill(process.pid, signal);
             return;
         }
-
         process.exit(code || 0);
     });
 }
 
-function main() {
-    const config = readConfig();
-    ensureDependencies();
-    ensureDockerDatabase(config.Database || {});
-    startServer();
-}
-
 process.on('SIGINT', () => stopServer('SIGINT'));
 process.on('SIGTERM', () => stopServer('SIGTERM'));
-
-main();
+startServer();

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -69,6 +69,7 @@ const tests = [
     'tests/test_c4_protocol_packets.js',
     'tests/test_cast_interrupt.js',
     'tests/test_character_write_queue.js',
+    'tests/test_hot_bot_load_test.js',
     'tests/test_sqlite_account_casefold.js',
     'tests/test_character_status_persistence.js',
     'tests/test_change_class.js',

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -53,6 +53,7 @@ const tests = [
     'tests/test_bot_market_opportunity.js',
     'tests/test_bot_population_state.js',
     'tests/test_bot_population_policy.js',
+    'tests/test_bot_population_scheduler_slices.js',
     'tests/test_bot_population_cooldown_cleanup.js',
     'tests/test_bot_cold_state_context.js',
     'tests/test_bot_pvp_risk.js',

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -68,6 +68,8 @@ const tests = [
     'tests/test_c4_buff_modifiers.js',
     'tests/test_c4_protocol_packets.js',
     'tests/test_cast_interrupt.js',
+    'tests/test_character_write_queue.js',
+    'tests/test_sqlite_account_casefold.js',
     'tests/test_character_status_persistence.js',
     'tests/test_change_class.js',
     'tests/test_clan_bot_invite.js',

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -297,11 +297,12 @@ function stopServer() {
     state.phase = 'stopping';
     appendLog('launcher', `stopping server process ${pid}`);
 
-    if (isWindows) {
-        spawnSync('taskkill.exe', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' });
-    } else {
-        state.child.kill('SIGTERM');
-    }
+    state.child.kill('SIGTERM');
+    setTimeout(() => {
+        if (state.child?.pid !== pid) return;
+        if (isWindows) spawnSync('taskkill.exe', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' });
+        else state.child.kill('SIGKILL');
+    }, 5000).unref();
 
     return publicState();
 }

--- a/scripts/world-wipe.js
+++ b/scripts/world-wipe.js
@@ -3,45 +3,24 @@
 
 const fs = require('fs');
 const path = require('path');
-const mariadb = require('mariadb');
+const { DatabaseSync } = require('node:sqlite');
 
 const rootDir = path.resolve(__dirname, '..');
 const scopes = new Set(['bots', 'players', 'all']);
 
-function parseIni(raw) {
-    const config = {};
-    let section = config;
-    raw.split(/\r?\n/).forEach((line) => {
-        const trimmed = line.trim();
-        if (!trimmed || trimmed.startsWith(';') || trimmed.startsWith('#')) return;
-        const sectionMatch = trimmed.match(/^\[([^\]]+)\]$/);
-        if (sectionMatch) {
-            section = config[sectionMatch[1]] = config[sectionMatch[1]] || {};
-            return;
-        }
-        const separator = trimmed.indexOf('=');
-        if (separator === -1) return;
-        section[trimmed.slice(0, separator).trim()] = trimmed.slice(separator + 1).trim();
+function readDatabasePath() {
+    const files = [path.join(rootDir, 'config', 'default.ini'), path.join(rootDir, 'config', 'local.ini')];
+    let value = 'tmp/nodel2.sqlite';
+    files.filter(fs.existsSync).forEach((file) => {
+        let inDatabase = false;
+        fs.readFileSync(file, 'utf8').split(/\r?\n/).forEach((line) => {
+            const trimmed = line.trim();
+            if (/^\[Database\]$/i.test(trimmed)) inDatabase = true;
+            else if (/^\[.+\]$/.test(trimmed)) inDatabase = false;
+            else if (inDatabase && /^path\s*=/.test(trimmed)) value = trimmed.slice(trimmed.indexOf('=') + 1).trim();
+        });
     });
-    return config;
-}
-
-function mergeConfig(base, override) {
-    Object.keys(override || {}).forEach((key) => {
-        if (base[key] && override[key] && typeof base[key] === 'object' && typeof override[key] === 'object') {
-            mergeConfig(base[key], override[key]);
-        } else {
-            base[key] = override[key];
-        }
-    });
-    return base;
-}
-
-function readConfig() {
-    const config = parseIni(fs.readFileSync(path.join(rootDir, 'config', 'default.ini'), 'utf8'));
-    const localPath = path.join(rootDir, 'config', 'local.ini');
-    if (fs.existsSync(localPath)) mergeConfig(config, parseIni(fs.readFileSync(localPath, 'utf8')));
-    return config;
+    return path.resolve(rootDir, value);
 }
 
 function validateScope(scope) {
@@ -52,124 +31,75 @@ function validateScope(scope) {
 
 function targetClause(scope) {
     switch (validateScope(scope)) {
-    case 'bots': return { sql: "username LIKE 'bot\\_%' ESCAPE '\\\\'", params: [] };
-    case 'players': return { sql: "username NOT LIKE 'bot\\_%' ESCAPE '\\\\'", params: [] };
+    case 'bots': return { sql: "username LIKE 'bot\\_%' ESCAPE '\\'", params: [] };
+    case 'players': return { sql: "username NOT LIKE 'bot\\_%' ESCAPE '\\'", params: [] };
     default: return { sql: '1 = 1', params: [] };
     }
 }
 
-function placeholders(count) {
-    return Array.from({ length: count }, () => '?').join(', ');
-}
-
-async function ignoreMissingTable(operation) {
-    try {
-        return await operation();
-    } catch (error) {
-        if (error.code !== 'ER_NO_SUCH_TABLE') throw error;
-        return null;
-    }
-}
-
-async function previewWithConnection(conn, scope) {
+function previewWithConnection(db, scope) {
     const target = targetClause(scope);
-    const [characters] = await Promise.all([
-        conn.query(`SELECT COUNT(*) AS count FROM characters WHERE ${target.sql}`, target.params),
-    ]);
-    const accounts = await conn.query(`SELECT COUNT(*) AS count FROM accounts WHERE ${target.sql}`, target.params);
     return {
         scope: validateScope(scope),
-        characters: Number(characters[0]?.count || 0),
-        accounts: Number(accounts[0]?.count || 0)
+        characters: Number(db.prepare(`SELECT COUNT(*) AS count FROM characters WHERE ${target.sql}`).get(...target.params).count || 0),
+        accounts: Number(db.prepare(`SELECT COUNT(*) AS count FROM accounts WHERE ${target.sql}`).get(...target.params).count || 0)
     };
 }
 
-async function wipeWithConnection(conn, scope) {
+function wipeWithConnection(db, scope) {
     const normalizedScope = validateScope(scope);
     const target = targetClause(normalizedScope);
-    const preview = await previewWithConnection(conn, normalizedScope);
-    const characters = await conn.query(`SELECT id FROM characters WHERE ${target.sql}`, target.params);
-    const ids = characters.map((row) => Number(row.id)).filter(Boolean);
+    const preview = previewWithConnection(db, normalizedScope);
+    const ids = db.prepare(`SELECT id FROM characters WHERE ${target.sql}`).all(...target.params).map((row) => Number(row.id)).filter(Boolean);
 
-    await conn.beginTransaction();
+    db.exec('BEGIN IMMEDIATE');
     try {
         if (normalizedScope === 'all') {
-            for (const table of [
+            [
                 'bot_life_events', 'bot_life_state', 'bot_goal_state', 'bot_social_memory',
                 'character_recipes', 'character_quests', 'warehouse_items', 'macros',
                 'shortcuts', 'skills', 'items', 'bot_background_parties', 'clan_crests', 'clans'
-            ]) {
-                await ignoreMissingTable(() => conn.query(`DELETE FROM ${table}`));
+            ].forEach((table) => db.exec(`DELETE FROM ${table}`));
+        }
+        if (ids.length) {
+            const placeholders = ids.map(() => '?').join(', ');
+            const clanIds = db.prepare(`SELECT id FROM clans WHERE leaderId IN (${placeholders})`).all(...ids)
+                .map((row) => Number(row.id)).filter(Boolean);
+            if (clanIds.length) {
+                const clanPlaceholders = clanIds.map(() => '?').join(', ');
+                db.prepare(`UPDATE characters SET clanId = 0, clanPrivileges = 0 WHERE clanId IN (${clanPlaceholders})`).run(...clanIds);
+                db.prepare(`DELETE FROM clans WHERE id IN (${clanPlaceholders})`).run(...clanIds);
             }
+            db.prepare(`DELETE FROM characters WHERE id IN (${placeholders})`).run(...ids);
         }
-
-        if (ids.length > 0) {
-            const idList = placeholders(ids.length);
-            const socialParams = [...ids, ...ids];
-            if (normalizedScope !== 'all') {
-                await ignoreMissingTable(() => conn.query(`DELETE FROM bot_life_events WHERE characterId IN (${idList})`, ids));
-                await ignoreMissingTable(() => conn.query(`DELETE FROM bot_life_state WHERE characterId IN (${idList})`, ids));
-                await ignoreMissingTable(() => conn.query(`DELETE FROM bot_goal_state WHERE characterId IN (${idList})`, ids));
-                await ignoreMissingTable(() => conn.query(`DELETE FROM bot_social_memory WHERE botId IN (${idList}) OR playerId IN (${idList})`, socialParams));
-                for (const table of ['character_recipes', 'character_quests', 'warehouse_items', 'macros', 'shortcuts', 'skills', 'items']) {
-                    await ignoreMissingTable(() => conn.query(`DELETE FROM ${table} WHERE characterId IN (${idList})`, ids));
-                }
-
-                const clans = await ignoreMissingTable(() => conn.query(`SELECT id FROM clans WHERE leaderId IN (${idList})`, ids)) || [];
-                const clanIds = clans.map((row) => Number(row.id)).filter(Boolean);
-                if (clanIds.length > 0) {
-                    const clanList = placeholders(clanIds.length);
-                    await ignoreMissingTable(() => conn.query(`DELETE FROM clan_crests WHERE clanId IN (${clanList})`, clanIds));
-                    await conn.query(`UPDATE characters SET clanId = 0, clanPrivileges = 0 WHERE clanId IN (${clanList})`, clanIds);
-                    await ignoreMissingTable(() => conn.query(`DELETE FROM clans WHERE id IN (${clanList})`, clanIds));
-                }
-            }
-
-            await conn.query(`DELETE FROM characters WHERE id IN (${idList})`, ids);
-        }
-
-        if (normalizedScope === 'bots') {
-            await ignoreMissingTable(() => conn.query('DELETE FROM bot_background_parties'));
-        }
-        await conn.query(`DELETE FROM accounts WHERE ${target.sql}`, target.params);
-        await conn.commit();
+        if (normalizedScope === 'bots') db.exec('DELETE FROM bot_background_parties');
+        db.prepare(`DELETE FROM accounts WHERE ${target.sql}`).run(...target.params);
+        db.exec('COMMIT');
         return preview;
     } catch (error) {
-        await conn.rollback();
+        db.exec('ROLLBACK');
         throw error;
     }
 }
 
-async function withConnection(work) {
-    const config = readConfig().Database || {};
-    const conn = await mariadb.createConnection({
-        host: config.hostname,
-        port: Number(config.port || 3306),
-        user: config.user,
-        password: config.password,
-        database: config.databaseName
-    });
+function withConnection(work) {
+    const db = new DatabaseSync(readDatabasePath(), { timeout: 5000 });
+    db.exec('PRAGMA foreign_keys = ON');
     try {
-        return await work(conn);
+        return work(db);
     } finally {
-        await conn.end();
+        db.close();
     }
 }
 
-function preview(scope) {
-    return withConnection((conn) => previewWithConnection(conn, scope));
-}
-
-function wipe(scope) {
-    return withConnection((conn) => wipeWithConnection(conn, scope));
-}
+function preview(scope) { return withConnection((db) => previewWithConnection(db, scope)); }
+function wipe(scope) { return withConnection((db) => wipeWithConnection(db, scope)); }
 
 module.exports = { validateScope, targetClause, previewWithConnection, wipeWithConnection, preview, wipe };
 
 if (require.main === module) {
     const argument = process.argv.find((value) => value.startsWith('--scope='));
-    const scope = argument?.slice('--scope='.length);
-    wipe(scope).then((result) => {
+    wipe(argument?.slice('--scope='.length)).then((result) => {
         process.stdout.write(`${JSON.stringify(result)}\n`);
     }).catch((error) => {
         process.stderr.write(`World wipe failed: ${error.message || error}\n`);

--- a/src/AuthenticationServer/Network/Request/AuthLogin.js
+++ b/src/AuthenticationServer/Network/Request/AuthLogin.js
@@ -22,11 +22,12 @@ function authLogin(session, buffer) {
 
 function consume(session, data) {
     Database.fetchUserPassword(data.username).then((rows) => {
-        const password = rows[0]?.password;
+        const account = rows[0];
+        const password = account?.password;
 
         // Username exists in database
         if (password) {
-            data.password === password ? passwordMatch(session, data.username) : failure(session, 0x02);
+            data.password === password ? passwordMatch(session, account.username) : failure(session, 0x02);
         }
         else { // User account does not exist, create if needed
             const optn = options.default.AuthServer;

--- a/src/Database.js
+++ b/src/Database.js
@@ -1,810 +1,540 @@
-const SQL = require('like-sql'), builder = new SQL();
+const fs = require('fs');
+const path = require('path');
+const { DatabaseSync } = require('node:sqlite');
 
-let conn;
-let transactionTail = Promise.resolve();
+let connection;
+let queryTail = Promise.resolve();
+let databasePath;
+let flushPendingCharacterWrites = null;
 
-function normalizeRowNumbers(row) {
-    return Object.fromEntries(
-        Object.entries(row).map(([key, value]) => [key, typeof value === 'bigint' ? Number(value) : value])
-    );
+const metrics = {
+    pending: 0,
+    total: 0,
+    reads: 0,
+    writes: 0,
+    transactions: 0,
+    failures: 0,
+    waitMs: 0,
+    runMs: 0,
+    maxPending: 0,
+    byOperation: new Map()
+};
+
+function now() {
+    return Date.now();
 }
 
-function migrateCharacterExperience(optn) {
-    return conn.query(
-        'SELECT DATA_TYPE AS dataType FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?',
-        [optn.databaseName, 'characters', 'exp']
-    ).then((rows) => {
-        if (rows[0]?.dataType === 'bigint') return null;
-        return conn.query('ALTER TABLE `characters` MODIFY COLUMN `exp` BIGINT NOT NULL DEFAULT 0');
-    }).catch((error) => {
-        utils.infoWarn('DB', 'failed to migrate characters.exp to BIGINT: %s', error.message);
-    });
+function normalizeValue(value) {
+    if (typeof value === 'bigint') return Number(value);
+    if (Buffer.isBuffer(value)) return value;
+    return value;
 }
 
-function migrateCharacterStatus() {
-    return conn.query('ALTER TABLE `characters` ADD COLUMN `cp` FLOAT NULL')
-        .catch((error) => {
-            if (error?.errno !== 1060) utils.infoWarn('DB', 'failed to add characters.cp: %s', error.message);
-        })
-        .then(() => conn.query('ALTER TABLE `characters` ADD COLUMN `effects` TEXT NULL'))
-        .catch((error) => {
-            if (error?.errno !== 1060) utils.infoWarn('DB', 'failed to add characters.effects: %s', error.message);
-        });
+function normalizeRow(row) {
+    if (!row || typeof row !== 'object') return row;
+    return Object.fromEntries(Object.entries(row).map(([key, value]) => [key, normalizeValue(value)]));
 }
 
-function migrateWarehouse() {
-    return conn.query(`CREATE TABLE IF NOT EXISTS warehouse_items (
-        id INT(8) NOT NULL AUTO_INCREMENT,
-        selfId INT(5) NOT NULL,
-        name VARCHAR(48) NOT NULL,
-        amount BIGINT NOT NULL DEFAULT 1,
-        petData TEXT NULL,
-        characterId INT(8) NOT NULL,
-        PRIMARY KEY (id),
-        KEY characterId (characterId)
-    )`).then(() => conn.query('ALTER TABLE warehouse_items ADD COLUMN petData TEXT NULL')
-        .catch((error) => {
-            if (error?.errno !== 1060) utils.infoWarn('DB', 'failed to add warehouse_items.petData: %s', error.message);
-        }))
-        .catch((error) => {
-            utils.infoWarn('DB', 'failed to create warehouse_items: %s', error.message);
-        });
+function normalizeRows(rows) {
+    return (rows || []).map(normalizeRow);
 }
 
-function migrateMacros() {
-    return conn.query(`CREATE TABLE IF NOT EXISTS macros (
-        characterId INT(8) NOT NULL,
-        id INT(8) NOT NULL,
-        icon TINYINT UNSIGNED NOT NULL,
-        name VARCHAR(64) NOT NULL,
-        descr VARCHAR(64) NOT NULL,
-        acronym VARCHAR(16) NOT NULL,
-        commands TEXT NOT NULL,
-        PRIMARY KEY (characterId, id),
-        KEY characterId (characterId)
-    )`).catch((error) => {
-        utils.infoWarn('DB', 'failed to create macros: %s', error.message);
-    });
-}
-
-function migrateCharacterRecipes() {
-    return conn.query(`CREATE TABLE IF NOT EXISTS character_recipes (
-        characterId INT(8) NOT NULL,
-        recipeId INT(8) NOT NULL,
-        type ENUM('dwarven', 'common') NOT NULL,
-        PRIMARY KEY (characterId, recipeId, type),
-        KEY characterId (characterId)
-    )`).catch((error) => {
-        utils.infoWarn('DB', 'failed to create character_recipes: %s', error.message);
-    });
-}
-
-function migrateCharacterQuests() {
-    return conn.query(`CREATE TABLE IF NOT EXISTS character_quests (
-        characterId INT(8) NOT NULL,
-        questId INT(8) NOT NULL,
-        state ENUM('created', 'started', 'completed') NOT NULL DEFAULT 'created',
-        variables TEXT NULL,
-        PRIMARY KEY (characterId, questId),
-        KEY characterId (characterId)
-    )`).catch((error) => {
-        utils.infoWarn('DB', 'failed to create character_quests: %s', error.message);
-    });
-}
-
-async function inTransaction(work) {
-    const previous = transactionTail;
-    let release;
-    transactionTail = new Promise((resolve) => { release = resolve; });
-    await previous;
-    try {
-        await conn.beginTransaction();
-        const result = await work();
-        await conn.commit();
-        return result;
-    } catch (error) {
-        await conn.rollback();
-        throw error;
-    } finally {
-        release();
+function escapeIdentifier(value) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+        throw new Error(`invalid SQL identifier: ${value}`);
     }
+    return `"${value}"`;
 }
 
-function petDataValue(petData) {
-    if (!petData) return null;
-    return typeof petData === 'string' ? petData : JSON.stringify(petData);
+function databaseFile() {
+    const configured = options.default.Database?.path || 'tmp/nodel2.sqlite';
+    return path.resolve(process.cwd(), configured);
 }
+
+function isReadStatement(sql) {
+    return /^\s*(SELECT|EXPLAIN|PRAGMA\s+[^=]+$)/i.test(String(sql || ''));
+}
+
+function operationName(sql, fallback = 'raw') {
+    const match = String(sql || '').trim().match(/^([A-Za-z]+)/);
+    return match ? `${fallback}:${match[1].toLowerCase()}` : fallback;
+}
+
+function record(operation, wait, run, read, failed = false) {
+    metrics.total += 1;
+    metrics.waitMs += wait;
+    metrics.runMs += run;
+    if (read) metrics.reads += 1;
+    else metrics.writes += 1;
+    if (failed) metrics.failures += 1;
+    const entry = metrics.byOperation.get(operation) || { count: 0, waitMs: 0, runMs: 0, failures: 0 };
+    entry.count += 1;
+    entry.waitMs += wait;
+    entry.runMs += run;
+    if (failed) entry.failures += 1;
+    metrics.byOperation.set(operation, entry);
+}
+
+function enqueue(work, { operation = 'raw', read = false } = {}) {
+    const queuedAt = now();
+    metrics.pending += 1;
+    metrics.maxPending = Math.max(metrics.maxPending, metrics.pending);
+    const execute = () => {
+        const startedAt = now();
+        const wait = startedAt - queuedAt;
+        try {
+            const result = work();
+            record(operation, wait, now() - startedAt, read);
+            return result;
+        } catch (error) {
+            record(operation, wait, now() - startedAt, read, true);
+            throw error;
+        } finally {
+            metrics.pending -= 1;
+        }
+    };
+    const result = queryTail.then(execute, execute);
+    queryTail = result.catch(() => null);
+    return result;
+}
+
+function run(sql, params = [], operation) {
+    const read = isReadStatement(sql);
+    return enqueue(() => {
+        if (!connection) throw new Error(`SQLite is not initialized (${operation || operationName(sql)})`);
+        const statement = connection.prepare(sql);
+        if (read) return normalizeRows(statement.all(...params));
+        const result = statement.run(...params);
+        return {
+            affectedRows: Number(result.changes || 0),
+            insertId: Number(result.lastInsertRowid || 0)
+        };
+    }, { operation: operation || operationName(sql), read });
+}
+
+function insert(table, values, operation) {
+    const columns = Object.keys(values || {});
+    if (!columns.length) throw new Error(`cannot insert empty ${table}`);
+    const sql = `INSERT INTO ${escapeIdentifier(table)} (${columns.map(escapeIdentifier).join(', ')}) VALUES (${columns.map(() => '?').join(', ')})`;
+    return run(sql, columns.map((key) => values[key]), operation || `insert:${table}`);
+}
+
+function update(table, values, where, params = [], operation) {
+    const columns = Object.keys(values || {});
+    if (!columns.length) return Promise.resolve({ affectedRows: 0, insertId: 0 });
+    const sql = `UPDATE ${escapeIdentifier(table)} SET ${columns.map((key) => `${escapeIdentifier(key)} = ?`).join(', ')}${where ? ` WHERE ${where}` : ''}`;
+    return run(sql, [...columns.map((key) => values[key]), ...params], operation || `update:${table}`);
+}
+
+function remove(table, where, params = [], operation) {
+    return run(`DELETE FROM ${escapeIdentifier(table)}${where ? ` WHERE ${where}` : ''}`, params, operation || `delete:${table}`);
+}
+
+function select(table, columns = ['*'], where = '', params = [], operation) {
+    const selected = columns.length === 1 && columns[0] === '*'
+        ? '*'
+        : columns.map(escapeIdentifier).join(', ');
+    return run(`SELECT ${selected} FROM ${escapeIdentifier(table)}${where ? ` WHERE ${where}` : ''}`, params, operation || `select:${table}`);
+}
+
+function selectOne(table, columns, where, params, operation) {
+    return select(table, columns, `${where} LIMIT 1`, params, operation);
+}
+
+function cleanZeroAmountItems() {
+    return run('DELETE FROM items WHERE amount <= 0', [], 'maintenance:zero-items');
+}
+
+async function inTransaction(work, operation = 'transaction') {
+    return enqueue(() => {
+        metrics.transactions += 1;
+        connection.exec('BEGIN IMMEDIATE');
+        try {
+            const result = work();
+            connection.exec('COMMIT');
+            return result;
+        } catch (error) {
+            connection.exec('ROLLBACK');
+            throw error;
+        }
+    }, { operation, read: false });
+}
+
+function withCharacterFlush(characterId, work) {
+    if (!flushPendingCharacterWrites || !Number(characterId)) return work();
+    return Promise.resolve(flushPendingCharacterWrites(Number(characterId))).then(work);
+}
+
+function withCharacterFlushes(characterIds, work) {
+    if (!flushPendingCharacterWrites) return work();
+    const ids = [...new Set((characterIds || []).map(Number).filter(Boolean))];
+    return ids.reduce(
+        (pending, characterId) => pending.then(() => flushPendingCharacterWrites(characterId)),
+        Promise.resolve()
+    ).then(work);
+}
+
+function applySchemaMigrations() {
+    const migrations = [
+        [1, () => {}],
+        [2, () => connection.exec(`
+            CREATE UNIQUE INDEX IF NOT EXISTS accounts_username_nocase ON accounts(username COLLATE NOCASE);
+            CREATE INDEX IF NOT EXISTS characters_username_nocase ON characters(username COLLATE NOCASE);
+        `)]
+    ];
+    const applied = new Set(connection.prepare('SELECT version FROM schema_migrations').all().map((row) => Number(row.version)));
+    migrations.forEach(([version, apply]) => {
+        if (applied.has(version)) return;
+        apply();
+        connection.prepare('INSERT INTO schema_migrations(version, appliedAt) VALUES (?, ?)').run(version, now());
+    });
+}
+
+function one(sql, params = []) {
+    return normalizeRow(connection.prepare(sql).get(...params));
+}
+
+function all(sql, params = []) {
+    return normalizeRows(connection.prepare(sql).all(...params));
+}
+
+function write(sql, params = []) {
+    const result = connection.prepare(sql).run(...params);
+    return { affectedRows: Number(result.changes || 0), insertId: Number(result.lastInsertRowid || 0) };
+}
+
+function applyBufferedCharacterStateUnsafe(characterId, state = {}) {
+    const character = state.character || {};
+    const fields = Object.entries(character).filter(([, value]) => value !== undefined);
+    if (fields.length) {
+        const sql = `UPDATE characters SET ${fields.map(([key]) => `${escapeIdentifier(key)} = ?`).join(', ')} WHERE id = ?`;
+        write(sql, [...fields.map(([, value]) => value), characterId]);
+    }
+    Object.values(state.items || {}).forEach((item) => {
+        if (item.delete || Number(item.amount) <= 0) {
+            write('DELETE FROM items WHERE id = ? AND characterId = ?', [item.id, characterId]);
+        } else {
+            write('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [item.amount, item.id, characterId]);
+        }
+    });
+    return { characterId, fields: fields.length, items: Object.keys(state.items || {}).length };
+}
+
+const UPSERT_CHARACTER_QUEST = `INSERT INTO character_quests (characterId, questId, state, variables)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(characterId, questId) DO UPDATE SET state = excluded.state, variables = excluded.variables`;
+const UPSERT_RECIPE = `INSERT INTO character_recipes (characterId, recipeId, type) VALUES (?, ?, ?)
+    ON CONFLICT(characterId, recipeId, type) DO NOTHING`;
+const UPSERT_MACRO = `INSERT INTO macros (characterId, id, icon, name, descr, acronym, commands)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(characterId, id) DO UPDATE SET icon = excluded.icon, name = excluded.name,
+        descr = excluded.descr, acronym = excluded.acronym, commands = excluded.commands`;
 
 const Database = {
-    init: (callback) => {
-        const optn = options.default.Database;
+    init(callback = () => {}) {
+        try {
+            databasePath = databaseFile();
+            fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+            connection = new DatabaseSync(databasePath, { timeout: 5000 });
+            connection.exec('PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA foreign_keys = ON; PRAGMA busy_timeout = 5000; PRAGMA temp_store = MEMORY;');
+            connection.exec(fs.readFileSync(path.join(process.cwd(), 'database', 'sql', 'sqlite.sql'), 'utf8'));
+            applySchemaMigrations();
+            cleanZeroAmountItems().catch((error) => utils.infoWarn('DB', 'failed to clean zero amount items: %s', error.message));
+            utils.infoSuccess('DB', 'SQLite connected %s', databasePath);
+            callback();
+        } catch (error) {
+            utils.infoFail('DB', 'SQLite initialization failed -> %s', error.message);
+        }
+    },
 
-        require('mariadb').createConnection({
-            host     : optn.hostname,
-            port     : optn.port,
-            user     : optn.user,
-            password : optn.password,
-            database : optn.databaseName
+    execute(statement, operation = 'raw') {
+        return run(statement[0], statement[1] || [], operation);
+    },
 
-        }).then((instance) => {
-            utils.infoSuccess('DB', 'connected');
-            conn = instance;
-            Promise.all([
-                conn.query('ALTER TABLE `items` ADD COLUMN `petData` TEXT NULL')
-                .catch((error) => {
-                    if (error?.errno !== 1060) {
-                        utils.infoWarn('DB', 'failed to add items.petData: %s', error.message);
+    isReady() { return !!connection; },
+
+    registerCharacterWriteFlush(flush) {
+        flushPendingCharacterWrites = typeof flush === 'function' ? flush : null;
+    },
+
+    stats({ resetPeak = false } = {}) {
+        const operations = Object.fromEntries(Array.from(metrics.byOperation.entries()).map(([key, value]) => [key, { ...value }]));
+        const snapshot = {
+            path: databasePath || null,
+            pending: metrics.pending,
+            maxPending: metrics.maxPending,
+            total: metrics.total,
+            reads: metrics.reads,
+            writes: metrics.writes,
+            transactions: metrics.transactions,
+            failures: metrics.failures,
+            avgWaitMs: metrics.total ? Math.round(metrics.waitMs / metrics.total) : 0,
+            avgRunMs: metrics.total ? Math.round(metrics.runMs / metrics.total) : 0,
+            operations
+        };
+        if (resetPeak) metrics.maxPending = metrics.pending;
+        return snapshot;
+    },
+
+    checkpoint() {
+        return enqueue(() => normalizeRows(connection.prepare('PRAGMA wal_checkpoint(PASSIVE)').all()), { operation: 'maintenance:checkpoint', read: false });
+    },
+
+    applyBufferedCharacterState(characterId, state = {}) {
+        return inTransaction(() => applyBufferedCharacterStateUnsafe(characterId, state), 'buffered-character:flush');
+    },
+
+    applyBufferedCharacterStates(entries = []) {
+        return inTransaction(() => entries.map(([characterId, state]) => applyBufferedCharacterStateUnsafe(Number(characterId), state)), 'buffered-character:flush-batch');
+    },
+
+    syncInventorySummary(characterId, inventory = {}) {
+        return withCharacterFlush(characterId, () => inTransaction(() => {
+            const existing = all('SELECT id, selfId, amount, equipped, slot FROM items WHERE characterId = ? ORDER BY id', [characterId]);
+            const bySelfId = new Map();
+            existing.forEach((row) => {
+                const key = Number(row.selfId);
+                if (!bySelfId.has(key)) bySelfId.set(key, row);
+            });
+            Object.values(inventory).forEach((item) => {
+                const selfId = Number(item.selfId || 0);
+                const amount = Number(item.amount || 0);
+                if (!selfId) return;
+                const current = bySelfId.get(selfId);
+                if (amount <= 0) {
+                    if (current) write('DELETE FROM items WHERE id = ? AND characterId = ?', [current.id, characterId]);
+                    return;
+                }
+                const equipped = item.equipped ? 1 : 0;
+                const slot = Number(item.slot || current?.slot || 0);
+                if (current) {
+                    if (Number(current.amount) !== amount || Number(current.equipped) !== equipped || Number(current.slot) !== slot) {
+                        write('UPDATE items SET amount = ?, equipped = ?, slot = ? WHERE id = ? AND characterId = ?', [amount, equipped, slot, current.id, characterId]);
                     }
-                }),
-                migrateCharacterExperience(optn),
-                migrateCharacterStatus(),
-                migrateWarehouse(),
-                migrateMacros(),
-                migrateCharacterRecipes(),
-                migrateCharacterQuests()
-            ]).finally(callback);
+                } else {
+                    write('INSERT INTO items (selfId, name, amount, equipped, slot, characterId) VALUES (?, ?, ?, ?, ?, ?)', [selfId, item.name || `Item ${selfId}`, amount, equipped, slot, characterId]);
+                }
+            });
+            return { characterId, entries: Object.keys(inventory).length };
+        }, 'inventory:sync-summary'));
+    },
 
-        }).catch(error => {
-            utils.infoFail('DB', 'failed(%d) -> %s', error.errno, error.text);
+    createAccount(username, password) {
+        return insert('accounts', { username, password }, 'account:create');
+    },
+    fetchUserPassword(username) {
+        return selectOne('accounts', ['username', 'password'], 'username = ? COLLATE NOCASE', [username], 'account:password');
+    },
+    fetchCharacters(username) {
+        return select('characters', ['*'], 'username = ? COLLATE NOCASE', [username], 'character:by-account');
+    },
+    fetchClanCharacters() {
+        return select('characters', ['*'], 'clanId != 0', [], 'character:clan-members');
+    },
+    fetchCharacterName(name) {
+        return selectOne('characters', ['*'], 'name = ? COLLATE NOCASE', [name], 'character:by-name');
+    },
+    createCharacter(username, data) {
+        return selectOne('accounts', ['username'], 'username = ? COLLATE NOCASE', [username], 'account:canonical-name')
+            .then((accounts) => {
+                if (!accounts[0]) throw new Error('account does not exist');
+                return insert('characters', {
+                    username: accounts[0].username, name: data.name, race: data.race, classId: data.classId,
+                    maxHp: data.maxHp, maxMp: data.maxMp, sex: data.sex, face: data.face,
+                    hair: data.hair, hairColor: data.hairColor, locX: data.locX, locY: data.locY, locZ: data.locZ
+                }, 'character:create');
+            });
+    },
+    deleteCharacter(username, name) {
+        return remove('characters', 'username = ? COLLATE NOCASE AND name = ? COLLATE NOCASE', [username, name], 'character:delete');
+    },
+    fetchSkills(characterId) {
+        return select('skills', ['*'], 'characterId = ?', [characterId], 'skill:list');
+    },
+    fetchSkill(characterId, skillSelfId) {
+        return selectOne('skills', ['*'], 'characterId = ? AND selfId = ?', [characterId, skillSelfId], 'skill:one');
+    },
+    deleteSkills(characterId) {
+        return remove('skills', 'characterId = ?', [characterId], 'skill:delete-all');
+    },
+    setSkill(skill, characterId) {
+        return run(`INSERT INTO skills (selfId, name, passive, level, characterId) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(characterId, selfId) DO UPDATE SET name = excluded.name, passive = excluded.passive, level = excluded.level`,
+        [skill.selfId, skill.name, skill.passive ? 1 : 0, skill.level, characterId], 'skill:upsert');
+    },
+    updateSkillLevel(characterId, skillSelfId, skillLevel) {
+        return update('skills', { level: skillLevel }, 'selfId = ? AND characterId = ?', [skillSelfId, characterId], 'skill:level');
+    },
+    setItem(characterId, item) {
+        const values = { selfId: item.selfId, name: item.name ?? '', amount: item.amount ?? 1, equipped: item.equipped ? 1 : 0, slot: item.slot ?? 0, characterId };
+        if (item.petData) values.petData = typeof item.petData === 'string' ? item.petData : JSON.stringify(item.petData);
+        return withCharacterFlush(characterId, () => insert('items', values, 'item:insert'));
+    },
+    fetchItems(characterId) {
+        return withCharacterFlush(characterId, () => select('items', ['*'], 'characterId = ? AND amount > 0', [characterId], 'item:list'));
+    },
+    updateItemAmount(characterId, id, amount) {
+        return withCharacterFlush(characterId, () => {
+            if (Number(amount) <= 0) return remove('items', 'id = ? AND characterId = ?', [id, characterId], 'item:delete-empty');
+            return update('items', { amount }, 'id = ? AND characterId = ?', [id, characterId], 'item:amount');
         });
     },
-
-    execute: (sql) => {
-        // Do not let unrelated queries run inside an active item-transfer transaction
-        // on this shared MariaDB connection.
-        return transactionTail.then(() => conn.query(sql[0], sql[1]));
-    },
-
-    // Creates a `New Account` in the database with provided credentials
-    createAccount: (username, password) => {
-        return Database.execute(
-            builder.insert('accounts', {
-                username: username,
-                password: password
-            })
-        );
-    },
-
-    // Returns the `Password` from a provided account
-    fetchUserPassword: (username) => {
-        return Database.execute(
-            builder.selectOne('accounts', ['password'], 'username = ?', username)
-        );
-    },
-
-    // Returns the `Characters` stored on a user's account
-    fetchCharacters: (username) => {
-        return Database.execute(
-            builder.select('characters', ['*'], 'username = ?', username)
-        ).then((rows) => rows.map(normalizeRowNumbers));
-    },
-
-    fetchClanCharacters() {
-        return Database.execute(
-            builder.select('characters', ['*'], 'clanId != 0')
-        ).then((rows) => rows.map(normalizeRowNumbers));
-    },
-
-    // Checks if acharacter `Name` exists
-    fetchCharacterName: (name) => {
-        return Database.execute(
-            builder.selectOne('characters', ['*'], 'name = ?', name)
-        ).then((rows) => rows.map(normalizeRowNumbers));
-    },
-
-    // Stores a new `Character` in database with provided details
-    createCharacter(username, data) {
-        return Database.execute(
-            builder.insert('characters', {
-                 username: username,
-                     name: data.name,
-                     race: data.race,
-                  classId: data.classId,
-                    maxHp: data.maxHp,
-                    maxMp: data.maxMp,
-                      sex: data.sex,
-                     face: data.face,
-                     hair: data.hair,
-                hairColor: data.hairColor,
-                     locX: data.locX,
-                     locY: data.locY,
-                     locZ: data.locZ,
-            })
-        );
-    },
-
-    deleteCharacter(username, name) {
-        return Database.execute(
-            builder.delete('characters', 'username = ? AND name = ?', username, name)
-        );
-    },
-
-    fetchSkills(characterId) {
-        return Database.execute(
-            builder.select('skills', ['*'], 'characterId = ?', characterId)
-        );
-    },
-
-    fetchSkill(characterId, skillSelfId) {
-        return Database.execute(
-            builder.selectOne('skills', ['*'], 'characterId = ? AND selfId = ?', characterId, skillSelfId)
-        );
-    },
-
-    deleteSkills(characterId) {
-        return Database.execute(
-            builder.delete('skills', 'characterId = ?', characterId)
-        );
-    },
-
-    setSkill(skill, characterId) {
-        return Database.execute(
-            builder.insert('skills', {
-                     selfId: skill.selfId,
-                       name: skill.name,
-                    passive: skill.passive,
-                      level: skill.level,
-                characterId: characterId,
-            })
-        );
-    },
-
-    updateSkillLevel(characterId, skillSelfId, skillLevel) {
-        return Database.execute(
-            builder.update('skills', {
-                level: skillLevel
-            }, 'selfId = ? AND characterId = ?', skillSelfId, characterId)
-        );
-    },
-
-    setItem(characterId, item) {
-        const values = {
-                 selfId: item.selfId,
-                   name: item.name ?? '',
-                 amount: item.amount ?? 1,
-               equipped: item.equipped ?? false,
-                   slot: item.slot ?? 0,
-            characterId: characterId
-        };
-        if (item.petData) values.petData = JSON.stringify(item.petData);
-        return Database.execute(
-            builder.insert('items', values)
-        );
-    },
-
-    fetchItems(characterId) {
-        return Database.execute(
-            builder.select('items', ['*'], 'characterId = ?', characterId)
-        );
-    },
-
-    updateItemAmount(characterId, id, amount) {
-        return Database.execute(
-            builder.update('items', {
-                amount: amount
-            }, 'id = ? AND characterId = ?', id, characterId)
-        );
-    },
-
     updateItemEquipState(characterId, id, equipped, slot) {
-        return Database.execute(
-            builder.update('items', {
-                equipped: equipped,
-                    slot: slot
-            }, 'id = ? AND characterId = ?', id, characterId)
-        );
+        return withCharacterFlush(characterId, () => update('items', { equipped: equipped ? 1 : 0, slot }, 'id = ? AND characterId = ?', [id, characterId], 'item:equip'));
     },
-
     deleteItem(characterId, id) {
-        return Database.execute(
-            builder.delete('items', 'id = ? AND characterId = ?', id, characterId)
-        )
+        return withCharacterFlush(characterId, () => remove('items', 'id = ? AND characterId = ?', [id, characterId], 'item:delete'));
     },
-
     deleteItems(characterId) {
-        return Database.execute(
-            builder.delete('items', 'characterId = ?', characterId)
-        );
+        return withCharacterFlush(characterId, () => remove('items', 'characterId = ?', [characterId], 'item:delete-all'));
     },
-
     fetchWarehouseItems(characterId) {
-        return Database.execute(
-            builder.select('warehouse_items', ['*'], 'characterId = ?', characterId)
-        ).then((rows) => rows.map(normalizeRowNumbers));
+        return select('warehouse_items', ['*'], 'characterId = ? AND amount > 0', [characterId], 'warehouse:list');
     },
-
     setWarehouseItem(characterId, item) {
-        const values = {
-            selfId: item.selfId,
-            name: item.name ?? '',
-            amount: item.amount ?? 1,
-            characterId
-        };
-        if (item.petData) values.petData = JSON.stringify(item.petData);
-        return Database.execute(
-            builder.insert('warehouse_items', values)
-        );
+        const values = { selfId: item.selfId, name: item.name ?? '', amount: item.amount ?? 1, characterId };
+        if (item.petData) values.petData = typeof item.petData === 'string' ? item.petData : JSON.stringify(item.petData);
+        return insert('warehouse_items', values, 'warehouse:insert');
     },
-
     updateWarehouseItemAmount(characterId, id, amount) {
-        return Database.execute(
-            builder.update('warehouse_items', { amount }, 'id = ? AND characterId = ?', id, characterId)
-        );
+        if (Number(amount) <= 0) return remove('warehouse_items', 'id = ? AND characterId = ?', [id, characterId], 'warehouse:delete-empty');
+        return update('warehouse_items', { amount }, 'id = ? AND characterId = ?', [id, characterId], 'warehouse:amount');
     },
-
     deleteWarehouseItem(characterId, id) {
-        return Database.execute(
-            builder.delete('warehouse_items', 'id = ? AND characterId = ?', id, characterId)
-        );
+        return remove('warehouse_items', 'id = ? AND characterId = ?', [id, characterId], 'warehouse:delete');
     },
 
     transferInventoryToWarehouse(characterId, item) {
-        return inTransaction(async () => {
-            const inventory = await conn.query(
-                'SELECT id, amount FROM items WHERE id = ? AND characterId = ? FOR UPDATE',
-                [item.id, characterId]
-            );
-            const source = inventory[0];
-            if (!source || Number(source.amount) < item.amount) throw new Error('inventory item changed');
-
-            // Every warehouse transfer locks the inventory row first, then the
-            // warehouse row. This avoids deposit/withdraw lock inversions.
-            const existing = item.stackable ? await conn.query(
-                'SELECT id, amount FROM warehouse_items WHERE characterId = ? AND selfId = ? FOR UPDATE',
-                [characterId, item.selfId]
-            ) : [];
-            const target = existing[0];
-            const warehouseAmount = (Number(target?.amount) || 0) + item.amount;
-            let warehouseId = target?.id;
-
-            if (target) {
-                await conn.query('UPDATE warehouse_items SET amount = ? WHERE id = ? AND characterId = ?', [warehouseAmount, warehouseId, characterId]);
-            } else {
-                const inserted = await conn.query(
-                    'INSERT INTO warehouse_items (selfId, name, amount, petData, characterId) VALUES (?, ?, ?, ?, ?)',
-                    [item.selfId, item.name || '', item.amount, petDataValue(item.petData), characterId]
-                );
-                warehouseId = Number(inserted.insertId);
-            }
-
-            const inventoryAmount = Number(source.amount) - item.amount;
-            if (inventoryAmount === 0) {
-                await conn.query('DELETE FROM items WHERE id = ? AND characterId = ?', [item.id, characterId]);
-            } else {
-                await conn.query('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [inventoryAmount, item.id, characterId]);
-            }
-            return { warehouseId, warehouseAmount, inventoryAmount };
-        });
+        return withCharacterFlush(characterId, () => inTransaction(() => {
+            const source = one('SELECT id, amount FROM items WHERE id = ? AND characterId = ?', [item.id, characterId]);
+            if (!source || Number(source.amount) < Number(item.amount)) throw new Error('inventory item changed');
+            const target = item.stackable ? one('SELECT id, amount FROM warehouse_items WHERE characterId = ? AND selfId = ? ORDER BY id LIMIT 1', [characterId, item.selfId]) : null;
+            const warehouseAmount = Number(target?.amount || 0) + Number(item.amount);
+            const warehouseId = target ? target.id : write('INSERT INTO warehouse_items (selfId, name, amount, petData, characterId) VALUES (?, ?, ?, ?, ?)', [item.selfId, item.name || '', item.amount, item.petData ? JSON.stringify(item.petData) : null, characterId]).insertId;
+            if (target) write('UPDATE warehouse_items SET amount = ? WHERE id = ? AND characterId = ?', [warehouseAmount, warehouseId, characterId]);
+            const inventoryAmount = Number(source.amount) - Number(item.amount);
+            if (inventoryAmount <= 0) write('DELETE FROM items WHERE id = ? AND characterId = ?', [item.id, characterId]);
+            else write('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [inventoryAmount, item.id, characterId]);
+            return { warehouseId: Number(warehouseId), warehouseAmount, inventoryAmount };
+        }, 'warehouse:deposit'));
     },
 
     transferWarehouseToInventory(characterId, item) {
-        return inTransaction(async () => {
-            // Keep the same lock order as deposits: inventory first, warehouse second.
-            const existing = item.stackable ? await conn.query(
-                'SELECT id, amount FROM items WHERE characterId = ? AND selfId = ? FOR UPDATE',
-                [characterId, item.selfId]
-            ) : [];
-            const target = existing[0];
-            const warehouse = await conn.query(
-                'SELECT id, amount, petData FROM warehouse_items WHERE id = ? AND characterId = ? FOR UPDATE',
-                [item.id, characterId]
-            );
-            const source = warehouse[0];
-            if (!source || Number(source.amount) < item.amount) throw new Error('warehouse item changed');
-
-            const inventoryAmount = (Number(target?.amount) || 0) + item.amount;
-            let inventoryId = target?.id;
-            if (target) {
-                await conn.query('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [inventoryAmount, inventoryId, characterId]);
-            } else {
-                const inserted = await conn.query(
-                    'INSERT INTO items (selfId, name, amount, equipped, slot, petData, characterId) VALUES (?, ?, ?, ?, ?, ?, ?)',
-                    [item.selfId, item.name || '', item.amount, false, 0, source.petData, characterId]
-                );
-                inventoryId = Number(inserted.insertId);
-            }
-
-            const warehouseAmount = Number(source.amount) - item.amount;
-            if (warehouseAmount === 0) {
-                await conn.query('DELETE FROM warehouse_items WHERE id = ? AND characterId = ?', [item.id, characterId]);
-            } else {
-                await conn.query('UPDATE warehouse_items SET amount = ? WHERE id = ? AND characterId = ?', [warehouseAmount, item.id, characterId]);
-            }
-            return { inventoryId, inventoryAmount, warehouseAmount, petData: source.petData };
-        });
+        return withCharacterFlush(characterId, () => inTransaction(() => {
+            const source = one('SELECT id, amount, petData FROM warehouse_items WHERE id = ? AND characterId = ?', [item.id, characterId]);
+            if (!source || Number(source.amount) < Number(item.amount)) throw new Error('warehouse item changed');
+            const target = item.stackable ? one('SELECT id, amount FROM items WHERE characterId = ? AND selfId = ? ORDER BY id LIMIT 1', [characterId, item.selfId]) : null;
+            const inventoryAmount = Number(target?.amount || 0) + Number(item.amount);
+            const inventoryId = target ? target.id : write('INSERT INTO items (selfId, name, amount, equipped, slot, petData, characterId) VALUES (?, ?, ?, 0, 0, ?, ?)', [item.selfId, item.name || '', item.amount, source.petData, characterId]).insertId;
+            if (target) write('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [inventoryAmount, inventoryId, characterId]);
+            const warehouseAmount = Number(source.amount) - Number(item.amount);
+            if (warehouseAmount <= 0) write('DELETE FROM warehouse_items WHERE id = ? AND characterId = ?', [item.id, characterId]);
+            else write('UPDATE warehouse_items SET amount = ? WHERE id = ? AND characterId = ?', [warehouseAmount, item.id, characterId]);
+            return { inventoryId: Number(inventoryId), inventoryAmount, warehouseAmount, petData: source.petData };
+        }, 'warehouse:withdraw'));
     },
 
-    fetchCharacterQuests(characterId) {
-        return Database.execute(
-            builder.select('character_quests', ['*'], 'characterId = ?', characterId)
-        ).then((rows) => rows.map(normalizeRowNumbers));
-    },
-
-    setCharacterQuest(characterId, questId, state, variables) {
-        return Database.execute([
-            `INSERT INTO character_quests (characterId, questId, state, variables)
-             VALUES (?, ?, ?, ?)
-             ON DUPLICATE KEY UPDATE state = VALUES(state), variables = VALUES(variables)`,
-            [characterId, questId, state, JSON.stringify(variables || {})]
-        ]);
-    },
-
-    deleteCharacterQuest(characterId, questId) {
-        return Database.execute(
-            builder.delete('character_quests', 'characterId = ? AND questId = ?', characterId, questId)
-        );
-    },
-
-    fetchCharacterRecipes(characterId) {
-        return Database.execute([
-            'SELECT recipeId, type FROM character_recipes WHERE characterId = ?',
-            [characterId]
-        ]).then((rows) => rows.map(normalizeRowNumbers));
-    },
-
-    setCharacterRecipe(characterId, recipeId, type) {
-        return Database.execute([
-            'INSERT INTO character_recipes (characterId, recipeId, type) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE recipeId = VALUES(recipeId)',
-            [characterId, recipeId, type]
-        ]);
-    },
+    fetchCharacterQuests(characterId) { return select('character_quests', ['*'], 'characterId = ?', [characterId], 'quest:list'); },
+    setCharacterQuest(characterId, questId, state, variables) { return run(UPSERT_CHARACTER_QUEST, [characterId, questId, state, JSON.stringify(variables || {})], 'quest:upsert'); },
+    deleteCharacterQuest(characterId, questId) { return remove('character_quests', 'characterId = ? AND questId = ?', [characterId, questId], 'quest:delete'); },
+    fetchCharacterRecipes(characterId) { return run('SELECT recipeId, type FROM character_recipes WHERE characterId = ?', [characterId], 'recipe:list'); },
+    setCharacterRecipe(characterId, recipeId, type) { return run(UPSERT_RECIPE, [characterId, recipeId, type], 'recipe:upsert'); },
 
     craftInventoryItems(characterId, { materials, product, mp }) {
-        return inTransaction(async () => {
+        return withCharacterFlush(characterId, () => inTransaction(() => {
             const sources = [];
             for (const material of [...materials].sort((left, right) => Number(left.id) - Number(right.id))) {
-                const rows = await conn.query(
-                    'SELECT id, selfId, amount FROM items WHERE id = ? AND characterId = ? FOR UPDATE',
-                    [material.id, characterId]
-                );
-                const source = rows[0];
-                if (!source || Number(source.selfId) !== Number(material.selfId) || Number(source.amount) < Number(material.amount)) {
-                    throw new Error('craft material changed');
-                }
+                const source = one('SELECT id, selfId, amount FROM items WHERE id = ? AND characterId = ?', [material.id, characterId]);
+                if (!source || Number(source.selfId) !== Number(material.selfId) || Number(source.amount) < Number(material.amount)) throw new Error('craft material changed');
                 sources.push({ id: Number(source.id), amount: Number(source.amount) - Number(material.amount) });
             }
-
-            const targets = product?.stackable ? await conn.query(
-                'SELECT id, amount FROM items WHERE characterId = ? AND selfId = ? FOR UPDATE',
-                [characterId, product.selfId]
-            ) : [];
-            const target = targets[0];
-            const productAmount = (Number(target?.amount) || 0) + Number(product?.amount || 0);
-            let productId = Number(target?.id) || 0;
-
-            for (const source of sources) {
-                if (source.amount === 0) {
-                    await conn.query('DELETE FROM items WHERE id = ? AND characterId = ?', [source.id, characterId]);
-                } else {
-                    await conn.query('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [source.amount, source.id, characterId]);
-                }
-            }
-
-            if (target) {
-                await conn.query('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [productAmount, productId, characterId]);
-            } else if (product) {
-                const inserted = await conn.query(
-                    'INSERT INTO items (selfId, name, amount, equipped, slot, characterId) VALUES (?, ?, ?, ?, ?, ?)',
-                    [product.selfId, product.name || '', product.amount, false, product.slot || 0, characterId]
-                );
-                productId = Number(inserted.insertId);
-            }
-
-            await conn.query('UPDATE characters SET mp = ? WHERE id = ?', [mp, characterId]);
+            const target = product?.stackable ? one('SELECT id, amount FROM items WHERE characterId = ? AND selfId = ? ORDER BY id LIMIT 1', [characterId, product.selfId]) : null;
+            let productId = Number(target?.id || 0);
+            const productAmount = Number(target?.amount || 0) + Number(product?.amount || 0);
+            sources.forEach((source) => source.amount <= 0 ? write('DELETE FROM items WHERE id = ? AND characterId = ?', [source.id, characterId]) : write('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [source.amount, source.id, characterId]));
+            if (target) write('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [productAmount, productId, characterId]);
+            else if (product) productId = write('INSERT INTO items (selfId, name, amount, equipped, slot, characterId) VALUES (?, ?, ?, 0, ?, ?)', [product.selfId, product.name || '', product.amount, product.slot || 0, characterId]).insertId;
+            write('UPDATE characters SET mp = ? WHERE id = ?', [mp, characterId]);
             return { sources, product: product ? { id: productId, amount: productAmount } : null };
-        });
+        }, 'craft:self'));
     },
 
     crystallizeInventoryItem(characterId, { sourceId, sourceSelfId, crystalId, crystalName, crystalAmount }) {
-        return inTransaction(async () => {
-            const source = (await conn.query('SELECT id, selfId, amount, equipped FROM items WHERE id = ? AND characterId = ? FOR UPDATE', [sourceId, characterId]))[0];
+        return withCharacterFlush(characterId, () => inTransaction(() => {
+            const source = one('SELECT id, selfId, amount, equipped FROM items WHERE id = ? AND characterId = ?', [sourceId, characterId]);
             if (!source || Number(source.selfId) !== Number(sourceSelfId) || Number(source.amount) !== 1 || Number(source.equipped) !== 0) throw new Error('crystallize source changed');
-            const existing = (await conn.query('SELECT id, amount FROM items WHERE characterId = ? AND selfId = ? FOR UPDATE', [characterId, crystalId]))[0];
-            const amount = (Number(existing?.amount) || 0) + crystalAmount;
-            let id = Number(existing?.id) || 0;
-            await conn.query('DELETE FROM items WHERE id = ? AND characterId = ?', [sourceId, characterId]);
-            if (existing) await conn.query('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [amount, id, characterId]);
-            else { const inserted = await conn.query('INSERT INTO items (selfId, name, amount, equipped, slot, characterId) VALUES (?, ?, ?, ?, ?, ?)', [crystalId, crystalName || '', crystalAmount, false, 0, characterId]); id = Number(inserted.insertId); }
+            const target = one('SELECT id, amount FROM items WHERE characterId = ? AND selfId = ? ORDER BY id LIMIT 1', [characterId, crystalId]);
+            const amount = Number(target?.amount || 0) + Number(crystalAmount);
+            let id = Number(target?.id || 0);
+            write('DELETE FROM items WHERE id = ? AND characterId = ?', [sourceId, characterId]);
+            if (target) write('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [amount, id, characterId]);
+            else id = write('INSERT INTO items (selfId, name, amount, equipped, slot, characterId) VALUES (?, ?, ?, 0, 0, ?)', [crystalId, crystalName || '', crystalAmount, characterId]).insertId;
             return { crystalId, id, amount };
-        });
+        }, 'crystalize'));
     },
 
     craftForCustomer(crafterId, customerId, { materials, product, crafterMp, price, adena }) {
-        return inTransaction(async () => {
+        return withCharacterFlushes([crafterId, customerId], () => inTransaction(() => {
             const sources = [];
             for (const material of [...materials].sort((left, right) => Number(left.id) - Number(right.id))) {
-                const rows = await conn.query(
-                    'SELECT id, selfId, amount FROM items WHERE id = ? AND characterId = ? FOR UPDATE',
-                    [material.id, customerId]
-                );
-                const source = rows[0];
-                if (!source || Number(source.selfId) !== Number(material.selfId) || Number(source.amount) < Number(material.amount)) {
-                    throw new Error('customer craft material changed');
-                }
+                const source = one('SELECT id, selfId, amount FROM items WHERE id = ? AND characterId = ?', [material.id, customerId]);
+                if (!source || Number(source.selfId) !== Number(material.selfId) || Number(source.amount) < Number(material.amount)) throw new Error('customer craft material changed');
                 sources.push({ id: Number(source.id), amount: Number(source.amount) - Number(material.amount) });
             }
-
             const fee = Number(price) || 0;
-            let customerAdena = null;
-            let crafterAdena = null;
+            const customerAdena = fee > 0 ? one('SELECT id, amount FROM items WHERE characterId = ? AND selfId = 57 ORDER BY id LIMIT 1', [customerId]) : null;
+            if (fee > 0 && (!customerAdena || Number(customerAdena.amount) < fee)) throw new Error('customer adena changed');
+            let crafterAdena = fee > 0 ? one('SELECT id, amount FROM items WHERE characterId = ? AND selfId = 57 ORDER BY id LIMIT 1', [crafterId]) : null;
+            const target = product?.stackable ? one('SELECT id, amount FROM items WHERE characterId = ? AND selfId = ? ORDER BY id LIMIT 1', [customerId, product.selfId]) : null;
+            let productId = Number(target?.id || 0);
+            const productAmount = Number(target?.amount || 0) + Number(product?.amount || 0);
+            sources.forEach((source) => source.amount <= 0 ? write('DELETE FROM items WHERE id = ? AND characterId = ?', [source.id, customerId]) : write('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [source.amount, source.id, customerId]));
+            if (target) write('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [productAmount, productId, customerId]);
+            else if (product) productId = write('INSERT INTO items (selfId, name, amount, equipped, slot, characterId) VALUES (?, ?, ?, 0, ?, ?)', [product.selfId, product.name || '', product.amount, product.slot || 0, customerId]).insertId;
+            let nextCrafterAdena = null;
             if (fee > 0) {
-                customerAdena = (await conn.query(
-                    'SELECT id, amount FROM items WHERE characterId = ? AND selfId = 57 FOR UPDATE', [customerId]
-                ))[0];
-                if (!customerAdena || Number(customerAdena.amount) < fee) throw new Error('customer adena changed');
-                crafterAdena = (await conn.query(
-                    'SELECT id, amount FROM items WHERE characterId = ? AND selfId = 57 FOR UPDATE', [crafterId]
-                ))[0];
-            }
-
-            const targets = product?.stackable ? await conn.query(
-                'SELECT id, amount FROM items WHERE characterId = ? AND selfId = ? FOR UPDATE',
-                [customerId, product.selfId]
-            ) : [];
-            const target = targets[0];
-            const productAmount = (Number(target?.amount) || 0) + Number(product?.amount || 0);
-            let productId = Number(target?.id) || 0;
-
-            for (const source of sources) {
-                if (source.amount === 0) {
-                    await conn.query('DELETE FROM items WHERE id = ? AND characterId = ?', [source.id, customerId]);
-                } else {
-                    await conn.query('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [source.amount, source.id, customerId]);
-                }
-            }
-
-            if (target) {
-                await conn.query('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [productAmount, productId, customerId]);
-            } else if (product) {
-                const inserted = await conn.query(
-                    'INSERT INTO items (selfId, name, amount, equipped, slot, characterId) VALUES (?, ?, ?, ?, ?, ?)',
-                    [product.selfId, product.name || '', product.amount, false, product.slot || 0, customerId]
-                );
-                productId = Number(inserted.insertId);
-            }
-
-            if (fee > 0) {
-                await conn.query('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [
-                    Number(customerAdena.amount) - fee, customerAdena.id, customerId
-                ]);
+                write('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [Number(customerAdena.amount) - fee, customerAdena.id, customerId]);
                 if (crafterAdena) {
-                    await conn.query('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [
-                        Number(crafterAdena.amount) + fee, crafterAdena.id, crafterId
-                    ]);
+                    nextCrafterAdena = Number(crafterAdena.amount) + fee;
+                    write('UPDATE items SET amount = ? WHERE id = ? AND characterId = ?', [nextCrafterAdena, crafterAdena.id, crafterId]);
                 } else {
-                    const inserted = await conn.query(
-                        'INSERT INTO items (selfId, name, amount, equipped, slot, characterId) VALUES (?, ?, ?, ?, ?, ?)',
-                        [57, adena?.name || 'Adena', fee, false, 0, crafterId]
-                    );
-                    crafterAdena = { id: Number(inserted.insertId), amount: 0 };
+                    const id = write('INSERT INTO items (selfId, name, amount, equipped, slot, characterId) VALUES (57, ?, ?, 0, 0, ?)', [adena?.name || 'Adena', fee, crafterId]).insertId;
+                    nextCrafterAdena = fee;
+                    crafterAdena = { id, amount: 0 };
                 }
             }
-
-            await conn.query('UPDATE characters SET mp = ? WHERE id = ?', [crafterMp, crafterId]);
-            return {
-                sources,
-                product: product ? { id: productId, amount: productAmount } : null,
-                customerAdena: fee > 0 ? { id: Number(customerAdena.id), amount: Number(customerAdena.amount) - fee } : null,
-                crafterAdena: fee > 0 ? { id: Number(crafterAdena.id), amount: Number(crafterAdena.amount) + fee } : null
-            };
-        });
+            write('UPDATE characters SET mp = ? WHERE id = ?', [crafterMp, crafterId]);
+            return { sources, product: product ? { id: productId, amount: productAmount } : null, customerAdena: fee > 0 ? { id: Number(customerAdena.id), amount: Number(customerAdena.amount) - fee } : null, crafterAdena: fee > 0 ? { id: Number(crafterAdena.id), amount: nextCrafterAdena } : null };
+        }, 'craft:customer'));
     },
 
-    updateItemPetData(characterId, id, petData) {
-        return Database.execute(
-            builder.update('items', {
-                petData: JSON.stringify(petData || {})
-            }, 'id = ? AND characterId = ?', id, characterId)
-        );
-    },
-
-    fetchClans() {
-        return Database.execute(
-            builder.select('clans', ['*'])
-        );
-    },
-
-    createClanCrest(clanId, kind, data) {
-        return Database.execute([
-            'INSERT INTO clan_crests (clanId, kind, data) VALUES (?, ?, ?)',
-            [clanId, kind, data]
-        ]);
-    },
-
-    fetchClanCrest(id) {
-        return Database.execute(
-            builder.selectOne('clan_crests', ['*'], 'id = ? LIMIT 1', id)
-        );
-    },
-
-    createClan(data) {
-        return Database.execute(
-            builder.insert('clans', {
-                name: data.name,
-                leaderId: data.leaderId
-            })
-        );
-    },
-
-    updateClanCrest(id, crestId) {
-        return Database.execute(
-            builder.update('clans', {
-                crestId: crestId
-            }, 'id = ? LIMIT 1', id)
-        );
-    },
-
-    updateClanLevel(id, level) {
-        return Database.execute(
-            builder.update('clans', {
-                level: level
-            }, 'id = ? LIMIT 1', id)
-        );
-    },
-
-    updateCharacterClan(id, clanId, clanPrivileges, clanJoinExpiryTime, clanCreateExpiryTime) {
-        return Database.execute(
-            builder.update('characters', {
-                clanId: clanId,
-                clanPrivileges: clanPrivileges,
-                clanJoinExpiryTime: clanJoinExpiryTime,
-                clanCreateExpiryTime: clanCreateExpiryTime
-            }, 'id = ? LIMIT 1', id)
-        );
-    },
-
-    updateCharacterClanPrivileges(id, clanPrivileges) {
-        return Database.execute(
-            builder.update('characters', {
-                clanPrivileges: clanPrivileges
-            }, 'id = ? LIMIT 1', id)
-        );
-    },
-
-    deleteGearItems(characterId) {
-        return Database.execute(
-            builder.delete('items', 'characterId = ? AND selfId != 57', characterId)
-        );
-    },
-
-    setShortcut(characterId, shortcut) {
-        return Database.execute(
-            builder.insert('shortcuts', {
-                         id: shortcut.id,
-                       kind: shortcut.kind,
-                       slot: shortcut.slot,
-                    unknown: shortcut.unknown,
-                characterId: characterId
-            })
-        );
-    },
-
-    fetchShortcuts(characterId) {
-        return Database.execute(
-            builder.select('shortcuts', ['*'], 'characterId = ?', characterId)
-        );
-    },
-
-    deleteShortcut(characterId, slot) {
-        return Database.execute(
-            builder.delete('shortcuts', 'slot = ? AND characterId = ?', slot, characterId)
-        )
-    },
-
-    deleteShortcuts(characterId) {
-        return Database.execute(
-            builder.delete('shortcuts', 'characterId = ?', characterId)
-        );
-    },
-
-    setMacro(characterId, macro) {
-        return Database.execute([
-            `INSERT INTO macros (characterId, id, icon, name, descr, acronym, commands)
-             VALUES (?, ?, ?, ?, ?, ?, ?)
-             ON DUPLICATE KEY UPDATE icon = VALUES(icon), name = VALUES(name), descr = VALUES(descr),
-                 acronym = VALUES(acronym), commands = VALUES(commands)`,
-            [characterId, macro.id, macro.icon, macro.name, macro.descr, macro.acronym, JSON.stringify(macro.commands)]
-        ]);
-    },
-
-    fetchMacros(characterId) {
-        return Database.execute(
-            builder.select('macros', ['*'], 'characterId = ?', characterId)
-        ).then((rows) => rows.map((row) => ({
-            ...normalizeRowNumbers(row),
-            commands: (() => {
-                try { return JSON.parse(row.commands); }
-                catch (_) { return []; }
-            })()
-        })));
-    },
-
-    deleteMacro(characterId, macroId) {
-        return Database.execute(
-            builder.delete('macros', 'characterId = ? AND id = ?', characterId, macroId)
-        );
-    },
-
-    deleteMacros(characterId) {
-        return Database.execute(
-            builder.delete('macros', 'characterId = ?', characterId)
-        );
-    },
-
-    deleteMacroShortcuts(characterId, macroId) {
-        return Database.execute(
-            builder.delete('shortcuts', 'characterId = ? AND kind = 4 AND id = ?', characterId, macroId)
-        );
-    },
-
-    updateCharacterLocation(id, coords) {
-        return Database.execute(
-            builder.update('characters', {
-                locX: coords.locX,
-                locY: coords.locY,
-                locZ: coords.locZ,
-                head: coords.head ?? -1,
-            }, 'id = ? LIMIT 1', id)
-        );
-    },
-
-    updateCharacterName(id, name) {
-        return Database.execute(
-            builder.update('characters', {
-                name: name
-            }, 'id = ? LIMIT 1', id)
-        );
-    },
-
-    updateCharacterExperience(id, level, exp, sp) {
-        return Database.execute(
-            builder.update('characters', {
-                level: level,
-                  exp: exp,
-                   sp: sp
-            }, 'id = ? LIMIT 1', id)
-        );
-    },
-
-    updateCharacterVitals(id, hp, maxHp, mp, maxMp) {
-        return Database.execute(
-            builder.update('characters', {
-                   hp: hp,
-                maxHp: maxHp,
-                   mp: mp,
-                maxMp: maxMp,
-            }, 'id = ? LIMIT 1', id)
-        );
-    },
-
-    updateCharacterStatus(id, { hp, mp, cp, effects }) {
-        return Database.execute(
-            builder.update('characters', {
-                hp,
-                mp,
-                cp,
-                effects
-            }, 'id = ? LIMIT 1', id)
-        );
-    },
-
-    updateCharacterPvpPkKarma(id, pvp, pk, karma) {
-        return Database.execute(
-            builder.update('characters', {
-                  pvp: pvp,
-                   pk: pk,
-                karma: karma
-            }, 'id = ? LIMIT 1', id)
-        );
-    },
-
-    updateCharacterClassId(id, classId) {
-        return Database.execute(
-            builder.update('characters', {
-                classId: classId
-            }, 'id = ? LIMIT 1', id)
-        );
-    }
+    updateItemPetData(characterId, id, petData) { return withCharacterFlush(characterId, () => update('items', { petData: JSON.stringify(petData || {}) }, 'id = ? AND characterId = ?', [id, characterId], 'item:pet')); },
+    fetchClans() { return select('clans', ['*'], '', [], 'clan:list'); },
+    createClanCrest(clanId, kind, data) { return insert('clan_crests', { clanId, kind, data, createdAt: now() }, 'clan:crest-create'); },
+    fetchClanCrest(id) { return selectOne('clan_crests', ['*'], 'id = ?', [id], 'clan:crest'); },
+    createClan(data) { return insert('clans', { name: data.name, leaderId: data.leaderId }, 'clan:create'); },
+    updateClanCrest(id, crestId) { return update('clans', { crestId }, 'id = ?', [id], 'clan:crest'); },
+    updateClanLevel(id, level) { return update('clans', { level }, 'id = ?', [id], 'clan:level'); },
+    updateCharacterClan(id, clanId, clanPrivileges, clanJoinExpiryTime, clanCreateExpiryTime) { return update('characters', { clanId, clanPrivileges, clanJoinExpiryTime, clanCreateExpiryTime }, 'id = ?', [id], 'character:clan'); },
+    updateCharacterClanPrivileges(id, clanPrivileges) { return update('characters', { clanPrivileges }, 'id = ?', [id], 'character:clan-privileges'); },
+    deleteGearItems(characterId) { return withCharacterFlush(characterId, () => remove('items', 'characterId = ? AND selfId != 57', [characterId], 'item:delete-gear')); },
+    setShortcut(characterId, shortcut) { return run(`INSERT INTO shortcuts (id, kind, slot, unknown, characterId) VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(characterId, slot) DO UPDATE SET id = excluded.id, kind = excluded.kind, unknown = excluded.unknown`, [shortcut.id, shortcut.kind, shortcut.slot, shortcut.unknown, characterId], 'shortcut:upsert'); },
+    fetchShortcuts(characterId) { return select('shortcuts', ['*'], 'characterId = ?', [characterId], 'shortcut:list'); },
+    deleteShortcut(characterId, slot) { return remove('shortcuts', 'slot = ? AND characterId = ?', [slot, characterId], 'shortcut:delete'); },
+    deleteShortcuts(characterId) { return remove('shortcuts', 'characterId = ?', [characterId], 'shortcut:delete-all'); },
+    setMacro(characterId, macro) { return run(UPSERT_MACRO, [characterId, macro.id, macro.icon, macro.name, macro.descr, macro.acronym, JSON.stringify(macro.commands)], 'macro:upsert'); },
+    fetchMacros(characterId) { return select('macros', ['*'], 'characterId = ?', [characterId], 'macro:list').then((rows) => rows.map((row) => ({ ...row, commands: (() => { try { return JSON.parse(row.commands); } catch (_) { return []; } })() }))); },
+    deleteMacro(characterId, macroId) { return remove('macros', 'characterId = ? AND id = ?', [characterId, macroId], 'macro:delete'); },
+    deleteMacros(characterId) { return remove('macros', 'characterId = ?', [characterId], 'macro:delete-all'); },
+    deleteMacroShortcuts(characterId, macroId) { return remove('shortcuts', 'characterId = ? AND kind = 4 AND id = ?', [characterId, macroId], 'shortcut:delete-macro'); },
+    updateCharacterLocation(id, coords) { return withCharacterFlush(id, () => update('characters', { locX: coords.locX, locY: coords.locY, locZ: coords.locZ, head: coords.head ?? -1 }, 'id = ?', [id], 'character:location')); },
+    updateCharacterName(id, name) { return withCharacterFlush(id, () => update('characters', { name }, 'id = ?', [id], 'character:name')); },
+    updateCharacterExperience(id, level, exp, sp) { return withCharacterFlush(id, () => update('characters', { level, exp, sp }, 'id = ?', [id], 'character:experience')); },
+    updateCharacterVitals(id, hp, maxHp, mp, maxMp) { return withCharacterFlush(id, () => update('characters', { hp, maxHp, mp, maxMp }, 'id = ?', [id], 'character:vitals')); },
+    updateCharacterStatus(id, { hp, mp, cp, effects }) { return withCharacterFlush(id, () => update('characters', { hp, mp, cp, effects }, 'id = ?', [id], 'character:status')); },
+    updateCharacterPvpPkKarma(id, pvp, pk, karma) { return withCharacterFlush(id, () => update('characters', { pvp, pk, karma }, 'id = ?', [id], 'character:karma')); },
+    updateCharacterClassId(id, classId) { return withCharacterFlush(id, () => update('characters', { classId }, 'id = ?', [id], 'character:class')); }
 };
 
 module.exports = Database;

--- a/src/Database.js
+++ b/src/Database.js
@@ -6,6 +6,11 @@ let connection;
 let queryTail = Promise.resolve();
 let databasePath;
 let flushPendingCharacterWrites = null;
+const cooperative = {
+    depth: 0,
+    sliceStartedAt: 0,
+    sliceMs: 0
+};
 
 const metrics = {
     pending: 0,
@@ -22,6 +27,10 @@ const metrics = {
 
 function now() {
     return Date.now();
+}
+
+function yieldToEventLoop() {
+    return new Promise((resolve) => setImmediate(resolve));
 }
 
 function normalizeValue(value) {
@@ -93,7 +102,17 @@ function enqueue(work, { operation = 'raw', read = false } = {}) {
             metrics.pending -= 1;
         }
     };
-    const result = queryTail.then(execute, execute);
+    const queued = queryTail.then(execute, execute);
+    const cooperativeQueue = cooperative.depth > 0;
+    const result = cooperativeQueue
+        ? queued.then((value) => {
+            if (cooperative.depth <= 0 || now() - cooperative.sliceStartedAt < cooperative.sliceMs) return value;
+            return yieldToEventLoop().then(() => {
+                cooperative.sliceStartedAt = now();
+                return value;
+            });
+        })
+        : queued;
     queryTail = result.catch(() => null);
     return result;
 }
@@ -255,6 +274,22 @@ const Database = {
 
     registerCharacterWriteFlush(flush) {
         flushPendingCharacterWrites = typeof flush === 'function' ? flush : null;
+    },
+
+    cooperatively(work, sliceMs = 12) {
+        const outermost = cooperative.depth === 0;
+        if (outermost) {
+            cooperative.sliceStartedAt = now();
+            cooperative.sliceMs = Math.max(1, Number(sliceMs) || 12);
+        }
+        cooperative.depth += 1;
+        return Promise.resolve().then(work).finally(() => {
+            cooperative.depth -= 1;
+            if (cooperative.depth === 0) {
+                cooperative.sliceStartedAt = 0;
+                cooperative.sliceMs = 0;
+            }
+        });
     },
 
     stats({ resetPeak = false } = {}) {

--- a/src/GameServer/Actor/Backpack.js
+++ b/src/GameServer/Actor/Backpack.js
@@ -7,6 +7,7 @@ const DataCache      = invoke('GameServer/DataCache');
 const ConsoleText    = invoke('GameServer/ConsoleText');
 const World          = invoke('GameServer/World/World');
 const Database       = invoke('Database');
+const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
 const ShotStock      = invoke('GameServer/Inventory/ShotStock');
 const SkillEffects   = invoke('GameServer/Skills/C4SkillEffects');
 const C4ItemSkills   = invoke('GameServer/Items/C4ItemSkills');
@@ -81,10 +82,7 @@ class Backpack extends BackpackModel {
                 session.dataSendToMe(ServerResponse.itemsList(this.fetchItems()));
                 callback(item.fetchSelfId());
 
-                // Update database in the background
-                Database.updateItemAmount(session.actor.fetchId(), item.fetchId(), total).catch((err) => {
-                    utils.infoWarn('Database', 'Failed to update item amount: ' + err);
-                });
+                CharacterWriteQueue.itemAmount(session.actor.fetchId(), item.fetchId(), total);
             }
             else {
                 // Update memory state instantly
@@ -92,10 +90,7 @@ class Backpack extends BackpackModel {
                 session.dataSendToMe(ServerResponse.itemsList(this.fetchItems()));
                 callback(item.fetchSelfId());
 
-                // Update database in the background
-                Database.deleteItem(session.actor.fetchId(), item.fetchId()).catch((err) => {
-                    utils.infoWarn('Database', 'Failed to delete item: ' + err);
-                });
+                CharacterWriteQueue.itemAmount(session.actor.fetchId(), item.fetchId(), 0);
             }
         });
     }

--- a/src/GameServer/Actor/Generics/ExperienceReward.js
+++ b/src/GameServer/Actor/Generics/ExperienceReward.js
@@ -1,7 +1,7 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const DataCache      = invoke('GameServer/DataCache');
 const ConsoleText    = invoke('GameServer/ConsoleText');
-const Database       = invoke('Database');
+const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
 const ProgressionRates = invoke('GameServer/ProgressionRates');
 const Karma = invoke('GameServer/Karma');
 const EffectStats = invoke('GameServer/Effects/EffectStats');
@@ -47,9 +47,9 @@ function experienceReward(session, actor, exp, sp) {
     session.dataSendToMe(ServerResponse.userInfo(actor));
 
     // Update database with new exp, sp
-    Database.updateCharacterExperience(actor.fetchId(), actor.fetchLevel(), totalExp, totalSp);
+    CharacterWriteQueue.experience(actor.fetchId(), actor.fetchLevel(), totalExp, totalSp);
     if (karmaLost > 0) {
-        Database.updateCharacterPvpPkKarma(actor.fetchId(), actor.fetchPvp(), actor.fetchPk(), actor.fetchKarma());
+        CharacterWriteQueue.karma(actor.fetchId(), actor.fetchPvp(), actor.fetchPk(), actor.fetchKarma());
     }
 }
 

--- a/src/GameServer/Actor/Generics/LevelUp.js
+++ b/src/GameServer/Actor/Generics/LevelUp.js
@@ -1,7 +1,7 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const DataCache      = invoke('GameServer/DataCache');
 const ConsoleText    = invoke('GameServer/ConsoleText');
-const Database       = invoke('Database');
+const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
 
 function levelUp(session, actor, nextLevel) {
     // Update stats
@@ -46,7 +46,7 @@ function levelUp(session, actor, nextLevel) {
             // A bot has no client of its own, so nearby players and party
             // members need the normal character refresh after a profession.
             session.dataSendToOthers?.(ServerResponse.charInfo(actor), actor);
-            Database.updateCharacterVitals(id, actor.fetchHp(), actor.fetchMaxHp(), actor.fetchMp(), actor.fetchMaxMp());
+            CharacterWriteQueue.vitals(id, actor.fetchHp(), actor.fetchMaxHp(), actor.fetchMp(), actor.fetchMaxMp());
         }
     })
 
@@ -55,7 +55,7 @@ function levelUp(session, actor, nextLevel) {
     ConsoleText.transmit(session, ConsoleText.caption.levelUp);
 
     // Update database with new hp, mp
-    Database.updateCharacterVitals(id, hp, maxHp, mp, maxMp);
+    CharacterWriteQueue.vitals(id, hp, maxHp, mp, maxMp);
 
     const ClanService = invoke('GameServer/Clan/ClanService');
     const clanUpdate = ClanService.updateActorMember(actor);

--- a/src/GameServer/Actor/Generics/UpdatePosition.js
+++ b/src/GameServer/Actor/Generics/UpdatePosition.js
@@ -1,4 +1,4 @@
-const Database = invoke('Database');
+const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
 const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
 
 function updatePosition(session, actor, coords, environmentOptions) {
@@ -12,7 +12,7 @@ function updatePosition(session, actor, coords, environmentOptions) {
 
     // TODO: Write less in DB about movement
     actor.setLocXYZH(coords);
-    Database.updateCharacterLocation(actor.fetchId(), coords);
+    CharacterWriteQueue.location(actor.fetchId(), coords);
 
     // Update Online users, NPCs, underwater locations
     Generics.updateEnvironment(session, actor, environmentOptions);

--- a/src/GameServer/Bot/AI/BotSocialMemory.js
+++ b/src/GameServer/Bot/AI/BotSocialMemory.js
@@ -151,22 +151,22 @@ function save(record) {
             groupRuns, wipesTogether, helpedInCombat, gaveUsefulLoot, ignoredLootRequests,
             tradesCompleted, insults, recentlyAbandonedAt, notes, updatedAt
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON DUPLICATE KEY UPDATE
-            playerName = VALUES(playerName),
-            botName = VALUES(botName),
-            trust = VALUES(trust),
-            familiarity = VALUES(familiarity),
-            lastGroupedAt = VALUES(lastGroupedAt),
-            groupRuns = VALUES(groupRuns),
-            wipesTogether = VALUES(wipesTogether),
-            helpedInCombat = VALUES(helpedInCombat),
-            gaveUsefulLoot = VALUES(gaveUsefulLoot),
-            ignoredLootRequests = VALUES(ignoredLootRequests),
-            tradesCompleted = VALUES(tradesCompleted),
-            insults = VALUES(insults),
-            recentlyAbandonedAt = VALUES(recentlyAbandonedAt),
-            notes = VALUES(notes),
-            updatedAt = VALUES(updatedAt)`,
+        ON CONFLICT(playerId, botId) DO UPDATE SET
+            playerName = excluded.playerName,
+            botName = excluded.botName,
+            trust = excluded.trust,
+            familiarity = excluded.familiarity,
+            lastGroupedAt = excluded.lastGroupedAt,
+            groupRuns = excluded.groupRuns,
+            wipesTogether = excluded.wipesTogether,
+            helpedInCombat = excluded.helpedInCombat,
+            gaveUsefulLoot = excluded.gaveUsefulLoot,
+            ignoredLootRequests = excluded.ignoredLootRequests,
+            tradesCompleted = excluded.tradesCompleted,
+            insults = excluded.insults,
+            recentlyAbandonedAt = excluded.recentlyAbandonedAt,
+            notes = excluded.notes,
+            updatedAt = excluded.updatedAt`,
         [
             record.playerId,
             record.botId,
@@ -194,29 +194,7 @@ const BotSocialMemory = {
         if (initialized || initStarted) return;
         initStarted = true;
 
-        Database.execute([
-            `CREATE TABLE IF NOT EXISTS ${TABLE} (
-                playerId INT NOT NULL,
-                botId INT NOT NULL,
-                playerName VARCHAR(35) NOT NULL DEFAULT '',
-                botName VARCHAR(35) NOT NULL DEFAULT '',
-                trust INT NOT NULL DEFAULT 0,
-                familiarity INT NOT NULL DEFAULT 0,
-                lastGroupedAt BIGINT NULL,
-                groupRuns INT NOT NULL DEFAULT 0,
-                wipesTogether INT NOT NULL DEFAULT 0,
-                helpedInCombat INT NOT NULL DEFAULT 0,
-                gaveUsefulLoot INT NOT NULL DEFAULT 0,
-                ignoredLootRequests INT NOT NULL DEFAULT 0,
-                tradesCompleted INT NOT NULL DEFAULT 0,
-                insults INT NOT NULL DEFAULT 0,
-                recentlyAbandonedAt BIGINT NULL,
-                notes TEXT NULL,
-                updatedAt BIGINT NOT NULL DEFAULT 0,
-                PRIMARY KEY (playerId, botId)
-            )`,
-            []
-        ]).then(() => {
+        Database.execute(['SELECT 1', []], 'schema:bot-social').then(() => {
             initialized = true;
             utils.infoSuccess('BotSocial', 'memory table ready');
         }).catch((err) => {

--- a/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
+++ b/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
@@ -4,6 +4,7 @@ const ProgressionRates = invoke('GameServer/ProgressionRates');
 const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 const CraftShopService = invoke('GameServer/Bot/Economy/CraftShopService');
 const CraftSupplementMaterials = invoke('GameServer/Bot/Economy/CraftSupplementMaterials');
+let sourceIndexCache = { spots: null, rewards: null, byItemId: new Map() };
 const BotGear = invoke('GameServer/Bot/AI/BotGear');
 const GearLifecycle = invoke('GameServer/Bot/AI/GearLifecycle');
 const MarketOpportunity = invoke('GameServer/Bot/Economy/MarketOpportunity');
@@ -443,23 +444,47 @@ function bestSourceForState(sources = [], state = {}) {
     return sources.find((source) => soloSafeForSource(state, source)) || sources[0] || null;
 }
 
-function sourceForItem(itemId, spots = [], state = {}) {
+function sourceIndexFor(spots = []) {
+    const rewards = DataCache.npcRewards || [];
+    if (sourceIndexCache.spots === spots && sourceIndexCache.rewards === rewards) {
+        return sourceIndexCache.byItemId;
+    }
+
     const spotByNpc = new Map();
     const spotByName = new Map();
     (spots || []).forEach((spot) => (spot.npcEntries || []).forEach((entry) => {
         if (entry.selfId) spotByNpc.set(Number(entry.selfId), spot);
         if (entry.name) spotByName.set(String(entry.name).trim().toLowerCase(), spot);
     }));
-    return (DataCache.npcRewards || []).flatMap((reward) => ['drop'].map((kind) => {
+
+    const byItemId = new Map();
+    rewards.forEach((reward) => {
         const spot = spotByNpc.get(Number(reward.selfId))
             || spotByName.get(String(reward.template?.name || '').trim().toLowerCase());
-        const { chance, expectedYield } = itemDropYield(reward, itemId, kind, {
+        if (!spot) return;
+        const itemIds = new Set((reward.rewards || []).flatMap((group) => (
+            (group.items || []).map((item) => Number(item.selfId || 0)).filter(Boolean)
+        )));
+        itemIds.forEach((id) => {
+            const entries = byItemId.get(id) || [];
+            entries.push({ reward, spot });
+            byItemId.set(id, entries);
+        });
+    });
+
+    sourceIndexCache = { spots, rewards, byItemId };
+    return byItemId;
+}
+
+function sourceForItem(itemId, spots = [], state = {}) {
+    return (sourceIndexFor(spots).get(Number(itemId)) || []).map(({ reward, spot }) => {
+        const { chance, expectedYield } = itemDropYield(reward, itemId, 'drop', {
             npcLevel: Number(spot?.avgLevel || 0),
             killerLevel: Number(state.level || 0)
         });
-        if (!chance || !spot) return null;
-        return { npcId: Number(reward.selfId), npcName: reward.template?.name || `NPC ${reward.selfId}`, kind, chance, expectedYield, spotId: spot.id, spotLevel: Number(spot.avgLevel || 1) };
-    })).filter(Boolean).sort((a, b) => b.expectedYield - a.expectedYield);
+        if (!chance) return null;
+        return { npcId: Number(reward.selfId), npcName: reward.template?.name || `NPC ${reward.selfId}`, kind: 'drop', chance, expectedYield, spotId: spot.id, spotLevel: Number(spot.avgLevel || 1) };
+    }).filter(Boolean).sort((a, b) => b.expectedYield - a.expectedYield);
 }
 
 function stationRecipeIds() {

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -34,6 +34,8 @@ const CHAT_PHRASES = {
         "Ready to rumble!"
     ]
 };
+const REAL_PLAYER_CACHE_MS = 250;
+let realPlayerCache = { world: null, revision: -1, checkedAt: 0, sessions: [] };
 
 function getRandomPhrase(category, ...args) {
     const list = CHAT_PHRASES[category];
@@ -58,6 +60,23 @@ function isRealPlayerSession(session) {
         session.accountId &&
         !String(session.accountId).startsWith('bot_')
     );
+}
+
+function realPlayerSessions(World) {
+    const sessions = World?.user?.sessions;
+    if (!Array.isArray(sessions)) return null;
+    const timestamp = Date.now();
+    const revision = Number(World.user.revision || 0);
+    if (realPlayerCache.world === World && realPlayerCache.revision === revision && timestamp - realPlayerCache.checkedAt < REAL_PLAYER_CACHE_MS) {
+        return realPlayerCache.sessions;
+    }
+    realPlayerCache = {
+        world: World,
+        revision,
+        checkedAt: timestamp,
+        sessions: sessions.filter(isRealPlayerSession)
+    };
+    return realPlayerCache.sessions;
 }
 
 const States = {
@@ -149,7 +168,7 @@ const BotAI = {
         }
 
         const World = invoke('GameServer/World/World');
-        const onlinePlayers = World.user.sessions.filter(isRealPlayerSession);
+        const onlinePlayers = realPlayerSessions(World) || [];
 
         if (onlinePlayers.length === 0) {
             return 30000;
@@ -300,7 +319,7 @@ const BotAI = {
 
         const isCompanion = !!session.followPlayerSession && session.partyCompanion === true;
         const World = invoke('GameServer/World/World');
-        const onlinePlayers = World.user.sessions.filter(isRealPlayerSession);
+        const onlinePlayers = realPlayerSessions(World) || [];
         const visibleRealPlayers = this.visibleRealPlayers(session, bot, World);
 
         if (!botDead && onlinePlayers.length > 0 && visibleRealPlayers.length === 0 && !isCompanion && session.plan !== 'shopping' && session.plan !== 'pk_hunting') {
@@ -476,7 +495,19 @@ const BotAI = {
     },
 
     visibleRealPlayers(session, bot, World = invoke('GameServer/World/World')) {
-        if (!session || !bot || !World || typeof World.fetchVisibleUsers !== 'function') return [];
+        if (!session || !bot || !World) return [];
+        const players = realPlayerSessions(World);
+        if (players && typeof bot.fetchLocX === 'function' && typeof bot.fetchLocY === 'function') {
+            const x = bot.fetchLocX();
+            const y = bot.fetchLocY();
+            return players.filter((candidate) => {
+                if (candidate === session || !candidate.actor || typeof candidate.actor.fetchLocX !== 'function' || typeof candidate.actor.fetchLocY !== 'function') return false;
+                const dx = candidate.actor.fetchLocX() - x;
+                const dy = candidate.actor.fetchLocY() - y;
+                return dx * dx + dy * dy <= 6000 * 6000;
+            });
+        }
+        if (typeof World.fetchVisibleUsers !== 'function') return [];
         return World.fetchVisibleUsers(session, bot).filter(isRealPlayerSession);
     },
 

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -278,7 +278,7 @@ const BotManager = {
         // Adventurers now belong exclusively to the persistent population
         // seeder. Keeping the old static starters here doubled the fresh-world
         // population before wave one had even begun.
-        const bots = [...MERCHANT_BOTS];
+        const bots = process.env.L2NODE_HOT_LOAD_TEST === '1' ? [] : [...MERCHANT_BOTS];
         console.info('BotManager :: Static services: merchants=%d; adventure population is seeder-managed', bots.length);
         
         // Wait 5 seconds after startup to let world finish loading

--- a/src/GameServer/Bot/Goals/GoalState.js
+++ b/src/GameServer/Bot/Goals/GoalState.js
@@ -62,9 +62,9 @@ function save(snapshot) {
     return Database.execute([
         `INSERT INTO ${TABLE} (characterId, goalJson, updatedAt)
         VALUES (?, ?, ?)
-        ON DUPLICATE KEY UPDATE
-            goalJson = VALUES(goalJson),
-            updatedAt = VALUES(updatedAt)`,
+        ON CONFLICT(characterId) DO UPDATE SET
+            goalJson = excluded.goalJson,
+            updatedAt = excluded.updatedAt`,
         [snapshot.characterId, safeJson(snapshot.current), snapshot.updatedAt]
     ]);
 }
@@ -74,14 +74,7 @@ const GoalState = {
         if (initialized) return Promise.resolve(true);
         if (initPromise) return initPromise;
 
-        initPromise = Database.execute([
-            `CREATE TABLE IF NOT EXISTS ${TABLE} (
-                characterId INT NOT NULL PRIMARY KEY,
-                goalJson TEXT NULL,
-                updatedAt BIGINT NOT NULL
-            )`,
-            []
-        ]).then(() => {
+        initPromise = Database.execute(['SELECT 1', []], 'schema:bot-goals').then(() => {
             initialized = true;
             return true;
         }).catch((err) => {

--- a/src/GameServer/Bot/LoadTest/HotBotLoadTest.js
+++ b/src/GameServer/Bot/LoadTest/HotBotLoadTest.js
@@ -1,0 +1,272 @@
+const Database = invoke('Database');
+const BotManager = invoke('GameServer/Bot/BotManager');
+const BotAI = invoke('GameServer/Bot/BotAI');
+const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
+
+const PREFIX = 'bot_load_';
+const CLASS_PROFILES = [
+    { race: 0, classId: 0 },
+    { race: 1, classId: 10 },
+    { race: 2, classId: 18 },
+    { race: 3, classId: 25 }
+];
+
+function positiveEnv(name, fallback, min, max) {
+    const value = Number(process.env[name]);
+    if (!Number.isFinite(value)) return fallback;
+    return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+function percentile(values, ratio) {
+    if (!values.length) return 0;
+    const sorted = [...values].sort((left, right) => left - right);
+    return Math.round(sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * ratio) - 1)]);
+}
+
+function maximum(values) {
+    return values.reduce((current, value) => Math.max(current, value), 0);
+}
+
+function hotSessions() {
+    return BotManager.sessions.filter((session) => (
+        session.actor && String(session.accountId || '').startsWith(PREFIX)
+    ));
+}
+
+function operationDelta(before = {}, after = {}) {
+    const names = new Set([...Object.keys(before), ...Object.keys(after)]);
+    return Object.fromEntries([...names].map((name) => {
+        const initial = before[name] || {};
+        const current = after[name] || {};
+        return [name, {
+            count: Number(current.count || 0) - Number(initial.count || 0),
+            waitMs: Number(current.waitMs || 0) - Number(initial.waitMs || 0),
+            runMs: Number(current.runMs || 0) - Number(initial.runMs || 0),
+            failures: Number(current.failures || 0) - Number(initial.failures || 0)
+        }];
+    }));
+}
+
+function profileFor(index) {
+    const profile = CLASS_PROFILES[index % CLASS_PROFILES.length];
+    const serial = String(index + 1).padStart(4, '0');
+    return {
+        username: `${PREFIX}${serial}`,
+        name: `Load${serial}`,
+        race: profile.race,
+        sex: index % 2,
+        classId: profile.classId,
+        face: index % 3,
+        hair: index % 5,
+        hairColor: index % 4,
+        plan: 'hunting',
+        fullNewbieBlessing: false
+    };
+}
+
+function createProfiler() {
+    const samples = new Map();
+    const restore = [];
+    return {
+        wrap(label, target, method) {
+            if (!target || typeof target[method] !== 'function') return;
+            const original = target[method];
+            target[method] = function profiledMethod(...args) {
+                const startedAt = Date.now();
+                try {
+                    return original.apply(this, args);
+                } finally {
+                    if (!samples.has(label)) samples.set(label, []);
+                    samples.get(label).push(Date.now() - startedAt);
+                }
+            };
+            restore.push(() => { target[method] = original; });
+        },
+        snapshot() {
+            return Object.fromEntries([...samples.entries()].map(([label, values]) => [label, {
+                count: values.length,
+                totalMs: values.reduce((sum, value) => sum + value, 0),
+                p95Ms: percentile(values, 0.95),
+                maxMs: maximum(values)
+            }]));
+        },
+        restore() {
+            restore.splice(0).reverse().forEach((callback) => callback());
+        }
+    };
+}
+
+function emit(result) {
+    process.stdout.write(`HOT_LOAD_RESULT ${JSON.stringify(result)}\n`);
+}
+
+const HotBotLoadTest = {
+    started: false,
+
+    start() {
+        if (this.started) return;
+        this.started = true;
+
+        const count = positiveEnv('L2NODE_HOT_LOAD_COUNT', 50, 1, 500);
+        const durationMs = positiveEnv('L2NODE_HOT_LOAD_DURATION_MS', 60000, 5000, 30 * 60 * 1000);
+        const tickMs = positiveEnv('L2NODE_HOT_LOAD_TICK_MS', 1000, 250, 10000);
+        const spreadMs = positiveEnv('L2NODE_HOT_LOAD_SPREAD_MS', 100, 25, tickMs);
+        const provisionTimeoutMs = positiveEnv('L2NODE_HOT_LOAD_PROVISION_TIMEOUT_MS', 120000, 30000, 10 * 60 * 1000);
+        const runStartedAt = Date.now();
+
+        console.info('HotLoad    :: provisioning %d real hot bot(s), duration=%dms tick=%dms', count, durationMs, tickMs);
+        Array.from({ length: count }, (_, index) => profileFor(index))
+            .forEach((profile, index) => BotManager.provisionAndSpawn(profile, index));
+
+        const provisionDeadline = Date.now() + provisionTimeoutMs;
+        const waitForBots = setInterval(() => {
+            const spawned = hotSessions().length;
+            if (spawned < count && Date.now() < provisionDeadline) return;
+            clearInterval(waitForBots);
+            if (spawned !== count) {
+                this.finish({
+                    ok: false,
+                    reason: 'provision_timeout',
+                    requested: count,
+                    spawned,
+                    provisionMs: Date.now() - runStartedAt
+                });
+                return;
+            }
+            this.measure({ count, durationMs, tickMs, spreadMs, runStartedAt });
+        }, 100);
+    },
+
+    measure({ count, durationMs, tickMs, spreadMs, runStartedAt }) {
+        Promise.all(hotSessions().map((session) => Database.fetchItems(session.actor.fetchId())
+            .then((items) => [session.actor.fetchId(), items[0] || null])))
+            .then((entries) => this.measureReady({
+                count, durationMs, tickMs, spreadMs, runStartedAt, itemByCharacter: new Map(entries)
+            }))
+            .catch((error) => this.finish({
+                ok: false,
+                reason: 'inventory_load_failed',
+                requested: count,
+                spawned: hotSessions().length,
+                provisionMs: Date.now() - runStartedAt,
+                errors: [error.message || String(error)]
+            }));
+    },
+
+    measureReady({ count, durationMs, tickMs, spreadMs, runStartedAt, itemByCharacter }) {
+        const startedAt = Date.now();
+        const baseline = Database.stats({ resetPeak: true });
+        const lagSamples = [];
+        const tickDurations = [];
+        const errors = [];
+        const profiler = createProfiler();
+        const BotStatus = invoke('GameServer/Bot/AI/BotStatus');
+        const HuntingState = invoke('GameServer/Bot/AI/States/HuntingState');
+        const World = invoke('GameServer/World/World');
+        const GeodataEngine = invoke('GameServer/Geodata/GeodataEngine');
+        profiler.wrap('status', BotStatus, 'getStatus');
+        profiler.wrap('hunting', HuntingState, 'tick');
+        profiler.wrap('npcRadius', World, 'fetchNpcsInRadius');
+        profiler.wrap('lineOfSight', GeodataEngine, 'hasLineOfSight');
+        let totalTicks = 0;
+        let persistenceWrites = 0;
+        let expectedLagAt = Date.now() + 100;
+        const shards = Math.max(1, Math.ceil(tickMs / spreadMs));
+        let activeShard = 0;
+
+        hotSessions().forEach((session) => {
+            session.aiActive = false;
+            if (session.aiTimeout) clearTimeout(session.aiTimeout);
+            session.aiTimeout = null;
+        });
+
+        const lagTimer = setInterval(() => {
+            const measuredAt = Date.now();
+            lagSamples.push(Math.max(0, measuredAt - expectedLagAt));
+            expectedLagAt = measuredAt + 100;
+        }, 100);
+        const tickTimer = setInterval(() => {
+            const tickStartedAt = Date.now();
+            hotSessions().forEach((session, index) => {
+                if (index % shards !== activeShard) return;
+                try {
+                    const actor = session.actor;
+                    BotAI.tick(session);
+                    CharacterWriteQueue.location(actor.fetchId(), {
+                        locX: actor.fetchLocX(), locY: actor.fetchLocY(), locZ: actor.fetchLocZ(), head: actor.fetchHead()
+                    });
+                    CharacterWriteQueue.vitals(actor.fetchId(), actor.fetchHp(), actor.fetchMaxHp(), actor.fetchMp(), actor.fetchMaxMp());
+                    CharacterWriteQueue.experience(actor.fetchId(), actor.fetchLevel(), actor.fetchExp(), actor.fetchSp());
+                    const item = itemByCharacter.get(actor.fetchId());
+                    if (item) CharacterWriteQueue.itemAmount(actor.fetchId(), item.id, item.amount);
+                    persistenceWrites += item ? 4 : 3;
+                    totalTicks += 1;
+                } catch (error) {
+                    errors.push(error.message || String(error));
+                }
+            });
+            tickDurations.push(Date.now() - tickStartedAt);
+            activeShard = (activeShard + 1) % shards;
+        }, spreadMs);
+
+        setTimeout(() => {
+            clearInterval(lagTimer);
+            clearInterval(tickTimer);
+            const expectedTicks = count * Math.max(1, Math.floor(durationMs / tickMs) - 1);
+            const after = Database.stats();
+            const result = {
+                ok: errors.length === 0 && hotSessions().length === count && totalTicks >= expectedTicks * 0.9,
+                requested: count,
+                spawned: hotSessions().length,
+                durationMs: Date.now() - startedAt,
+                provisionMs: startedAt - runStartedAt,
+                schedule: { tickMs, spreadMs, shards },
+                ticks: {
+                    total: totalTicks,
+                    expected: expectedTicks,
+                    persistenceWrites,
+                    tickP95Ms: percentile(tickDurations, 0.95),
+                    tickMaxMs: maximum(tickDurations)
+                },
+                eventLoop: {
+                    samples: lagSamples.length,
+                    lagP95Ms: percentile(lagSamples, 0.95),
+                    lagMaxMs: maximum(lagSamples)
+                },
+                database: {
+                    peakPending: after.maxPending,
+                    total: after.total - baseline.total,
+                    reads: after.reads - baseline.reads,
+                    writes: after.writes - baseline.writes,
+                    transactions: after.transactions - baseline.transactions,
+                    failures: after.failures - baseline.failures,
+                    operations: operationDelta(baseline.operations, after.operations)
+                },
+                profile: profiler.snapshot(),
+                memory: process.memoryUsage(),
+                errors: errors.slice(0, 10)
+            };
+            profiler.restore();
+            this.finish(result);
+        }, durationMs).unref?.();
+    },
+
+    finish(result) {
+        CharacterWriteQueue.flushAll()
+            .catch((error) => {
+                result.ok = false;
+                result.errors = [...(result.errors || []), `flush: ${error.message || error}`];
+            })
+            .then(() => Database.checkpoint())
+            .catch((error) => {
+                result.ok = false;
+                result.errors = [...(result.errors || []), `checkpoint: ${error.message || error}`];
+            })
+            .finally(() => {
+                emit(result);
+                setTimeout(() => process.exit(result.ok ? 0 : 1), 0);
+            });
+    }
+};
+
+module.exports = HotBotLoadTest;

--- a/src/GameServer/Bot/Population/BackgroundPartyState.js
+++ b/src/GameServer/Bot/Population/BackgroundPartyState.js
@@ -64,17 +64,17 @@ function save(row) {
             partyId, leaderId, memberIdsJson, spotId, startedAt, nextResolveAt,
             cohesion, risk, status, roleCoverageJson, statsJson, updatedAt
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON DUPLICATE KEY UPDATE
-            leaderId = VALUES(leaderId),
-            memberIdsJson = VALUES(memberIdsJson),
-            spotId = VALUES(spotId),
-            nextResolveAt = VALUES(nextResolveAt),
-            cohesion = VALUES(cohesion),
-            risk = VALUES(risk),
-            status = VALUES(status),
-            roleCoverageJson = VALUES(roleCoverageJson),
-            statsJson = VALUES(statsJson),
-            updatedAt = VALUES(updatedAt)`,
+        ON CONFLICT(partyId) DO UPDATE SET
+            leaderId = excluded.leaderId,
+            memberIdsJson = excluded.memberIdsJson,
+            spotId = excluded.spotId,
+            nextResolveAt = excluded.nextResolveAt,
+            cohesion = excluded.cohesion,
+            risk = excluded.risk,
+            status = excluded.status,
+            roleCoverageJson = excluded.roleCoverageJson,
+            statsJson = excluded.statsJson,
+            updatedAt = excluded.updatedAt`,
         [
             row.partyId,
             row.leaderId,
@@ -98,26 +98,7 @@ const BackgroundPartyState = {
         if (initStarted) return initPromise;
         initStarted = true;
 
-        initPromise = Database.execute([
-            `CREATE TABLE IF NOT EXISTS ${TABLE} (
-                partyId VARCHAR(64) NOT NULL,
-                leaderId INT NOT NULL DEFAULT 0,
-                memberIdsJson TEXT NULL,
-                spotId VARCHAR(32) NULL,
-                startedAt BIGINT NOT NULL DEFAULT 0,
-                nextResolveAt BIGINT NULL,
-                cohesion DECIMAL(5,4) NOT NULL DEFAULT 0.6500,
-                risk DECIMAL(5,4) NOT NULL DEFAULT 0.2500,
-                status VARCHAR(16) NOT NULL DEFAULT 'active',
-                roleCoverageJson TEXT NULL,
-                statsJson TEXT NULL,
-                updatedAt BIGINT NOT NULL DEFAULT 0,
-                PRIMARY KEY (partyId),
-                INDEX status_nextResolveAt (status, nextResolveAt),
-                INDEX spotId (spotId)
-            )`,
-            []
-        ]).then(() => this.loadActive()).then(() => {
+        initPromise = Database.execute(['SELECT 1', []], 'schema:bot-parties').then(() => this.loadActive()).then(() => {
             initialized = true;
             utils.infoSuccess('BotParty', 'background party table ready');
             return true;

--- a/src/GameServer/Bot/Population/BotLifeEvents.js
+++ b/src/GameServer/Bot/Population/BotLifeEvents.js
@@ -20,20 +20,7 @@ const BotLifeEvents = {
         if (initStarted) return initPromise;
         initStarted = true;
 
-        initPromise = Database.execute([
-            `CREATE TABLE IF NOT EXISTS ${TABLE} (
-                id BIGINT NOT NULL AUTO_INCREMENT,
-                characterId INT NOT NULL,
-                eventType VARCHAR(32) NOT NULL,
-                summary VARCHAR(255) NOT NULL DEFAULT '',
-                weight INT NOT NULL DEFAULT 1,
-                createdAt BIGINT NOT NULL DEFAULT 0,
-                metaJson TEXT NULL,
-                PRIMARY KEY (id),
-                INDEX characterId_createdAt (characterId, createdAt)
-            )`,
-            []
-        ]).then(() => {
+        initPromise = Database.execute(['SELECT 1', []], 'schema:bot-life-events').then(() => {
             initialized = true;
             utils.infoSuccess('BotLife', 'events table ready');
             return true;

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -128,46 +128,8 @@ function refreshCraftShop(state = {}) {
     };
 }
 
-function syncInventoryItem(characterId, existingItems, item) {
-    const selfId = Number(item.selfId || 0);
-    const amount = Number(item.amount || 0);
-    if (!selfId || amount < 0) return Promise.resolve(null);
-
-    const existing = existingItems.find((row) => Number(row.selfId) === selfId);
-    if (existing) {
-        let chain = Promise.resolve(null);
-        if (Number(existing.amount || 0) !== amount) {
-            chain = chain.then(() => Database.updateItemAmount(characterId, existing.id, amount));
-        }
-        const equipped = !!item.equipped;
-        const slot = Number(item.slot || existing.slot || 0);
-        if (!!existing.equipped !== equipped || Number(existing.slot || 0) !== slot) {
-            chain = chain.then(() => Database.updateItemEquipState(characterId, existing.id, equipped, slot));
-        }
-        return chain;
-    }
-
-    if (amount === 0) return Promise.resolve(null);
-
-    const template = itemTemplate(selfId);
-    return Database.setItem(characterId, {
-        selfId,
-        name: item.name || itemName(selfId),
-        amount,
-        equipped: !!item.equipped,
-        slot: Number(item.slot || template?.etc?.slot || 0)
-    });
-}
-
 function syncInventorySummary(characterId, inventory) {
-    const entries = Object.values(inventory || {});
-    if (!entries.length) return Promise.resolve(null);
-
-    return Database.fetchItems(characterId).then((existingItems) => (
-        entries.reduce((chain, item) => (
-            chain.then(() => syncInventoryItem(characterId, existingItems, item))
-        ), Promise.resolve())
-    ));
+    return Database.syncInventorySummary(characterId, inventory);
 }
 
 function targetCombatTelemetry(previous = {}, debug = {}, timestamp = now()) {
@@ -187,6 +149,9 @@ function targetCombatTelemetry(previous = {}, debug = {}, timestamp = now()) {
         lastDefeatedNpcIds: defeatedNpcIds,
         lastResolvedAt: timestamp
     });
+    const limitTargets = (values) => Object.fromEntries(Object.entries(values)
+        .sort(([, left], [, right]) => Number(right.lastResolvedAt || 0) - Number(left.lastResolvedAt || 0))
+        .slice(0, 24));
     const targets = { ...(previous.targets || {}) };
     const current = add(targets[targetKey]);
     targets[targetKey] = current;
@@ -199,8 +164,20 @@ function targetCombatTelemetry(previous = {}, debug = {}, timestamp = now()) {
         ...(previous || {}),
         targetNpcId,
         ...current,
-        targets,
-        populationTargets
+        targets: limitTargets(targets),
+        populationTargets: limitTargets(populationTargets)
+    };
+}
+
+function compactResolveDebug(debug = {}) {
+    return {
+        route: debug.route || null,
+        partyId: debug.partyId || null,
+        targetNpcId: Number(debug.targetNpcId || 0) || null,
+        wins: Number(debug.wins || 0),
+        fights: Number(debug.fights || 0),
+        defeated: Array.isArray(debug.defeatedNpcIds) ? debug.defeatedNpcIds.slice(-8).map(Number) : [],
+        at: now()
     };
 }
 
@@ -347,25 +324,6 @@ function rowFromState(state) {
     };
 }
 
-function addColumn(name, definition) {
-    return Database.execute([
-        `ALTER TABLE ${TABLE} ADD COLUMN ${name} ${definition}`,
-        []
-    ]).catch((err) => {
-        if (err.code === 'ER_DUP_FIELDNAME' || err.errno === 1060) return null;
-        throw err;
-    });
-}
-
-function ensureColumns() {
-    return Promise.all([
-        addColumn('level', 'INT NOT NULL DEFAULT 1 AFTER characterName'),
-        addColumn('exp', 'BIGINT NOT NULL DEFAULT 0 AFTER level'),
-        addColumn('sp', 'BIGINT NOT NULL DEFAULT 0 AFTER exp'),
-        addColumn('adena', 'BIGINT NOT NULL DEFAULT 0 AFTER sp')
-    ]);
-}
-
 function save(row) {
     return Database.execute([
         `INSERT INTO ${TABLE} (
@@ -374,35 +332,35 @@ function save(row) {
             lastResolvedAt, lastHotAt, locX, locY, locZ, hp, maxHp, mp, maxMp,
             targetLevelBand, deathCount, partyId, inventorySummary, statsJson, updatedAt
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON DUPLICATE KEY UPDATE
-            accountName = VALUES(accountName),
-            characterName = VALUES(characterName),
-            level = VALUES(level),
-            exp = VALUES(exp),
-            sp = VALUES(sp),
-            adena = VALUES(adena),
-            homeRegion = VALUES(homeRegion),
-            currentRegion = VALUES(currentRegion),
-            spotId = VALUES(spotId),
-            activity = VALUES(activity),
-            phase = VALUES(phase),
-            activityStartedAt = VALUES(activityStartedAt),
-            nextResolveAt = VALUES(nextResolveAt),
-            lastResolvedAt = VALUES(lastResolvedAt),
-            lastHotAt = VALUES(lastHotAt),
-            locX = VALUES(locX),
-            locY = VALUES(locY),
-            locZ = VALUES(locZ),
-            hp = VALUES(hp),
-            maxHp = VALUES(maxHp),
-            mp = VALUES(mp),
-            maxMp = VALUES(maxMp),
-            targetLevelBand = VALUES(targetLevelBand),
-            deathCount = VALUES(deathCount),
-            partyId = VALUES(partyId),
-            inventorySummary = VALUES(inventorySummary),
-            statsJson = VALUES(statsJson),
-            updatedAt = VALUES(updatedAt)`,
+        ON CONFLICT(characterId) DO UPDATE SET
+            accountName = excluded.accountName,
+            characterName = excluded.characterName,
+            level = excluded.level,
+            exp = excluded.exp,
+            sp = excluded.sp,
+            adena = excluded.adena,
+            homeRegion = excluded.homeRegion,
+            currentRegion = excluded.currentRegion,
+            spotId = excluded.spotId,
+            activity = excluded.activity,
+            phase = excluded.phase,
+            activityStartedAt = excluded.activityStartedAt,
+            nextResolveAt = excluded.nextResolveAt,
+            lastResolvedAt = excluded.lastResolvedAt,
+            lastHotAt = excluded.lastHotAt,
+            locX = excluded.locX,
+            locY = excluded.locY,
+            locZ = excluded.locZ,
+            hp = excluded.hp,
+            maxHp = excluded.maxHp,
+            mp = excluded.mp,
+            maxMp = excluded.maxMp,
+            targetLevelBand = excluded.targetLevelBand,
+            deathCount = excluded.deathCount,
+            partyId = excluded.partyId,
+            inventorySummary = excluded.inventorySummary,
+            statsJson = excluded.statsJson,
+            updatedAt = excluded.updatedAt`,
         [
             row.characterId,
             row.accountName,
@@ -624,7 +582,7 @@ function recoverStaleCraftWaits() {
         SET activity = 'hunting',
             activityStartedAt = ?,
             nextResolveAt = ?,
-            statsJson = JSON_SET(COALESCE(statsJson, '{}'), '$.lastReason', 'startup_craft_wait_recovery'),
+            statsJson = json_set(COALESCE(statsJson, '{}'), '$.lastReason', 'startup_craft_wait_recovery'),
             updatedAt = ?
         WHERE phase = 'cold'
         AND activity = 'crafting'
@@ -647,9 +605,9 @@ function migrateAcquisitionPartyWaits() {
         SET activity = 'party_wait',
             activityStartedAt = ?,
             nextResolveAt = ?,
-            statsJson = JSON_SET(
+            statsJson = json_set(
                 COALESCE(statsJson, '{}'),
-                '$.partyWaitUntil', CAST(? AS UNSIGNED),
+                '$.partyWaitUntil', CAST(? AS INTEGER),
                 '$.restUntil', NULL,
                 '$.lastReason', 'acquisition_party_wait'
             ),
@@ -657,8 +615,8 @@ function migrateAcquisitionPartyWaits() {
         WHERE phase = 'cold'
         AND activity = 'resting'
         AND (partyId IS NULL OR partyId = '')
-        AND JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.lastReason')) = 'acquisition_party_wait'
-        AND COALESCE(CAST(JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.restUntil')) AS UNSIGNED), 0) = 0`,
+        AND json_extract(statsJson, '$.lastReason') = 'acquisition_party_wait'
+        AND COALESCE(CAST(json_extract(statsJson, '$.restUntil') AS INTEGER), 0) = 0`,
         [timestamp, replanAt, replanAt, timestamp]
     ]).then((result) => {
         const migrated = Number(result?.affectedRows || 0);
@@ -673,12 +631,12 @@ function discardInvalidEquipmentPlans() {
     const timestamp = now();
     return Database.execute([
         `UPDATE ${TABLE}
-        SET statsJson = JSON_REMOVE(COALESCE(statsJson, '{}'), '$.equipmentPlan'),
+        SET statsJson = json_remove(COALESCE(statsJson, '{}'), '$.equipmentPlan'),
             updatedAt = ?
-        WHERE JSON_EXTRACT(statsJson, '$.equipmentPlan.target') IS NOT NULL
+        WHERE json_extract(statsJson, '$.equipmentPlan.target') IS NOT NULL
         AND (
-            COALESCE(CAST(JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.equipmentPlan.target.selfId')) AS UNSIGNED), 0) <= 0
-            OR TRIM(COALESCE(JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.equipmentPlan.target.name')), '')) IN ('', '0')
+            COALESCE(CAST(json_extract(statsJson, '$.equipmentPlan.target.selfId') AS INTEGER), 0) <= 0
+            OR TRIM(COALESCE(json_extract(statsJson, '$.equipmentPlan.target.name'), '')) IN ('', '0')
         )`,
         [timestamp]
     ]).then((result) => {
@@ -696,39 +654,7 @@ const BotLifeState = {
         if (initStarted) return initPromise;
         initStarted = true;
 
-        initPromise = Database.execute([
-            `CREATE TABLE IF NOT EXISTS ${TABLE} (
-                characterId INT NOT NULL,
-                accountName VARCHAR(16) NOT NULL DEFAULT '',
-                characterName VARCHAR(35) NOT NULL DEFAULT '',
-                homeRegion VARCHAR(64) NULL,
-                currentRegion VARCHAR(64) NULL,
-                spotId VARCHAR(32) NULL,
-                activity VARCHAR(32) NOT NULL DEFAULT 'hunting',
-                phase VARCHAR(16) NOT NULL DEFAULT 'cold',
-                activityStartedAt BIGINT NULL,
-                nextResolveAt BIGINT NULL,
-                lastResolvedAt BIGINT NULL,
-                lastHotAt BIGINT NULL,
-                locX INT NOT NULL DEFAULT 0,
-                locY INT NOT NULL DEFAULT 0,
-                locZ INT NOT NULL DEFAULT 0,
-                hp INT NOT NULL DEFAULT 0,
-                maxHp INT NOT NULL DEFAULT 0,
-                mp INT NOT NULL DEFAULT 0,
-                maxMp INT NOT NULL DEFAULT 0,
-                targetLevelBand VARCHAR(16) NULL,
-                deathCount INT NOT NULL DEFAULT 0,
-                partyId VARCHAR(64) NULL,
-                inventorySummary TEXT NULL,
-                statsJson TEXT NULL,
-                updatedAt BIGINT NOT NULL DEFAULT 0,
-                PRIMARY KEY (characterId),
-                INDEX phase_nextResolveAt (phase, nextResolveAt),
-                INDEX accountName (accountName)
-            )`,
-            []
-        ]).then(() => ensureColumns()).then(() => recoverStaleHotStates()).then(() => recoverStaleCraftWaits()).then(() => migrateAcquisitionPartyWaits()).then(() => discardInvalidEquipmentPlans()).then(() => hydrateCache()).then((count) => {
+        initPromise = Database.execute(['SELECT 1', []], 'schema:bot-life').then(() => recoverStaleHotStates()).then(() => recoverStaleCraftWaits()).then(() => migrateAcquisitionPartyWaits()).then(() => discardInvalidEquipmentPlans()).then(() => hydrateCache()).then((count) => {
             const repairs = [...cache.values()]
                 .map(recoverOrphanedGiranState)
                 .filter((state) => state !== cache.get(state.characterId));
@@ -1006,8 +932,8 @@ const BotLifeState = {
             -- Cold stores settle on trade/expiry events, and craft-service
             -- stations are materialized on demand.  Neither belongs in the
             -- combat scheduler's periodic queue.
-            AND NOT (activity = 'merchant' AND JSON_EXTRACT(statsJson, '$.marketStore') IS NOT NULL)
-            AND NOT (activity = 'crafting' AND JSON_EXTRACT(statsJson, '$.craftShop') IS NOT NULL)
+            AND NOT (activity = 'merchant' AND json_extract(statsJson, '$.marketStore') IS NOT NULL)
+            AND NOT (activity = 'crafting' AND json_extract(statsJson, '$.craftShop') IS NOT NULL)
             AND (nextResolveAt IS NULL OR nextResolveAt <= ?)
             -- Travel and crafting are finite state transitions. They must
             -- outrank a large resting/hunting backlog, otherwise a bot can
@@ -1017,15 +943,15 @@ const BotLifeState = {
                 -- Startup craft recovery is a one-shot replan.  Serve it
                 -- before the normal hunting backlog so a repaired station
                 -- wait immediately selects its missing raw material.
-                WHEN JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.lastReason')) = 'startup_craft_wait_recovery' THEN 1
+                WHEN json_extract(statsJson, '$.lastReason') = 'startup_craft_wait_recovery' THEN 1
                 WHEN activity = 'dead' THEN 2
                 ELSE 3
             END ASC,
             COALESCE(nextResolveAt, 0) ASC,
                 CASE
                 -- A rate-model rollout must promptly replace persisted kill estimates.
-                WHEN JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.equipmentPlan.expectedKills')) IS NOT NULL
-                    AND COALESCE(CAST(JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.equipmentPlan.rateModelVersion')) AS UNSIGNED), 0) < 2 THEN 0
+                WHEN json_extract(statsJson, '$.equipmentPlan.expectedKills') IS NOT NULL
+                    AND COALESCE(CAST(json_extract(statsJson, '$.equipmentPlan.rateModelVersion') AS INTEGER), 0) < 2 THEN 0
                 WHEN activity = 'dead' THEN 1
                 WHEN activity IN ('traveling', 'shopping', 'merchant', 'crafting') THEN 2
                 ELSE 3
@@ -1050,9 +976,9 @@ const BotLifeState = {
             `SELECT * FROM ${TABLE}
             WHERE phase = 'cold'
             AND activity = 'merchant'
-            AND JSON_EXTRACT(statsJson, '$.marketStore') IS NOT NULL
-            AND COALESCE(CAST(JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.marketStore.marketTownRoutingVersion')) AS UNSIGNED), 0) < ?
-            AND COALESCE(CAST(JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.marketStore.expiresAt')) AS UNSIGNED), 0) > ?
+            AND json_extract(statsJson, '$.marketStore') IS NOT NULL
+            AND COALESCE(CAST(json_extract(statsJson, '$.marketStore.marketTownRoutingVersion') AS INTEGER), 0) < ?
+            AND COALESCE(CAST(json_extract(statsJson, '$.marketStore.expiresAt') AS INTEGER), 0) > ?
             ORDER BY updatedAt ASC
             LIMIT ${safeLimit}`,
             [version, Date.now()]
@@ -1073,8 +999,8 @@ const BotLifeState = {
             `SELECT * FROM ${TABLE}
             WHERE phase = 'cold'
             AND activity = 'merchant'
-            AND JSON_EXTRACT(statsJson, '$.marketStore') IS NOT NULL
-            AND COALESCE(CAST(JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.marketStore.expiresAt')) AS UNSIGNED), 0) <= ?
+            AND json_extract(statsJson, '$.marketStore') IS NOT NULL
+            AND COALESCE(CAST(json_extract(statsJson, '$.marketStore.expiresAt') AS INTEGER), 0) <= ?
             ORDER BY updatedAt ASC
             LIMIT ${safeLimit}`,
             [Number(timestamp) || Date.now()]
@@ -1226,7 +1152,7 @@ const BotLifeState = {
         return Database.execute([
             `SELECT partyId,
                 COUNT(*) AS memberCount,
-                SUM(CASE WHEN JSON_UNQUOTE(JSON_EXTRACT(statsJson, '$.equipmentPlan.requiresParty')) = 'true' THEN 1 ELSE 0 END) AS requiredMembers,
+                SUM(CASE WHEN json_extract(statsJson, '$.equipmentPlan.requiresParty') = 1 THEN 1 ELSE 0 END) AS requiredMembers,
                 MIN(updatedAt) AS oldestAt
             FROM ${TABLE}
             WHERE phase = 'cold'
@@ -1323,7 +1249,7 @@ const BotLifeState = {
             spEarned: Number(state.stats?.spEarned || 0) + Number(result.materialize?.sp || 0),
             adenaEarned: Number(state.stats?.adenaEarned || 0) + Number(result.materialize?.adena || 0) + materializedAdenaItems,
             route: result.debug?.route || state.stats?.route || null,
-            lastResolveDebug: result.debug || null,
+            lastResolveDebug: compactResolveDebug(result.debug),
             ...(targetCombat ? { targetCombat } : {})
         };
         const inventory = { ...(state.inventory || {}) };
@@ -1397,7 +1323,7 @@ const BotLifeState = {
                 // Keep lifecycle telemetry from this resolve authoritative over
                 // that snapshot, which still contains the previous tick's data.
                 ...(targetCombat ? { targetCombat } : {}),
-                lastResolveDebug: result.debug || null,
+                lastResolveDebug: compactResolveDebug(result.debug),
                 equipment: equipmentSummaryFromInventory(equippedInventory)
             },
             inventory: equippedInventory,

--- a/src/GameServer/Bot/Population/PopulationConfig.js
+++ b/src/GameServer/Bot/Population/PopulationConfig.js
@@ -6,6 +6,9 @@ const DEFAULTS = {
     directorEnabled: true,
     summaryIntervalMs: 30000,
     schedulerIntervalMs: 5000,
+    // Cold simulation is invisible to players. Keep its total throughput,
+    // but let sockets and hot AI run between bounded pieces of work.
+    schedulerSliceMs: 12,
     // Existing cold population predates full class progression. Reconcile it
     // in small batches so restart never becomes a database migration spike.
     classProgressionMigrationIntervalMs: 10000,
@@ -102,6 +105,7 @@ const ENV_KEYS = {
     activationLevelRange: 'BOT_ACTIVATION_LEVEL_RANGE',
     nearPlayerHotTarget: 'BOT_NEAR_PLAYER_HOT_TARGET',
     maxActivationsPerScan: 'BOT_MAX_ACTIVATIONS_PER_SCAN',
+    schedulerSliceMs: 'BOT_POPULATION_SCHEDULER_SLICE_MS',
     partyInviteRange: 'BOT_PARTY_INVITE_RANGE',
     marketTradeChatEnabled: 'BOT_MARKET_TRADE_CHAT_ENABLED',
     marketTradeChatIntervalMs: 'BOT_MARKET_TRADE_CHAT_INTERVAL_MS',

--- a/src/GameServer/Bot/Population/PopulationMetrics.js
+++ b/src/GameServer/Bot/Population/PopulationMetrics.js
@@ -21,6 +21,7 @@ function emptyCounters() {
         dbFlushes: 0,
         schedulerRuns: 0,
         schedulerSkips: 0,
+        schedulerYields: 0,
         schedulerOverruns: 0,
         slowResolves: 0
     };
@@ -54,7 +55,8 @@ const PopulationMetrics = {
     },
     interval: {
         resolveDurationsMs: [],
-        schedulerDurationsMs: []
+        schedulerDurationsMs: [],
+        schedulerSliceDurationsMs: []
     },
     timer: null,
 
@@ -162,6 +164,15 @@ const PopulationMetrics = {
         }
     },
 
+    recordSchedulerYield(sliceMs) {
+        const value = Math.max(0, Number(sliceMs) || 0);
+        this.counters.schedulerYields += 1;
+        this.interval.schedulerSliceDurationsMs.push(value);
+        if (this.interval.schedulerSliceDurationsMs.length > Config.resolveSampleLimit) {
+            this.interval.schedulerSliceDurationsMs.shift();
+        }
+    },
+
     recordSchedulerSkip() {
         this.counters.schedulerSkips += 1;
     },
@@ -177,8 +188,10 @@ const PopulationMetrics = {
         this.lastSummaryCounters = { ...this.counters };
         const resolveStats = stats(this.interval.resolveDurationsMs);
         const schedulerStats = stats(this.interval.schedulerDurationsMs);
+        const schedulerSliceStats = stats(this.interval.schedulerSliceDurationsMs);
         this.interval.resolveDurationsMs = [];
         this.interval.schedulerDurationsMs = [];
+        this.interval.schedulerSliceDurationsMs = [];
 
         return {
             uptimeMs: elapsedMs,
@@ -187,6 +200,7 @@ const PopulationMetrics = {
             eventLoop: { ...this.eventLoop },
             resolve: resolveStats,
             scheduler: schedulerStats,
+            schedulerSlice: schedulerSliceStats,
             memory: process.memoryUsage ? process.memoryUsage() : null
         };
     }

--- a/src/GameServer/Bot/Population/PopulationService.js
+++ b/src/GameServer/Bot/Population/PopulationService.js
@@ -1,5 +1,6 @@
 const Config  = invoke('GameServer/Bot/Population/PopulationConfig');
 const Metrics = invoke('GameServer/Bot/Population/PopulationMetrics');
+const Database = invoke('Database');
 const Status  = invoke('GameServer/Bot/Population/PopulationStatus');
 const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
 const LifeEvents = invoke('GameServer/Bot/Population/BotLifeEvents');
@@ -805,28 +806,18 @@ const PopulationService = {
 
         const startedAt = Date.now();
         this.resolving = true;
-        return this.resolveDueParties()
+        return Database.cooperatively(() => this.resolveDueParties()
             .then(() => this.reconcileMarketGoals())
             .then(() => LifeState.dueCold(Config.maxResolvesPerTick))
-            .then((states) => {
-                if (states.length === 0) return [];
-                return states.reduce((chain, state) => (
-                    chain.then((results) => this.resolveColdState(state)
-                        .then((result) => {
-                            results.push(result);
-                            return results;
-                        })
+            .then((states) => this.runInSchedulerSlices(states, (state) => this.resolveColdState(state)
                         .catch((error) => {
                             // A single bot may lose a race with a market or
                             // craft transaction. It must not abort every
                             // remaining cold resolve in this scheduler tick.
                             utils.infoWarn('BotPopulation', 'cold resolve failed for %s: %s', state.name, error?.message || error);
                             Metrics.recordSkippedResolve();
-                            results.push({ ok: false, reason: 'resolve_rejected', state });
-                            return results;
-                        }))
-                ), Promise.resolve([]));
-            })
+                            return { ok: false, reason: 'resolve_rejected', state };
+                        }))), Config.schedulerSliceMs)
             .catch((err) => {
                 utils.infoWarn('BotPopulation', 'background scheduler failed: %s', err.message);
                 return [];
@@ -863,40 +854,49 @@ const PopulationService = {
         if (Config.backgroundPartyEnabled === false) return Promise.resolve([]);
 
         return BackgroundPartyState.due(Config.maxPartyResolvesPerTick)
-            .then((parties) => {
-                if (parties.length === 0) return [];
-                return parties.reduce((chain, party) => (
-                    chain.then((results) => this.resolveBackgroundParty(party).then((result) => {
-                        results.push(result);
-                        return results;
-                    }))
-                ), Promise.resolve([]));
-            });
+            .then((parties) => this.runInSchedulerSlices(parties, (party) => this.resolveBackgroundParty(party)));
     },
 
     reconcileMarketGoals() {
         return LifeState.marketGoalCandidates(Config.maxMarketGoalReconcilesPerTick)
-            .then((states) => states.reduce(
-                (chain, state) => chain.then((results) => {
+            .then((states) => this.runInSchedulerSlices(states, (state) => {
                     const spot = SpotProfiles.findForState(state);
                     return GoalService.review(state, { spot }).then((goalSnapshot) => {
                         const travel = GoalExecutor.beginMarketTravel(state, goalSnapshot?.current);
-                        if (!travel) return results;
+                        if (!travel) return null;
                         return LifeState.upsertState(travel, 'reconciled_market_travel').then((saved) => {
                             if (saved) {
                                 console.info('BotPopulation :: reconciled market travel for %s', state.name);
-                                results.push(saved);
                             }
-                            return results;
+                            return saved;
                         });
                     });
-                }),
-                Promise.resolve([])
-            ))
+                }).then((results) => results.filter(Boolean)))
             .catch((err) => {
                 utils.infoWarn('BotPopulation', 'market-goal reconcile failed: %s', err.message);
                 return [];
             });
+    },
+
+    yieldSchedulerSlice(sliceStartedAt) {
+        Metrics.recordSchedulerYield(Date.now() - sliceStartedAt);
+        return new Promise((resolve) => setImmediate(resolve));
+    },
+
+    async runInSchedulerSlices(items, work) {
+        const results = [];
+        let sliceStartedAt = Date.now();
+        const sliceMs = Math.max(1, Number(Config.schedulerSliceMs) || 12);
+
+        for (const item of items || []) {
+            results.push(await work(item));
+            if (Date.now() - sliceStartedAt >= sliceMs) {
+                await this.yieldSchedulerSlice(sliceStartedAt);
+                sliceStartedAt = Date.now();
+            }
+        }
+
+        return results;
     },
 
     resolveBackgroundParty(party) {

--- a/src/GameServer/Bot/Population/PopulationStatus.js
+++ b/src/GameServer/Bot/Population/PopulationStatus.js
@@ -37,12 +37,13 @@ const PopulationStatus = {
         const heapMb = metrics.memory?.heapUsed ? Math.round(metrics.memory.heapUsed / 1024 / 1024) : 0;
         const resolve = metrics.resolve || {};
         const scheduler = metrics.scheduler || {};
+        const schedulerSlice = metrics.schedulerSlice || {};
 
         return {
             ...counts,
             metrics,
             director: Director.snapshot(),
-            line: `hot=${counts.hot} warm=${counts.warm} cold=${counts.cold} parties=${counts.parties} persisted=${counts.persisted} merchants=${counts.merchants} ticks=${metrics.delta.hotTicks} resolves=${metrics.delta.backgroundResolves} partyResolves=${metrics.delta.partyResolves} combatActions=${metrics.delta.combatActions} skillUses=${metrics.delta.skillUses} heals=${metrics.delta.heals} skipped=${metrics.delta.skippedResolves} activations=${metrics.delta.activations} cooldowns=${metrics.delta.cooldowns} partyForms=${metrics.delta.partyFormations} partyRecruits=${metrics.delta.partyRecruits} partyDissolves=${metrics.delta.partyDissolutions} dbFlushes=${metrics.delta.dbFlushes} resolveAvg=${resolve.avgMs || 0}ms resolveP95=${resolve.p95Ms || 0}ms schedulerP95=${scheduler.p95Ms || 0}ms schedulerSkips=${metrics.delta.schedulerSkips || 0} schedulerOverruns=${metrics.delta.schedulerOverruns || 0} slowResolves=${metrics.delta.slowResolves || 0} heap=${heapMb}MB lag=${lag}ms maxLag=${maxLag}ms ${Director.statusLine()}`
+            line: `hot=${counts.hot} warm=${counts.warm} cold=${counts.cold} parties=${counts.parties} persisted=${counts.persisted} merchants=${counts.merchants} ticks=${metrics.delta.hotTicks} resolves=${metrics.delta.backgroundResolves} partyResolves=${metrics.delta.partyResolves} combatActions=${metrics.delta.combatActions} skillUses=${metrics.delta.skillUses} heals=${metrics.delta.heals} skipped=${metrics.delta.skippedResolves} activations=${metrics.delta.activations} cooldowns=${metrics.delta.cooldowns} partyForms=${metrics.delta.partyFormations} partyRecruits=${metrics.delta.partyRecruits} partyDissolves=${metrics.delta.partyDissolutions} dbFlushes=${metrics.delta.dbFlushes} resolveAvg=${resolve.avgMs || 0}ms resolveP95=${resolve.p95Ms || 0}ms schedulerP95=${scheduler.p95Ms || 0}ms sliceP95=${schedulerSlice.p95Ms || 0}ms schedulerYields=${metrics.delta.schedulerYields || 0} schedulerSkips=${metrics.delta.schedulerSkips || 0} schedulerOverruns=${metrics.delta.schedulerOverruns || 0} slowResolves=${metrics.delta.slowResolves || 0} heap=${heapMb}MB lag=${lag}ms maxLag=${maxLag}ms ${Director.statusLine()}`
         };
     }
 };

--- a/src/GameServer/Clan/ClanService.js
+++ b/src/GameServer/Clan/ClanService.js
@@ -110,41 +110,7 @@ function setActorClan(actor, clanId, privileges) {
 }
 
 function ensureSchema() {
-    const statements = [
-        `CREATE TABLE IF NOT EXISTS clans(
-            id INT NOT NULL AUTO_INCREMENT,
-            name VARCHAR(16) NOT NULL,
-            level INT NOT NULL DEFAULT 0,
-            leaderId INT NOT NULL,
-            crestId INT NOT NULL DEFAULT 0,
-            crestLargeId INT NOT NULL DEFAULT 0,
-            allyId INT NOT NULL DEFAULT 0,
-            allyName VARCHAR(16) NOT NULL DEFAULT "",
-            allyCrestId INT NOT NULL DEFAULT 0,
-            dissolvingExpiryTime BIGINT NOT NULL DEFAULT 0,
-            charPenaltyExpiryTime BIGINT NOT NULL DEFAULT 0,
-            PRIMARY KEY (id),
-            UNIQUE KEY name (name),
-            KEY leaderId (leaderId)
-        )`,
-        `CREATE TABLE IF NOT EXISTS clan_crests(
-            id INT NOT NULL AUTO_INCREMENT,
-            clanId INT NOT NULL,
-            kind VARCHAR(16) NOT NULL DEFAULT "pledge",
-            data VARBINARY(256) NOT NULL,
-            createdAt TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            PRIMARY KEY (id),
-            KEY clanId (clanId)
-        )`,
-        'ALTER TABLE characters ADD COLUMN clanId INT NOT NULL DEFAULT 0',
-        'ALTER TABLE characters ADD COLUMN clanPrivileges INT NOT NULL DEFAULT 0',
-        'ALTER TABLE characters ADD COLUMN clanJoinExpiryTime BIGINT NOT NULL DEFAULT 0',
-        'ALTER TABLE characters ADD COLUMN clanCreateExpiryTime BIGINT NOT NULL DEFAULT 0'
-    ];
-
-    return statements.reduce((chain, sql) => (
-        chain.then(() => Database.execute([sql, []]).catch(() => null))
-    ), Promise.resolve());
+    return Database.execute(['SELECT 1', []], 'schema:clans');
 }
 
 const ClanService = {

--- a/src/GameServer/Crafting/ManufactureShop.js
+++ b/src/GameServer/Crafting/ManufactureShop.js
@@ -1,6 +1,7 @@
 const C4RecipeItems = invoke('GameServer/Items/C4RecipeItems');
 const ServerResponse = invoke('GameServer/Network/Response');
 const Database = invoke('Database');
+const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
 const DataCache = invoke('GameServer/DataCache');
 const Item = invoke('GameServer/Item/Item');
 const { materialPlan } = invoke('GameServer/Crafting/CraftMaterials');
@@ -182,6 +183,7 @@ async function craft(session, crafterId, recipeId, random = Math.random) {
     const crafterMp = publicStation ? Number(crafter.fetchMp()) : Number(crafter.fetchMp()) - recipe.mpCost;
     activeCrafters.add(actorId);
     try {
+        await Promise.all([CharacterWriteQueue.flushCharacter(actorId), CharacterWriteQueue.flushCharacter(customerId)]);
         const success = recipe.successRate >= 100 || (Number(random()) * 100) < recipe.successRate;
         const result = await Database.craftForCustomer(actorId, customerId, {
             materials: consumed.map(({ item, amount }) => ({ id: item.fetchId(), selfId: item.fetchSelfId(), amount })),

--- a/src/GameServer/Crafting/RecipeCrafting.js
+++ b/src/GameServer/Crafting/RecipeCrafting.js
@@ -1,6 +1,7 @@
 const C4RecipeItems = invoke('GameServer/Items/C4RecipeItems');
 const ServerResponse = invoke('GameServer/Network/Response');
 const Database = invoke('Database');
+const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
 const DataCache = invoke('GameServer/DataCache');
 const Item = invoke('GameServer/Item/Item');
 const { materialPlan } = invoke('GameServer/Crafting/CraftMaterials');
@@ -96,6 +97,7 @@ async function craftSelf(session, recipeId, random = Math.random) {
 
     activeCrafters.add(actorId);
     try {
+        await CharacterWriteQueue.flushCharacter(actorId);
         const success = recipe.successRate >= 100 || (Number(random()) * 100) < recipe.successRate;
         const result = await Database.craftInventoryItems(actorId, {
             materials: consumed.map(({ item, amount }) => ({ id: item.fetchId(), selfId: item.fetchSelfId(), amount })),

--- a/src/GameServer/Crystallize.js
+++ b/src/GameServer/Crystallize.js
@@ -2,6 +2,7 @@ const Database = invoke('Database');
 const DataCache = invoke('GameServer/DataCache');
 const Item = invoke('GameServer/Item/Item');
 const ServerResponse = invoke('GameServer/Network/Response');
+const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
 const GRADES = { d: { level: 1, crystalId: 1458 }, c: { level: 2, crystalId: 1459 }, b: { level: 3, crystalId: 1460 }, a: { level: 4, crystalId: 1461 }, s: { level: 5, crystalId: 1462 } };
 async function crystallize(session, objectId, count) {
     const actor = session?.actor, item = actor?.backpack?.fetchItemRaw?.(objectId), skill = actor?.skillset?.fetchSkill?.(248);
@@ -9,6 +10,7 @@ async function crystallize(session, objectId, count) {
     if (!actor || actor.isDead?.() || Number(actor.fetchPrivateStoreType?.() || 0) !== 0 || Number(count) !== 1 || !item || item.fetchAmount() !== 1 || item.fetchEquipped() || !grade || amount <= 0 || Number(skill?.fetchLevel?.() || 0) < grade.level) { session?.dataSendToMe?.(ServerResponse.actionFailed()); return false; }
     const crystal = DataCache.items.find((entry) => Number(entry.selfId) === grade.crystalId); if (!crystal) return false;
     try {
+        await CharacterWriteQueue.flushCharacter(actor.fetchId());
         const result = await Database.crystallizeInventoryItem(actor.fetchId(), { sourceId: item.fetchId(), sourceSelfId: item.fetchSelfId(), crystalId: grade.crystalId, crystalName: crystal.template?.name || '', crystalAmount: amount });
         actor.backpack.items = actor.backpack.items.filter((entry) => entry !== item);
         const existing = actor.backpack.fetchItemRaw(result.id); if (existing) existing.setAmount(result.amount); else actor.backpack.items.push(new Item(result.id, { ...utils.crushOb(crystal), amount: result.amount, equipped: false, slot: 0 }));

--- a/src/GameServer/Persistence/CharacterWriteQueue.js
+++ b/src/GameServer/Persistence/CharacterWriteQueue.js
@@ -1,0 +1,89 @@
+const Database = invoke('Database');
+
+const FLUSH_INTERVAL_MS = 750;
+const pending = new Map();
+let timer = null;
+let flushing = Promise.resolve();
+
+function stateFor(characterId) {
+    const id = Number(characterId || 0);
+    if (!id) return null;
+    if (!pending.has(id)) pending.set(id, { character: {}, items: {} });
+    return pending.get(id);
+}
+
+function schedule() {
+    if (timer) return;
+    timer = setTimeout(() => {
+        timer = null;
+        flushAll().catch((error) => utils.infoWarn('DB', 'buffered persistence flush failed: %s', error.message));
+    }, FLUSH_INTERVAL_MS);
+    timer.unref?.();
+}
+
+function merge(characterId, fields) {
+    const state = stateFor(characterId);
+    if (!state) return;
+    Object.assign(state.character, fields);
+    schedule();
+}
+
+function queueItemAmount(characterId, id, amount) {
+    const state = stateFor(characterId);
+    if (!state || !id) return;
+    state.items[id] = { id: Number(id), amount: Number(amount), delete: Number(amount) <= 0 };
+    schedule();
+}
+
+function take(characterId) {
+    const id = Number(characterId || 0);
+    const state = pending.get(id);
+    if (!state) return null;
+    pending.delete(id);
+    return state;
+}
+
+function databaseReady() {
+    return typeof Database.isReady !== 'function' || Database.isReady();
+}
+
+function flushCharacter(characterId) {
+    if (!databaseReady()) {
+        schedule();
+        return flushing;
+    }
+    const state = take(characterId);
+    if (!state) return flushing;
+    flushing = flushing.then(() => Database.applyBufferedCharacterState(Number(characterId), state));
+    return flushing;
+}
+
+function flushAll() {
+    if (!databaseReady()) {
+        schedule();
+        return flushing;
+    }
+    const entries = [...pending.keys()]
+        .map((id) => [id, take(id)])
+        .filter(([, state]) => state);
+    if (!entries.length) return flushing;
+    flushing = flushing.then(() => Database.applyBufferedCharacterStates(entries));
+    return flushing;
+}
+
+function pendingCount() {
+    return pending.size;
+}
+
+Database.registerCharacterWriteFlush?.(flushCharacter);
+
+module.exports = {
+    itemAmount: queueItemAmount,
+    experience(characterId, level, exp, sp) { merge(characterId, { level, exp, sp }); },
+    location(characterId, coords = {}) { merge(characterId, { locX: coords.locX, locY: coords.locY, locZ: coords.locZ, head: coords.head ?? -1 }); },
+    vitals(characterId, hp, maxHp, mp, maxMp) { merge(characterId, { hp, maxHp, mp, maxMp }); },
+    karma(characterId, pvp, pk, karma) { merge(characterId, { pvp, pk, karma }); },
+    flushCharacter,
+    flushAll,
+    pendingCount
+};

--- a/src/GameServer/Warehouse/PersonalWarehouse.js
+++ b/src/GameServer/Warehouse/PersonalWarehouse.js
@@ -2,6 +2,7 @@ const Database = invoke('Database');
 const DataCache = invoke('GameServer/DataCache');
 const Item = invoke('GameServer/Item/Item');
 const World = invoke('GameServer/World/World');
+const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
 
 const MAX_LINES = 100;
 const INTERACTION_RADIUS = 300;
@@ -53,6 +54,7 @@ async function deposit(session, lines) {
     if (!isWarehouseNpc(session)) throw new Error('warehouse NPC is no longer active');
     const actor = session.actor;
     const backpack = actor.backpack;
+    await CharacterWriteQueue.flushCharacter(actor.fetchId());
     const inventory = backpack.fetchItems();
     if (!validateLines(lines, inventory)) throw new Error('invalid warehouse deposit');
 
@@ -91,6 +93,7 @@ async function withdraw(session, lines) {
     if (!isWarehouseNpc(session)) throw new Error('warehouse NPC is no longer active');
     const actor = session.actor;
     const backpack = actor.backpack;
+    await CharacterWriteQueue.flushCharacter(actor.fetchId());
     const stored = await list(actor.fetchId());
     if (!validateLines(lines, stored)) throw new Error('invalid warehouse withdrawal');
 

--- a/src/GameServer/World/World.js
+++ b/src/GameServer/World/World.js
@@ -54,7 +54,7 @@ function waitForBotSession(BotManager, name, attempts = 40) {
 
 const World = {
     init() {
-        this.user  = { sessions : [] };
+        this.user  = { sessions : [], revision: 0 };
         this.npc   = { spawns   : [], grid: {}, nextId: 1000000 };
         this.items = { spawns   : [], nextId: 5000000 };
 
@@ -76,10 +76,12 @@ const World = {
         else {
             this.user.sessions.push(session);
         }
+        this.user.revision += 1;
     },
 
     removeUser(session) {
         this.user.sessions = this.user.sessions.filter((ob) => ob !== session);
+        this.user.revision += 1;
     },
 
     fetchUser(id) {

--- a/src/Global.js
+++ b/src/Global.js
@@ -130,8 +130,10 @@ function mergeConfig(base, override) {
 
 const ini = require('js-ini');
 const defaultConfig = ini.parse(utils.parseRawFile('./config/default.ini'));
-const localConfig = utils.fileExists('./config/local.ini')
-    ? ini.parse(utils.parseRawFile('./config/local.ini'))
+const configOverridePath = process.env.L2NODE_CONFIG_FILE;
+const localConfigPath = configOverridePath || './config/local.ini';
+const localConfig = utils.fileExists(localConfigPath)
+    ? ini.parse(utils.parseRawFile(localConfigPath))
     : {};
 
 global.options = {

--- a/src/NodeL2.js
+++ b/src/NodeL2.js
@@ -13,6 +13,22 @@ const DevConsole = invoke('GameServer/DevConsole');
 const WorldObserver = invoke('WorldObserver/WorldObserverServer');
 const ProgressionRates = invoke('GameServer/ProgressionRates');
 const ClanService = invoke('GameServer/Clan/ClanService');
+const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
+
+let shuttingDown = false;
+function shutdown(signal) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    utils.infoWarn('DB', 'flushing buffered character state before %s', signal);
+    const forceExit = setTimeout(() => process.exit(0), 3000);
+    forceExit.unref?.();
+    CharacterWriteQueue.flushAll()
+        .catch((error) => utils.infoWarn('DB', 'final buffered flush failed: %s', error.message))
+        .finally(() => process.exit(0));
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
 
 console.info('\n\
     + ================================== \n\

--- a/src/NodeL2.js
+++ b/src/NodeL2.js
@@ -67,5 +67,8 @@ Database.init(() => {
         BotManager.init();
         WorldObserver.init();
         DevConsole.init();
+        if (process.env.L2NODE_HOT_LOAD_TEST === '1') {
+            invoke('GameServer/Bot/LoadTest/HotBotLoadTest').start();
+        }
     });
 });

--- a/tests/test_bot_ai_visibility.js
+++ b/tests/test_bot_ai_visibility.js
@@ -37,6 +37,28 @@ const World = {
 assert.deepStrictEqual(BotAI.visibleRealPlayers(botSession, botSession.actor, World), [visiblePlayer]);
 assert.deepStrictEqual(BotAI.visibleRealPlayers(botSession, botSession.actor, { fetchVisibleUsers: () => [] }), []);
 
+const positionedBot = {
+    fetchLocX: () => 100,
+    fetchLocY: () => 100
+};
+const positionedPlayer = {
+    accountId: 'player_joined_after_cache',
+    actor: {
+        fetchIsOnline: () => true,
+        fetchLocX: () => 150,
+        fetchLocY: () => 100
+    }
+};
+const cachedWorld = { user: { revision: 0, sessions: [] } };
+assert.deepStrictEqual(BotAI.visibleRealPlayers(botSession, positionedBot, cachedWorld), []);
+cachedWorld.user.sessions.push(positionedPlayer);
+cachedWorld.user.revision += 1;
+assert.deepStrictEqual(
+    BotAI.visibleRealPlayers(botSession, positionedBot, cachedWorld),
+    [positionedPlayer],
+    'a player joining during the cache window must be visible without waiting for the TTL'
+);
+
 let wakeups = 0;
 const originalWakeup = BotAI.wakeup;
 BotAI.wakeup = (session) => {

--- a/tests/test_bot_cold_market_listing.js
+++ b/tests/test_bot_cold_market_listing.js
@@ -18,7 +18,8 @@ const originals = {
     updateItemEquipState: Database.updateItemEquipState,
     updateCharacterLocation: Database.updateCharacterLocation,
     updateCharacterExperience: Database.updateCharacterExperience,
-    updateCharacterVitals: Database.updateCharacterVitals
+    updateCharacterVitals: Database.updateCharacterVitals,
+    syncInventorySummary: Database.syncInventorySummary
 };
 const calls = [];
 
@@ -37,6 +38,10 @@ async function run() {
     Database.updateCharacterLocation = () => Promise.resolve();
     Database.updateCharacterExperience = () => Promise.resolve();
     Database.updateCharacterVitals = () => Promise.resolve();
+    Database.syncInventorySummary = (characterId, inventory) => {
+        calls.push({ type: 'inventory-sync', characterId, inventory });
+        return Promise.resolve();
+    };
 
     const state = {
         characterId: 88,
@@ -116,8 +121,9 @@ async function run() {
     assert.strictEqual(sold.inventory['1'].amount, 0);
     assert.strictEqual(sold.activity, 'shopping', 'selling the final item must close the store as part of the trade event');
     assert.strictEqual(sold.stats.marketStore, null);
-    assert(calls.some((call) => call.type === 'amount' && call.id === 21 && call.amount === 0));
-    assert(calls.some((call) => call.type === 'amount' && call.id === 20 && call.amount === 500 + offer.price));
+    const soldSync = calls.find((call) => call.type === 'inventory-sync' && call.characterId === 88);
+    assert.strictEqual(soldSync.inventory['1'].amount, 0, 'the optimized sync must persist removal of sold stock');
+    assert.strictEqual(soldSync.inventory['57'].amount, 500 + offer.price, 'the optimized sync must persist the adena payout');
 
     const phantom = {
         ...opened.state,
@@ -171,6 +177,7 @@ run().catch((err) => {
     Database.updateCharacterLocation = originals.updateCharacterLocation;
     Database.updateCharacterExperience = originals.updateCharacterExperience;
     Database.updateCharacterVitals = originals.updateCharacterVitals;
+    Database.syncInventorySummary = originals.syncInventorySummary;
     LifeState.reset?.();
     MarketOpportunity.resetColdStores();
 });

--- a/tests/test_bot_cold_market_purchase.js
+++ b/tests/test_bot_cold_market_purchase.js
@@ -18,6 +18,7 @@ const originals = {
     updateItemAmount: Database.updateItemAmount,
     updateItemEquipState: Database.updateItemEquipState,
     setItem: Database.setItem,
+    syncInventorySummary: Database.syncInventorySummary,
     clearGoal: GoalState.clear,
     user: World.user,
     bestOffer: MarketOpportunity.bestOffer,
@@ -51,6 +52,10 @@ async function run() {
     };
     Database.setItem = (characterId, item) => {
         calls.push({ type: 'insert', characterId, item });
+        return Promise.resolve();
+    };
+    Database.syncInventorySummary = (characterId, inventory) => {
+        calls.push({ type: 'inventory-sync', characterId, inventory });
         return Promise.resolve();
     };
     GoalState.clear = (characterId, status) => {
@@ -93,9 +98,10 @@ async function run() {
     assert.strictEqual(result.state.inventory['2'].equipped, true);
     assert.strictEqual(result.state.stats.equipment[0].selfId, 2);
     assert.strictEqual(playerStore.items[0].count, 0, 'private offer should be consumed');
-    assert(calls.some((call) => call.type === 'amount' && call.id === 10 && call.amount === 0));
-    assert(calls.some((call) => call.type === 'equip' && call.id === 11 && call.equipped === false));
-    assert(calls.some((call) => call.type === 'insert' && call.item.selfId === 2 && call.item.equipped === true));
+    const weaponSync = calls.find((call) => call.type === 'inventory-sync' && call.characterId === 77);
+    assert.strictEqual(weaponSync.inventory['57'].amount, 0, 'the optimized sync must persist spent adena');
+    assert.strictEqual(weaponSync.inventory['1'].equipped, false, 'the optimized sync must persist the replaced weapon');
+    assert.strictEqual(weaponSync.inventory['2'].equipped, true, 'the optimized sync must persist the new weapon');
     assert(calls.some((call) => call.type === 'goal' && call.characterId === 77 && call.status === 'completed'));
 
     const noOffer = await ColdMarketService.tryPurchase({
@@ -142,8 +148,9 @@ async function run() {
     assert.strictEqual(armorPurchase.inventory['354'].equipped, true);
     assert(armorPurchase.stats.equipment.some((item) => item.selfId === 1 && item.slot === 7));
     assert(armorPurchase.stats.equipment.some((item) => item.selfId === 354 && item.slot === 10));
-    assert(calls.some((call) => call.type === 'equip' && call.characterId === 78 && call.id === 12 && call.equipped === false));
-    assert(calls.some((call) => call.type === 'insert' && call.characterId === 78 && call.item.selfId === 354 && call.item.equipped === true));
+    const armorSync = calls.find((call) => call.type === 'inventory-sync' && call.characterId === 78);
+    assert.strictEqual(armorSync.inventory['21'].equipped, false, 'the optimized sync must persist the unequipped old chest');
+    assert.strictEqual(armorSync.inventory['354'].equipped, true, 'the optimized sync must persist the new chest');
 
     console.log('Bot cold market purchase checks passed');
 }
@@ -157,6 +164,7 @@ run().catch((err) => {
     Database.updateItemAmount = originals.updateItemAmount;
     Database.updateItemEquipState = originals.updateItemEquipState;
     Database.setItem = originals.setItem;
+    Database.syncInventorySummary = originals.syncInventorySummary;
     GoalState.clear = originals.clearGoal;
     World.user = originals.user;
     MarketOpportunity.bestOffer = originals.bestOffer;

--- a/tests/test_bot_goal_state.js
+++ b/tests/test_bot_goal_state.js
@@ -27,7 +27,7 @@ try {
         assert.strictEqual(snapshot.current.priority, 100);
         assert.deepStrictEqual(snapshot.current.blockers, ['spot_contested']);
         assert.strictEqual(GoalState.snapshot(77).current.type, 'upgrade_gear');
-        assert(statements.some((entry) => entry.sql.includes('CREATE TABLE IF NOT EXISTS bot_goal_state')));
+        assert(statements.some((entry) => entry.sql === 'SELECT 1'), 'schema is owned by the SQLite migration, not hot-path DDL');
         const insert = statements.find((entry) => entry.sql.includes('INSERT INTO bot_goal_state'));
         assert(insert, 'goal state should use one upsert boundary');
         assert.strictEqual(insert.params[0], 77);

--- a/tests/test_bot_population_scheduler_slices.js
+++ b/tests/test_bot_population_scheduler_slices.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const Config = invoke('GameServer/Bot/Population/PopulationConfig');
+const PopulationService = invoke('GameServer/Bot/Population/PopulationService');
+
+const originalSliceMs = Config.schedulerSliceMs;
+const originalYield = PopulationService.yieldSchedulerSlice;
+
+async function run() {
+    const values = [];
+    const yields = [];
+    Config.schedulerSliceMs = 1;
+    PopulationService.yieldSchedulerSlice = async (startedAt) => {
+        yields.push(Date.now() - startedAt);
+    };
+
+    const results = await PopulationService.runInSchedulerSlices([1, 2, 3], async (value) => {
+        await new Promise((resolve) => setTimeout(resolve, 2));
+        values.push(value);
+        return value * 2;
+    });
+
+    assert.deepStrictEqual(values, [1, 2, 3], 'scheduler work must stay ordered');
+    assert.deepStrictEqual(results, [2, 4, 6], 'scheduler work results must be retained');
+    assert.strictEqual(yields.length, 3, 'each over-budget scheduler slice must yield before more work');
+    console.log('Bot population scheduler slice checks passed');
+}
+
+run()
+    .catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    })
+    .finally(() => {
+        Config.schedulerSliceMs = originalSliceMs;
+        PopulationService.yieldSchedulerSlice = originalYield;
+    });

--- a/tests/test_bot_population_state.js
+++ b/tests/test_bot_population_state.js
@@ -8,7 +8,17 @@ const DataCache = invoke('GameServer/DataCache');
 DataCache.init();
 
 const originalExecute = Database.execute;
+const originalSyncInventorySummary = Database.syncInventorySummary;
+const originalUpdateCharacterLocation = Database.updateCharacterLocation;
+const originalUpdateCharacterExperience = Database.updateCharacterExperience;
+const originalUpdateCharacterVitals = Database.updateCharacterVitals;
+const originalFetchSkills = Database.fetchSkills;
+const originalFetchSkill = Database.fetchSkill;
+const originalSetSkill = Database.setSkill;
+const originalUpdateSkillLevel = Database.updateSkillLevel;
+const originalUpdateCharacterClassId = Database.updateCharacterClassId;
 const statements = [];
+const classUpdates = [];
 
 try {
     Database.execute = ([sql, params]) => {
@@ -23,6 +33,18 @@ try {
             return Promise.resolve([]);
         }
         return Promise.resolve([]);
+    };
+    Database.syncInventorySummary = () => Promise.resolve();
+    Database.updateCharacterLocation = () => Promise.resolve();
+    Database.updateCharacterExperience = () => Promise.resolve();
+    Database.updateCharacterVitals = () => Promise.resolve();
+    Database.fetchSkills = () => Promise.resolve([]);
+    Database.fetchSkill = () => Promise.resolve([]);
+    Database.setSkill = () => Promise.resolve();
+    Database.updateSkillLevel = () => Promise.resolve();
+    Database.updateCharacterClassId = (characterId, classId) => {
+        classUpdates.push({ characterId, classId });
+        return Promise.resolve();
     };
 
     const BotLifeState = invoke('GameServer/Bot/Population/BotLifeState');
@@ -41,7 +63,7 @@ try {
         assert.strictEqual(craftRecovery.params[1], craftRecovery.params[0], 'recovered craft waits must be due immediately for their replan');
         const partyWaitMigration = statements.find((entry) => entry.sql.includes("migrated %d acquisition party waits") || entry.sql.includes("activity = 'party_wait'"));
         assert(partyWaitMigration, 'startup must move legacy acquisition waits out of the rest scheduler');
-        const invalidPlanMigration = statements.find((entry) => entry.sql.includes("JSON_REMOVE(COALESCE(statsJson, '{}'), '$.equipmentPlan')"));
+        const invalidPlanMigration = statements.find((entry) => entry.sql.includes("json_remove(COALESCE(statsJson, '{}'), '$.equipmentPlan')"));
         assert(invalidPlanMigration, 'startup must discard malformed persisted equipment plans that passive bots would not otherwise replan');
         assert(invalidPlanMigration.sql.includes("'$.equipmentPlan.target.selfId'"), 'the invalid-plan migration must validate the persisted target identity');
         return BotLifeState.upsertState({
@@ -49,15 +71,15 @@ try {
             timing: { activityStartedAt: 1, nextResolveAt: 2, lastResolvedAt: 1 },
             vitals: {}, stats: { classId: 31 }, inventory: {}
         }, 'persistence_probe').then(() => {
-            const save = statements.find((entry) => entry.sql.includes('ON DUPLICATE KEY UPDATE'));
-            assert(save.sql.includes('nextResolveAt = VALUES(nextResolveAt)'), 'persisted cold resolve timing must advance after every tick');
-            assert(save.sql.includes('lastResolvedAt = VALUES(lastResolvedAt)'), 'persisted cold resolve history must survive an upsert');
-            assert(save.sql.includes('inventorySummary = VALUES(inventorySummary)'), 'background drop rewards must persist after an upsert');
+            const save = statements.find((entry) => entry.sql.includes('ON CONFLICT(characterId) DO UPDATE'));
+            assert(save.sql.includes('nextResolveAt = excluded.nextResolveAt'), 'persisted cold resolve timing must advance after every tick');
+            assert(save.sql.includes('lastResolvedAt = excluded.lastResolvedAt'), 'persisted cold resolve history must survive an upsert');
+            assert(save.sql.includes('inventorySummary = excluded.inventorySummary'), 'background drop rewards must persist after an upsert');
             return BotLifeState.migrateLegacyClassProgression(1).then((migrated) => {
                 assert.strictEqual(migrated.length, 1, 'legacy cold bots without progression markers must be migrated');
-                const classUpdate = statements.filter((entry) => entry.sql.includes('classId')).at(-1);
+                const classUpdate = classUpdates.at(-1);
                 assert(classUpdate, 'migration must persist the profession on the physical character');
-                assert.ok([36, 37].includes(classUpdate.params[0]), 'migration must use the physical character class as its source of truth');
+                assert.ok([36, 37].includes(classUpdate.classId), 'migration must use the physical character class as its source of truth');
                 return BotLifeState.dueCold(5, 1000);
             });
         }).then(() => {
@@ -120,7 +142,7 @@ try {
                     }
                 });
             }).then(() => {
-                const partySave = statements.filter((entry) => entry.sql.includes('ON DUPLICATE KEY UPDATE')).at(-1);
+                const partySave = statements.filter((entry) => entry.sql.includes('ON CONFLICT(characterId) DO UPDATE')).at(-1);
                 const persistedStats = JSON.parse(partySave.params[27]);
                 assert.strictEqual(persistedStats.lastResolveDebug.partyId, 'bgp_probe', 'a party result must not be replaced by its previous solo debug snapshot');
                 assert.strictEqual(persistedStats.targetCombat.populationTargets['93'].targetKills, 1, 'a party result must retain its shared target telemetry');
@@ -133,8 +155,26 @@ try {
         process.exitCode = 1;
     }).finally(() => {
         Database.execute = originalExecute;
+        Database.syncInventorySummary = originalSyncInventorySummary;
+        Database.updateCharacterLocation = originalUpdateCharacterLocation;
+        Database.updateCharacterExperience = originalUpdateCharacterExperience;
+        Database.updateCharacterVitals = originalUpdateCharacterVitals;
+        Database.fetchSkills = originalFetchSkills;
+        Database.fetchSkill = originalFetchSkill;
+        Database.setSkill = originalSetSkill;
+        Database.updateSkillLevel = originalUpdateSkillLevel;
+        Database.updateCharacterClassId = originalUpdateCharacterClassId;
     });
 } catch (err) {
     Database.execute = originalExecute;
+    Database.syncInventorySummary = originalSyncInventorySummary;
+    Database.updateCharacterLocation = originalUpdateCharacterLocation;
+    Database.updateCharacterExperience = originalUpdateCharacterExperience;
+    Database.updateCharacterVitals = originalUpdateCharacterVitals;
+    Database.fetchSkills = originalFetchSkills;
+    Database.fetchSkill = originalFetchSkill;
+    Database.setSkill = originalSetSkill;
+    Database.updateSkillLevel = originalUpdateSkillLevel;
+    Database.updateCharacterClassId = originalUpdateCharacterClassId;
     throw err;
 }

--- a/tests/test_character_write_queue.js
+++ b/tests/test_character_write_queue.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const Database = invoke('Database');
+const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
+
+const originalApply = Database.applyBufferedCharacterState;
+const originalApplyBatch = Database.applyBufferedCharacterStates;
+const originalIsReady = Database.isReady;
+const writes = [];
+
+Database.applyBufferedCharacterState = (characterId, state) => {
+    writes.push({ characterId, state });
+    return Promise.resolve({ characterId });
+};
+Database.applyBufferedCharacterStates = (entries) => {
+    writes.push({ batch: entries });
+    return Promise.resolve(entries);
+};
+Database.isReady = () => true;
+
+(async () => {
+    CharacterWriteQueue.experience(42, 20, 1234, 567);
+    CharacterWriteQueue.location(42, { locX: 10, locY: 20, locZ: 30, head: 40 });
+    CharacterWriteQueue.itemAmount(42, 100, 7);
+    CharacterWriteQueue.itemAmount(42, 100, 3);
+    CharacterWriteQueue.itemAmount(42, 101, 0);
+
+    await CharacterWriteQueue.flushCharacter(42);
+
+    assert.strictEqual(writes.length, 1, 'one character tick must become one transactional flush');
+    assert.deepStrictEqual(writes[0], {
+        characterId: 42,
+        state: {
+            character: { level: 20, exp: 1234, sp: 567, locX: 10, locY: 20, locZ: 30, head: 40 },
+            items: {
+                100: { id: 100, amount: 3, delete: false },
+                101: { id: 101, amount: 0, delete: true }
+            }
+        }
+    });
+    assert.strictEqual(CharacterWriteQueue.pendingCount(), 0, 'flushed state must not be written twice');
+
+    CharacterWriteQueue.experience(43, 10, 100, 20);
+    CharacterWriteQueue.vitals(44, 50, 50, 30, 30);
+    await CharacterWriteQueue.flushAll();
+    assert.strictEqual(writes[1].batch.length, 2, 'a timer flush must group all hot characters into one database transaction');
+    console.log('character write queue coalescing ok');
+})().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+}).finally(() => {
+    Database.applyBufferedCharacterState = originalApply;
+    Database.applyBufferedCharacterStates = originalApplyBatch;
+    Database.isReady = originalIsReady;
+});

--- a/tests/test_hot_bot_load_test.js
+++ b/tests/test_hot_bot_load_test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { parseArguments, appendTail } = require('../scripts/hot-bot-load-test');
+
+assert.deepStrictEqual(parseArguments([]), {
+    counts: [50, 100, 200, 300], durationMs: 60000, tickMs: 1000, spreadMs: 100
+});
+assert.deepStrictEqual(parseArguments(['--counts=25,100', '--duration=12', '--tick=500', '--spread=50']), {
+    counts: [25, 100], durationMs: 12000, tickMs: 500, spreadMs: 50
+});
+assert.throws(() => parseArguments(['--counts=0']), /counts/);
+assert.throws(() => parseArguments(['--duration=2']), /duration/);
+assert.throws(() => parseArguments(['--tick=100']), /tick/);
+assert.throws(() => parseArguments(['--spread=2000']), /spread/);
+assert.strictEqual(appendTail('1234', '5678').length, 8, 'short diagnostic output must remain unchanged');
+const diagnosticTail = appendTail('x'.repeat(1024 * 1024), 'tail');
+assert.strictEqual(diagnosticTail.length, 1024 * 1024, 'diagnostic output must stay bounded');
+assert.ok(diagnosticTail.endsWith('tail'), 'diagnostic output must retain the newest text');
+console.log('hot bot load runner argument checks passed');

--- a/tests/test_sqlite_account_casefold.js
+++ b/tests/test_sqlite_account_casefold.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+require('../src/Global');
+
+const Database = invoke('Database');
+const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
+const databasePath = path.join(process.cwd(), 'tmp', 'test-sqlite-account-casefold.sqlite');
+
+fs.rmSync(databasePath, { force: true });
+options.default.Database.path = path.relative(process.cwd(), databasePath);
+
+Database.init();
+
+(async () => {
+    await Database.createAccount('PlayerOne', 'secret');
+    const account = (await Database.fetchUserPassword('PLAYERONE'))[0];
+    assert.deepStrictEqual(account, { username: 'PlayerOne', password: 'secret' }, 'account lookup must preserve MariaDB-style case-insensitive logins');
+    await assert.rejects(Database.createAccount('playerone', 'other'), /UNIQUE constraint failed/, 'case variants must not create separate accounts');
+
+    await Database.createCharacter('playerone', {
+        name: 'CasefoldProbe', race: 0, classId: 0, maxHp: 50, maxMp: 25,
+        sex: 0, face: 0, hair: 0, hairColor: 0, locX: 0, locY: 0, locZ: 0
+    });
+    const character = (await Database.fetchCharacters('PLAYERONE'))[0];
+    assert.strictEqual(character.username, 'PlayerOne', 'new character must reference the canonical account name');
+
+    const inserted = await Database.setItem(character.id, { selfId: 57, name: 'Adena', amount: 10 });
+    CharacterWriteQueue.itemAmount(character.id, inserted.insertId, 9);
+    await Database.updateItemAmount(character.id, inserted.insertId, 4);
+    const item = (await Database.fetchItems(character.id))[0];
+    assert.strictEqual(item.amount, 4, 'a direct inventory update must run after pending buffered writes');
+
+    console.log('sqlite casefold and buffered-write barrier ok');
+})().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/tests/test_world_wipe.js
+++ b/tests/test_world_wipe.js
@@ -3,19 +3,32 @@ const { targetClause, validateScope, previewWithConnection, wipeWithConnection }
 
 function fakeConnection() {
     const queries = [];
+    const resultFor = (sql) => {
+        if (sql.startsWith('SELECT COUNT(*) AS count FROM characters')) return { count: 2 };
+        if (sql.startsWith('SELECT COUNT(*) AS count FROM accounts')) return { count: 3 };
+        if (sql.startsWith('SELECT id FROM characters')) return [{ id: 11 }, { id: 12 }];
+        if (sql.startsWith('SELECT id FROM clans WHERE leaderId IN')) return [{ id: 7 }];
+        return [];
+    };
     return {
         queries,
-        async query(sql, params = []) {
-            queries.push({ sql, params });
-            if (sql.startsWith('SELECT COUNT(*) AS count FROM characters')) return [{ count: 2 }];
-            if (sql.startsWith('SELECT COUNT(*) AS count FROM accounts')) return [{ count: 3 }];
-            if (sql.startsWith('SELECT id FROM characters')) return [{ id: 11 }, { id: 12 }];
-            if (sql.startsWith('SELECT id FROM clans')) return [{ id: 7 }];
-            return [];
+        prepare(sql) {
+            return {
+                get(...params) {
+                    queries.push({ sql, params });
+                    return resultFor(sql);
+                },
+                all(...params) {
+                    queries.push({ sql, params });
+                    return resultFor(sql);
+                },
+                run(...params) {
+                    queries.push({ sql, params });
+                    return { changes: 1 };
+                }
+            };
         },
-        async beginTransaction() { queries.push({ sql: 'BEGIN' }); },
-        async commit() { queries.push({ sql: 'COMMIT' }); },
-        async rollback() { queries.push({ sql: 'ROLLBACK' }); }
+        exec(sql) { queries.push({ sql, params: [] }); }
     };
 }
 
@@ -26,28 +39,28 @@ function fakeConnection() {
     assert.match(targetClause('players').sql, /NOT LIKE/);
 
     const previewConnection = fakeConnection();
-    assert.deepStrictEqual(await previewWithConnection(previewConnection, 'players'), {
+    assert.deepStrictEqual(previewWithConnection(previewConnection, 'players'), {
         scope: 'players', characters: 2, accounts: 3
     });
 
     const conn = fakeConnection();
-    assert.deepStrictEqual(await wipeWithConnection(conn, 'bots'), {
+    assert.deepStrictEqual(wipeWithConnection(conn, 'bots'), {
         scope: 'bots', characters: 2, accounts: 3
     });
     const sql = conn.queries.map((entry) => entry.sql).join('\n');
     [
-        'character_recipes', 'character_quests', 'warehouse_items', 'macros',
-        'bot_goal_state', 'bot_background_parties', 'DELETE FROM accounts'
+        'DELETE FROM characters', 'bot_background_parties', 'DELETE FROM accounts',
+        'UPDATE characters SET clanId = 0', 'DELETE FROM clans WHERE id IN'
     ].forEach((table) => assert.ok(sql.includes(table), `expected cleanup for ${table}`));
     assert.ok(sql.includes('COMMIT'));
 
     const playerConnection = fakeConnection();
-    await wipeWithConnection(playerConnection, 'players');
+    wipeWithConnection(playerConnection, 'players');
     const playerSql = playerConnection.queries.map((entry) => entry.sql).join('\n');
     assert.ok(!playerSql.includes('DELETE FROM bot_background_parties'));
 
     const allConnection = fakeConnection();
-    await wipeWithConnection(allConnection, 'all');
+    wipeWithConnection(allConnection, 'all');
     const allSql = allConnection.queries.map((entry) => entry.sql).join('\n');
     assert.ok(allSql.includes('DELETE FROM bot_background_parties'));
     assert.ok(allSql.includes('DELETE FROM clans'));


### PR DESCRIPTION
## What changed

- Migrates runtime persistence from MariaDB to an embedded SQLite database, including schema setup, migration tooling, server scripts, and operational documentation.
- Keeps persistence writes buffered and adds SQLite-aware queue and checkpoint handling for character state.
- Adds an isolated hot-bot load runner that provisions real bot characters, drives normal bot AI paths in shards, persists character state, and records AI, event-loop, database, and memory metrics.
- Adds cache invalidation for real-player visibility so bot behavior updates immediately on player login or logout.

## Why

The server should run without a separately installed database service while retaining observable, durable persistence. The load runner establishes a repeatable baseline for scaling the active bot population and catches database or scheduling regressions before they reach a live world.

## Validation

- `npm test`
- Syntax check across 669 JavaScript files.
- Isolated 10-minute soak with 500 hot bots: 1.1 million buffered persistence writes, zero database failures, 59 ms AI-tick p95, and 19 ms event-loop lag p95.

## Current operating guidance

The hot AI and persistence path sustained 500 bots in isolation. Until the separate cold-population scheduler is further optimized under mixed live-world load, use 300 hot bots as the conservative production target and treat 400-500 as controlled capacity tiers.
