### PR TITLE
Fix NPC corpse decay lifecycle

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -160,6 +160,7 @@ const tests = [
     'tests/test_npc_social_aggro.js',
     'tests/test_npc_hot_bot_aggro.js',
     'tests/test_npc_known_object_lifecycle.js',
+    'tests/test_npc_decay.js',
     'tests/test_npc_respawn.js',
     'tests/test_party_companion_rest_follow.js',
     'tests/test_party_buff_targets.js',

--- a/src/GameServer/World/Generics/NpcDecay.js
+++ b/src/GameServer/World/Generics/NpcDecay.js
@@ -1,0 +1,150 @@
+const NpcVisibility = invoke('GameServer/World/NpcVisibility');
+
+const DEFAULT_REAPER_INTERVAL_MS = 1000;
+
+function logWarning(message, error) {
+    const detail = error?.message || error || 'unknown error';
+    if (typeof utils?.infoWarn === 'function') {
+        utils.infoWarn('NpcDecay', `${message}: ${detail}`);
+    }
+}
+
+function clearTimer(npc) {
+    if (!npc?.corpseDecayTimer) return;
+    clearTimeout(npc.corpseDecayTimer);
+    npc.corpseDecayTimer = undefined;
+}
+
+function numericDelay(delayMs) {
+    const value = Number(delayMs);
+    return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function schedule(world, sourceSession, npc, delayMs) {
+    if (!world?.npc?.spawns || !npc?.fetchId) return false;
+    if (npc.corpseDecayState === 'removed') return false;
+
+    clearTimer(npc);
+    const delay = numericDelay(delayMs);
+    npc.corpseDecayState = 'scheduled';
+    npc.corpseDecaySession = sourceSession || null;
+    npc.corpseDecayAt = Date.now() + delay;
+    npc.corpseDecayTimer = setTimeout(() => {
+        try {
+            decay(world, npc);
+        }
+        catch (error) {
+            // Leave the scheduled state intact so the reaper can retry an
+            // unexpected failure on the next pass.
+            logWarning('timer failed', error);
+        }
+    }, delay);
+    // A corpse timer must never keep a test process or a graceful server
+    // shutdown alive on its own. The reaper remains the durable fallback.
+    npc.corpseDecayTimer.unref?.();
+    return true;
+}
+
+function decay(world, npc) {
+    if (!world?.npc?.spawns || !npc?.fetchId) return false;
+    if (npc.corpseDecayState === 'removed') return false;
+
+    let npcId;
+    try {
+        npcId = npc.fetchId();
+    }
+    catch (error) {
+        logWarning('failed to read NPC id during decay', error);
+        return false;
+    }
+    const sourceSession = npc.corpseDecaySession;
+    npc.corpseDecayState = 'removed';
+    npc.corpseDecayAt = 0;
+    clearTimer(npc);
+
+    // Remove the server object first. Packet delivery is best effort and may
+    // fail for a disconnected client; it must not leave a corpse in the grid.
+    world.npc.spawns = world.npc.spawns.filter((entry) => {
+        if (entry === npc) return false;
+        try {
+            return entry?.fetchId?.() !== npcId;
+        }
+        catch (error) {
+            logWarning('failed to read a neighboring NPC id during decay', error);
+            return true;
+        }
+    });
+
+    try {
+        world.indexSpawnsInGrid?.();
+    }
+    catch (error) {
+        // Grid repair is useful but must not prevent the client deletion
+        // packet or strand the corpse in the known-object view.
+        logWarning(`grid rebuild failed for NPC ${npcId}`, error);
+    }
+
+    try {
+        NpcVisibility.deleteKnownNpc(world, sourceSession, npcId);
+    }
+    catch (error) {
+        logWarning(`failed to notify deletion for NPC ${npcId}`, error);
+    }
+
+    return true;
+}
+
+function sweepExpired(world, now = Date.now()) {
+    if (!world?.npc?.spawns) return 0;
+
+    let removed = 0;
+    [...world.npc.spawns].forEach((npc) => {
+        try {
+            if (
+                npc?.corpseDecayState !== 'removed' &&
+                Number(npc?.corpseDecayAt || 0) > 0 &&
+                Number(npc.corpseDecayAt) <= Number(now)
+            ) {
+                if (decay(world, npc)) removed += 1;
+            }
+        }
+        catch (error) {
+            // One malformed corpse must not block every later corpse in the
+            // same sweep. Keep it scheduled for a future retry.
+            logWarning('individual sweep failed', error);
+        }
+    });
+    return removed;
+}
+
+function start(world, intervalMs = DEFAULT_REAPER_INTERVAL_MS) {
+    stop(world);
+    if (!world?.npc) return null;
+
+    const interval = Math.max(50, Number(intervalMs) || DEFAULT_REAPER_INTERVAL_MS);
+    world.npc.corpseDecayReaper = setInterval(() => {
+        try {
+            sweepExpired(world);
+        }
+        catch (error) {
+            // One malformed NPC must not stop future corpse cleanup.
+            logWarning('reaper failed', error);
+        }
+    }, interval);
+    world.npc.corpseDecayReaper.unref?.();
+    return world.npc.corpseDecayReaper;
+}
+
+function stop(world) {
+    if (!world?.npc?.corpseDecayReaper) return;
+    clearInterval(world.npc.corpseDecayReaper);
+    world.npc.corpseDecayReaper = undefined;
+}
+
+module.exports = {
+    schedule,
+    decay,
+    sweepExpired,
+    start,
+    stop
+};

--- a/src/GameServer/World/Generics/NpcDecay.js
+++ b/src/GameServer/World/Generics/NpcDecay.js
@@ -1,6 +1,7 @@
 const NpcVisibility = invoke('GameServer/World/NpcVisibility');
 
 const DEFAULT_REAPER_INTERVAL_MS = 1000;
+const MAX_SWEEP_FAILURES = 3;
 
 function logWarning(message, error) {
     const detail = error?.message || error || 'unknown error';
@@ -29,6 +30,7 @@ function schedule(world, sourceSession, npc, delayMs) {
     npc.corpseDecayState = 'scheduled';
     npc.corpseDecaySession = sourceSession || null;
     npc.corpseDecayAt = Date.now() + delay;
+    npc.corpseDecaySweepFailures = 0;
     npc.corpseDecayTimer = setTimeout(() => {
         try {
             decay(world, npc);
@@ -60,6 +62,8 @@ function decay(world, npc) {
     const sourceSession = npc.corpseDecaySession;
     npc.corpseDecayState = 'removed';
     npc.corpseDecayAt = 0;
+    npc.corpseDecaySession = null;
+    npc.corpseDecaySweepFailures = 0;
     clearTimer(npc);
 
     // Remove the server object first. Packet delivery is best effort and may
@@ -94,11 +98,34 @@ function decay(world, npc) {
     return true;
 }
 
+function discardUnremovableNpc(world, npc, attempts) {
+    if (!world?.npc?.spawns || !npc) return false;
+
+    const previousLength = world.npc.spawns.length;
+    world.npc.spawns = world.npc.spawns.filter((entry) => entry !== npc);
+    npc.corpseDecayState = 'removed';
+    npc.corpseDecayAt = 0;
+    npc.corpseDecaySession = null;
+    npc.corpseDecaySweepFailures = 0;
+    clearTimer(npc);
+
+    try {
+        world.indexSpawnsInGrid?.();
+    }
+    catch (error) {
+        logWarning('grid rebuild failed while discarding an unremovable NPC', error);
+    }
+
+    logWarning(`discarded unremovable corpse after ${attempts} failed attempts`, 'NPC id unavailable');
+    return world.npc.spawns.length < previousLength;
+}
+
 function sweepExpired(world, now = Date.now()) {
     if (!world?.npc?.spawns) return 0;
 
     let removed = 0;
     [...world.npc.spawns].forEach((npc) => {
+        let failed = false;
         try {
             if (
                 npc?.corpseDecayState !== 'removed' &&
@@ -106,12 +133,22 @@ function sweepExpired(world, now = Date.now()) {
                 Number(npc.corpseDecayAt) <= Number(now)
             ) {
                 if (decay(world, npc)) removed += 1;
+                else failed = true;
             }
         }
         catch (error) {
             // One malformed corpse must not block every later corpse in the
             // same sweep. Keep it scheduled for a future retry.
             logWarning('individual sweep failed', error);
+            failed = true;
+        }
+
+        if (failed) {
+            const attempts = Number(npc?.corpseDecaySweepFailures || 0) + 1;
+            npc.corpseDecaySweepFailures = attempts;
+            if (attempts >= MAX_SWEEP_FAILURES && discardUnremovableNpc(world, npc, attempts)) {
+                removed += 1;
+            }
         }
     });
     return removed;

--- a/src/GameServer/World/Generics/RemoveNpc.js
+++ b/src/GameServer/World/Generics/RemoveNpc.js
@@ -1,11 +1,22 @@
 const SpoilSweep     = invoke('GameServer/Npc/SpoilSweep');
 const SpawnNpcs      = invoke('GameServer/World/Generics/SpawnNpcs');
-const NpcVisibility  = invoke('GameServer/World/NpcVisibility');
+const NpcDecay        = invoke('GameServer/World/Generics/NpcDecay');
 
 function removeNpc(session, npc) {
     const npcId = npc.fetchId();
+
+    let corpseDelay = 0;
+    try {
+        corpseDelay = SpoilSweep.corpseTime(npc);
+    }
+    catch (error) {
+        utils.infoWarn('NpcDecay', 'failed to calculate corpse time for NPC %d: %s', npcId, error.message);
+    }
+    // Register decay before any reward or quest side effect can fail. The
+    // reaper is a durable fallback for the one-shot timer below.
+    NpcDecay.schedule(this, session, npc, corpseDelay);
+
     SpawnNpcs.clearQuestSpawn(npc);
-    this.npcRewards(session, npc);
 
     // Datapack respawn is measured from the death event, independently of
     // the temporary corpse remaining visible in the world.
@@ -13,17 +24,24 @@ function removeNpc(session, npc) {
     if (SpawnNpcs.shouldRespawn(definition?.spawn)) {
         const delayMs = SpawnNpcs.respawnDelayMs(definition.spawn);
         setTimeout(() => {
-            this.spawnNpc(this, definition);
-            this.indexSpawnsInGrid();
+            try {
+                this.spawnNpc(this, definition);
+                this.indexSpawnsInGrid();
+            }
+            catch (error) {
+                utils.infoWarn('Spawn', 'failed to respawn NPC %d: %s', npcId, error.message);
+            }
         }, delayMs);
     }
 
-    // Delete NPC from world
-    setTimeout(() => {
-        NpcVisibility.deleteKnownNpc(this, session, npcId);
-        this.npc.spawns = this.npc.spawns.filter(ob => ob.fetchId() !== npcId);
-        this.indexSpawnsInGrid();
-    }, SpoilSweep.corpseTime(npc));
+    try {
+        this.npcRewards(session, npc);
+    }
+    catch (error) {
+        // Rewards are auxiliary to corpse cleanup. A bad drop row or a
+        // disconnected recipient must not strand the dead NPC forever.
+        utils.infoWarn('NpcRewards', 'failed for NPC %d: %s', npcId, error.message);
+    }
 }
 
 module.exports = removeNpc;

--- a/src/GameServer/World/NpcVisibility.js
+++ b/src/GameServer/World/NpcVisibility.js
@@ -47,7 +47,14 @@ function npcRemovalRecipients(world, sourceSession, npcId) {
 function deleteKnownNpc(world, sourceSession, npcId, response = ServerResponse) {
     const packet = response.deleteOb(npcId);
     const recipients = npcRemovalRecipients(world, sourceSession, npcId);
-    recipients.forEach((session) => session.dataSendToMe(packet));
+    recipients.forEach((session) => {
+        try {
+            session.dataSendToMe(packet);
+        }
+        catch (error) {
+            utils.infoWarn('NpcVisibility', 'failed to send DeleteObject for NPC %d: %s', npcId, error.message);
+        }
+    });
     return recipients.size;
 }
 

--- a/src/GameServer/World/World.js
+++ b/src/GameServer/World/World.js
@@ -1,6 +1,7 @@
 const ServerResponse = invoke('GameServer/Network/Response');
 const ConsoleText    = invoke('GameServer/ConsoleText');
 const SpeckMath      = invoke('GameServer/SpeckMath');
+const NpcDecay       = invoke('GameServer/World/Generics/NpcDecay');
 
 function actorLoc(actor) {
     return {
@@ -99,12 +100,14 @@ const World = {
     waitForBotSession,
 
     init() {
+        NpcDecay.stop(this);
         this.user  = { sessions : [], revision: 0 };
         this.npc   = { spawns   : [], grid: {}, nextId: 1000000 };
         this.items = { spawns   : [], nextId: 5000000 };
 
         World.spawnNpcs();
         this.indexSpawnsInGrid();
+        NpcDecay.start(this);
         invoke('GameServer/Npc/NpcAggro').startAggroTicker(this);
     },
 

--- a/tests/test_npc_decay.js
+++ b/tests/test_npc_decay.js
@@ -67,6 +67,7 @@ function wait(ms) {
         1,
         'the viewer must receive exactly one DeleteObject'
     );
+    assert.strictEqual(directNpc.corpseDecaySession, null, 'removed corpses must not retain their source session');
     assert.strictEqual(NpcDecay.decay(directWorld, directNpc), false, 'decay must be idempotent');
 
     const botSource = { accountId: 'bot_hot_test', dataSendToMe() {} };
@@ -133,6 +134,25 @@ function wait(ms) {
     const malformedWorld = world([malformedNpc, laterNpc]);
     assert.doesNotThrow(() => NpcDecay.sweepExpired(malformedWorld), 'one malformed NPC must not abort the whole sweep');
     assert.strictEqual(malformedWorld.npc.spawns.includes(laterNpc), false, 'later overdue NPCs must still decay');
+    assert.strictEqual(NpcDecay.sweepExpired(malformedWorld, Date.now()), 0, 'a malformed corpse should retry before being discarded');
+    assert.strictEqual(NpcDecay.sweepExpired(malformedWorld, Date.now()), 1, 'the final failed attempt should discard the malformed corpse');
+    assert.strictEqual(malformedWorld.npc.spawns.includes(malformedNpc), false, 'an unremovable corpse must not retry forever');
+    assert.strictEqual(malformedNpc.corpseDecayState, 'removed', 'discarded malformed corpses must be marked removed');
+    assert.strictEqual(malformedNpc.corpseDecayAt, 0, 'discarded malformed corpses must clear their expiry');
+
+    const reaperTimerNpc = npc(9100008);
+    reaperTimerNpc.corpseDecayState = 'scheduled';
+    reaperTimerNpc.corpseDecayAt = Date.now() - 1;
+    const reaperTimerWorld = world([reaperTimerNpc]);
+    NpcDecay.start(reaperTimerWorld, 50);
+    try {
+        await wait(150);
+        assert.strictEqual(reaperTimerWorld.npc.spawns.length, 0, 'start must run the reaper for overdue corpses');
+    }
+    finally {
+        NpcDecay.stop(reaperTimerWorld);
+    }
+    assert.strictEqual(reaperTimerWorld.npc.corpseDecayReaper, undefined, 'stop must clear the reaper interval');
 
     const rewardFailureNpc = npc(9100005);
     const rewardFailureWorld = world([rewardFailureNpc]);

--- a/tests/test_npc_decay.js
+++ b/tests/test_npc_decay.js
@@ -1,0 +1,154 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const NpcDecay = invoke('GameServer/World/Generics/NpcDecay');
+const NpcVisibility = invoke('GameServer/World/NpcVisibility');
+const RemoveNpc = invoke('GameServer/World/Generics/RemoveNpc');
+
+function npcInfo(id) {
+    const packet = Buffer.alloc(5);
+    packet[0] = 0x16;
+    packet.writeInt32LE(id, 1);
+    return packet;
+}
+
+function deleteObjectId(packet) {
+    return packet?.[0] === 0x12 ? packet.readInt32LE(1) : null;
+}
+
+function viewer(online = true, fail = false) {
+    return {
+        actor: { fetchIsOnline: () => online },
+        sent: [],
+        dataSendToMe(packet) {
+            if (fail) throw new Error('socket closed');
+            this.sent.push(packet);
+            NpcVisibility.trackNpcPacket(this, packet);
+        }
+    };
+}
+
+function npc(id, corpseTime = 10) {
+    return {
+        fetchId: () => id,
+        fetchCorpseTime: () => corpseTime,
+        model: {}
+    };
+}
+
+function world(spawns, sessions = []) {
+    return {
+        user: { sessions },
+        npc: { spawns, grid: {} },
+        indexCalls: 0,
+        indexSpawnsInGrid() {
+            this.indexCalls += 1;
+        }
+    };
+}
+
+function wait(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+(async () => {
+    const directViewer = viewer();
+    const directNpc = npc(9100001);
+    NpcVisibility.trackNpcPacket(directViewer, npcInfo(directNpc.fetchId()));
+    const directWorld = world([directNpc], [directViewer]);
+
+    assert.strictEqual(NpcDecay.schedule(directWorld, directViewer, directNpc, 5), true);
+    await wait(30);
+    assert.strictEqual(directWorld.npc.spawns.length, 0, 'a corpse timer must remove the NPC from the world');
+    assert.strictEqual(directWorld.indexCalls, 1, 'corpse removal must rebuild the NPC grid');
+    assert.strictEqual(
+        directViewer.sent.map(deleteObjectId).filter((id) => id === directNpc.fetchId()).length,
+        1,
+        'the viewer must receive exactly one DeleteObject'
+    );
+    assert.strictEqual(NpcDecay.decay(directWorld, directNpc), false, 'decay must be idempotent');
+
+    const botSource = { accountId: 'bot_hot_test', dataSendToMe() {} };
+    const companionViewer = viewer();
+    const companionNpc = npc(9100002);
+    NpcVisibility.trackNpcPacket(companionViewer, npcInfo(companionNpc.fetchId()));
+    const companionWorld = world([companionNpc], [companionViewer]);
+    NpcDecay.schedule(companionWorld, botSource, companionNpc, 10000);
+    assert.strictEqual(NpcDecay.decay(companionWorld, companionNpc), true, 'hot-bot/companion kills must use the same decay path');
+    assert.strictEqual(companionWorld.npc.spawns.length, 0, 'companion corpse must leave the world immediately when decayed');
+    assert.strictEqual(
+        companionViewer.sent.map(deleteObjectId).filter((id) => id === companionNpc.fetchId()).length,
+        1,
+        'a player who saw a companion kill must receive DeleteObject'
+    );
+
+    const failingViewer = viewer(true, true);
+    const healthyViewer = viewer();
+    const failedNpc = npc(9100003);
+    NpcVisibility.trackNpcPacket(failingViewer, npcInfo(failedNpc.fetchId()));
+    NpcVisibility.trackNpcPacket(healthyViewer, npcInfo(failedNpc.fetchId()));
+    const failedWorld = world([failedNpc], [failingViewer, healthyViewer]);
+    NpcDecay.schedule(failedWorld, botSource, failedNpc, 10000);
+    assert.doesNotThrow(() => NpcDecay.decay(failedWorld, failedNpc), 'one broken client must not abort corpse cleanup');
+    assert.strictEqual(failedWorld.npc.spawns.length, 0, 'world cleanup must happen even when packet delivery fails');
+    assert.strictEqual(
+        healthyViewer.sent.map(deleteObjectId).filter((id) => id === failedNpc.fetchId()).length,
+        1,
+        'healthy viewers must still receive DeleteObject after another viewer fails'
+    );
+
+    const gridFailureViewer = viewer();
+    const gridFailureNpc = npc(9100006);
+    NpcVisibility.trackNpcPacket(gridFailureViewer, npcInfo(gridFailureNpc.fetchId()));
+    const gridFailureWorld = world([gridFailureNpc], [gridFailureViewer]);
+    gridFailureWorld.indexSpawnsInGrid = () => {
+        throw new Error('grid rebuild failed');
+    };
+    assert.doesNotThrow(() => NpcDecay.decay(gridFailureWorld, gridFailureNpc), 'grid failure must not abort corpse deletion');
+    assert.strictEqual(gridFailureWorld.npc.spawns.length, 0, 'grid failure must not retain the corpse');
+    assert.strictEqual(
+        gridFailureViewer.sent.map(deleteObjectId).filter((id) => id === gridFailureNpc.fetchId()).length,
+        1,
+        'grid failure must not suppress DeleteObject'
+    );
+
+    const reaperNpc = npc(9100004);
+    reaperNpc.corpseDecayState = 'scheduled';
+    reaperNpc.corpseDecayAt = Date.now() - 1;
+    const reaperWorld = world([reaperNpc]);
+    assert.strictEqual(NpcDecay.sweepExpired(reaperWorld), 1, 'the reaper must remove overdue corpses');
+    assert.strictEqual(reaperWorld.npc.spawns.length, 0, 'the reaper must remove overdue NPCs from the world');
+
+    const malformedNpc = {
+        corpseDecayState: 'scheduled',
+        corpseDecayAt: Date.now() - 1,
+        fetchId() {
+            throw new Error('malformed npc id');
+        }
+    };
+    const laterNpc = npc(9100007);
+    laterNpc.corpseDecayState = 'scheduled';
+    laterNpc.corpseDecayAt = Date.now() - 1;
+    const malformedWorld = world([malformedNpc, laterNpc]);
+    assert.doesNotThrow(() => NpcDecay.sweepExpired(malformedWorld), 'one malformed NPC must not abort the whole sweep');
+    assert.strictEqual(malformedWorld.npc.spawns.includes(laterNpc), false, 'later overdue NPCs must still decay');
+
+    const rewardFailureNpc = npc(9100005);
+    const rewardFailureWorld = world([rewardFailureNpc]);
+    rewardFailureWorld.npcRewards = () => {
+        throw new Error('drop calculation failed');
+    };
+    RemoveNpc.call(rewardFailureWorld, viewer(), rewardFailureNpc);
+    await wait(30);
+    assert.strictEqual(
+        rewardFailureWorld.npc.spawns.length,
+        0,
+        'a reward exception must not strand the corpse before decay is registered'
+    );
+
+    console.log('NPC decay lifecycle regression checks passed');
+})().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- Add a durable NPC corpse-decay scheduler with a one-second reaper fallback.
- Remove dead NPCs from the world spawn list and rebuild the NPC grid.
- Notify the source session and every online viewer that still knows the NPC, including hot-bot/companion kill paths.
- Isolate reward, packet-delivery, grid-rebuild, timer, and malformed-NPC failures so one error cannot strand or block other corpses.

## Root cause

NPC cleanup depended on a one-shot timeout in the death handler. Exceptions from reward processing, client packet delivery, grid rebuilding, or an individual malformed NPC could prevent the cleanup path from completing, leaving a corpse visible or retained in server state.

## Validation

- `node tests/test_npc_decay.js`
- `node tests/test_npc_known_object_lifecycle.js`
- `node tests/test_npc_respawn.js`
- `node scripts/check-syntax.js` — 782 JavaScript files
- `npm test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - NPC corpses now decay automatically after a configurable delay.
  - Expired corpses are cleaned up reliably, including after temporary server interruptions.
  - NPC removal updates world visibility and spawn state consistently.

- **Bug Fixes**
  - NPC deletion notifications continue reaching other nearby players when one delivery fails.
  - NPC cleanup remains resilient when malformed data or other processing errors occur.

- **Tests**
  - Added regression coverage for corpse decay, cleanup failures, visibility updates, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->