### PR TITLE
Keep player-led raid parties engaged and rebalance raid encounters

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -61,6 +61,7 @@ const tests = [
     'tests/test_bot_agent_support_confirmation.js',
     'tests/test_bot_combat_skill_selection.js',
     'tests/test_bot_raid_safety.js',
+    'tests/test_raid_boss_balance.js',
     'tests/test_raid_entity_index.js',
     'tests/test_bot_conversation.js',
     'tests/test_bot_ambient_director.js',

--- a/src/GameServer/Bot/AI/BotRaidSafety.js
+++ b/src/GameServer/Bot/AI/BotRaidSafety.js
@@ -151,15 +151,22 @@ function raidHasPartyCombat(leaderSession, raid) {
 
     const entities = raidEntities(raid);
     if (entities.some((npc) => memberIds.has(Number(npc.fetchDestId?.() || 0)))) return true;
-    const boss = entities.find((npc) => isRaidBoss(npc)) || null;
-    const attackers = boss?.model?.raidAttackers;
-    const attackerIds = attackers instanceof Set
-        ? new Set([...attackers].map(Number))
-        : new Set((Array.isArray(attackers) ? attackers : []).map(Number));
-    return sessions.some((session) => (
-        attackerIds.has(objectId(session.actor)) &&
-        currentCombatTargetId(session.actor) === objectId(boss)
-    ));
+    const entityIds = new Set(entities.map(objectId).filter(Boolean));
+    return sessions.some((session) => entityIds.has(currentCombatTargetId(session.actor)));
+}
+
+function startPlayerPartyRaid(leaderSession, boss, now) {
+    const opener = selectRaidOpener(leaderSession);
+    const raid = {
+        bossId: objectId(boss),
+        bossTemplateId: templateId(boss),
+        openerId: objectId(opener?.actor),
+        phase: 'opening',
+        selectedAt: now,
+        lastActiveAt: now
+    };
+    leaderSession.partyRaidEngagement = raid;
+    return raid;
 }
 
 function syncPlayerPartyRaid(leaderSession, now = Date.now()) {
@@ -178,17 +185,21 @@ function syncPlayerPartyRaid(leaderSession, now = Date.now()) {
         raid = null;
     }
 
-    if (!raid && selectedBoss) {
-        const opener = selectRaidOpener(leaderSession);
-        raid = {
+    if (selectedBoss) {
+        const selectedRaid = {
             bossId: objectId(selectedBoss),
-            bossTemplateId: templateId(selectedBoss),
-            openerId: objectId(opener?.actor),
-            phase: 'opening',
-            selectedAt: now,
-            lastActiveAt: now
+            bossTemplateId: templateId(selectedBoss)
         };
-        leaderSession.partyRaidEngagement = raid;
+        const selectedMatches = Number(selectedRaid.bossId) === Number(raid?.bossId || 0);
+        // Reconcile an opening target atomically. During combat, change raids
+        // only when live party targeting/aggro proves that the newly selected
+        // entity is the fight in progress; a stray click must not abandon the
+        // current raid's grace period.
+        if (!raid || (!selectedMatches && (
+            raid.phase === 'opening' || raidHasPartyCombat(leaderSession, selectedRaid)
+        ))) {
+            raid = startPlayerPartyRaid(leaderSession, selectedBoss, now);
+        }
     }
 
     if (!raid) return null;

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -963,8 +963,12 @@ module.exports = {
         if (partyRaid) {
             pulling = { enabled: false, target: null, puller: null, engageable: false, phase: null };
         }
-        const rawPartyThreat = PartyAwareness.findThreatTargetingParty(playerSession);
-        if (rawPartyThreat?.type === 'raid') {
+        let rawPartyThreat = PartyAwareness.findThreatTargetingParty(playerSession);
+        if (rawPartyThreat?.type === 'raid' && !BotRaidSafety.canEngagePlayerPartyRaid(
+            session,
+            rawPartyThreat.actor,
+            playerSession
+        )) {
             PartyPulling.cancel(playerSession);
             if (BotRaidSafety.retreat(session, bot, rawPartyThreat.actor)) {
                 recordRoleDecision(session, bot, 'retreat', 'raid_entity_protected', {
@@ -973,6 +977,12 @@ module.exports = {
                 });
             }
             return;
+        }
+        if (rawPartyThreat?.type === 'raid') {
+            // Engagement may have become authoritative after threat discovery.
+            // The selected opener (opening) and matching party members (combat)
+            // must flow through the ordinary assist path, never raid retreat.
+            rawPartyThreat = { ...rawPartyThreat, type: 'npc' };
         }
         const holdingPulledTarget = pulling.target && !pulling.engageable;
         const rawThreatIsHeldPull = holdingPulledTarget &&

--- a/src/GameServer/DataCache.js
+++ b/src/GameServer/DataCache.js
@@ -1,5 +1,6 @@
 const validateSchema = require('jsonschema').validate;
 const ClassProgression = invoke('GameServer/ClassProgression');
+const RaidBossBalance = invoke('GameServer/RaidBoss/RaidBossBalance');
 
 const DataCache = {
     init: () => {
@@ -55,6 +56,7 @@ const DataCache = {
             ...C4LateTownGatekeepers.npcs,
             ...C4SevenSignsDungeonTeleports.npcs
         ];
+        DataCache.npcs = RaidBossBalance.weakenTemplates(DataCache.npcs);
         DataCache.npcSpawns       = [
             ...validateModel(path + 'Npcs/Spawns/spawns'),
             ...validateModel(path + 'Npcs/Spawns/c4_swamp_of_screams'),

--- a/src/GameServer/RaidBoss/RaidBossBalance.js
+++ b/src/GameServer/RaidBoss/RaidBossBalance.js
@@ -1,0 +1,58 @@
+const raidBossMinionDefinitions = require('../../../data/Npcs/Minions/c4_raid_bosses.json');
+
+const RAID_ENTITY_SCALE = 0.75;
+const raidBossMinionIds = new Set(
+    raidBossMinionDefinitions
+        .map((entry) => Number(entry?.minionId))
+        .filter((id) => Number.isInteger(id) && id > 0)
+);
+
+function isRaidBossTemplate(row) {
+    return row?.template?.raidBoss === true || row?.raidBoss === true;
+}
+
+function isRaidBossMinionTemplate(row) {
+    return raidBossMinionIds.has(Number(row?.selfId));
+}
+
+function isRaidEntityTemplate(row) {
+    return isRaidBossTemplate(row) || isRaidBossMinionTemplate(row);
+}
+
+function scaleStat(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric <= 0) return value;
+    return Math.max(1, Math.round(numeric * RAID_ENTITY_SCALE));
+}
+
+function weakenTemplate(row) {
+    if (!isRaidEntityTemplate(row)) return row;
+
+    const next = structuredClone(row);
+    next.stats = { ...(next.stats || {}) };
+    next.vitals = { ...(next.vitals || {}) };
+
+    ['pAtk', 'mAtk', 'pDef', 'mDef'].forEach((key) => {
+        if (Object.prototype.hasOwnProperty.call(next.stats, key)) {
+            next.stats[key] = scaleStat(next.stats[key]);
+        }
+    });
+    if (Object.prototype.hasOwnProperty.call(next.vitals, 'maxHp')) {
+        next.vitals.maxHp = scaleStat(next.vitals.maxHp);
+    }
+
+    return next;
+}
+
+function weakenTemplates(rows) {
+    return Array.isArray(rows) ? rows.map(weakenTemplate) : rows;
+}
+
+module.exports = {
+    RAID_ENTITY_SCALE,
+    isRaidBossTemplate,
+    isRaidBossMinionTemplate,
+    isRaidEntityTemplate,
+    weakenTemplate,
+    weakenTemplates
+};

--- a/src/GameServer/RaidBoss/RaidBossBalance.js
+++ b/src/GameServer/RaidBoss/RaidBossBalance.js
@@ -37,9 +37,11 @@ function weakenTemplate(row) {
             next.stats[key] = scaleStat(next.stats[key]);
         }
     });
-    if (Object.prototype.hasOwnProperty.call(next.vitals, 'maxHp')) {
-        next.vitals.maxHp = scaleStat(next.vitals.maxHp);
-    }
+    ['maxHp', 'revHp'].forEach((key) => {
+        if (Object.prototype.hasOwnProperty.call(next.vitals, key)) {
+            next.vitals[key] = scaleStat(next.vitals[key]);
+        }
+    });
 
     return next;
 }

--- a/tests/test_bot_raid_safety.js
+++ b/tests/test_bot_raid_safety.js
@@ -71,6 +71,13 @@ const minion = actor(6002, {
     minionBossObjectId: boss.fetchId(),
     locX: 120
 });
+const staleBoss = actor(6004, {
+    selfId: 10004,
+    name: 'stale raid boss',
+    attackable: true,
+    raidBoss: true,
+    locX: 160
+});
 const regular = actor(6003, {
     selfId: 1,
     name: 'ordinary monster',
@@ -133,6 +140,21 @@ assert.strictEqual(engagement.phase, 'opening',
 leader.state.fetchCombats = () => true;
 engagement = BotRaidSafety.syncPlayerPartyRaid(leaderSession, 1001);
 assert.strictEqual(engagement.phase, 'combat', 'a player hit must release the party into standard raid combat');
+staleBoss.model = { raidBoss: true, raidAttackers: new Set() };
+World.npc.spawns = [boss, minion, regular, staleBoss];
+leaderSession.partyRaidEngagement = {
+    bossId: staleBoss.fetchId(),
+    bossTemplateId: staleBoss.fetchSelfId(),
+    openerId: tank.fetchId(),
+    phase: 'combat',
+    selectedAt: 900,
+    lastActiveAt: 1001
+};
+engagement = BotRaidSafety.syncPlayerPartyRaid(leaderSession, 1002);
+assert.strictEqual(engagement.bossId, boss.fetchId(),
+    'live player combat with the selected boss must replace a stale engagement entity atomically');
+assert.strictEqual(engagement.phase, 'combat',
+    'the reconciled selected boss must remain normal party combat without an opening retreat race');
 boss.fetchDestId = () => leader.fetchId();
 assert.strictEqual(BotRaidSafety.canEngagePlayerPartyRaid(heavySession, boss, leaderSession), true,
     'all companions may attack the boss after combat begins');
@@ -154,6 +176,8 @@ assert.strictEqual(PartyAwareness.leaderCombatTargetId(leaderSession, { allowPla
 
 boss.fetchDestId = () => undefined;
 minion.fetchDestId = () => tank.fetchId();
+assert.strictEqual(PartyAwareness.findThreatTargetingParty(leaderSession).type, 'npc',
+    'a matching engaged raid minion must remain a normal party assist target');
 tankSession.incomingThreatId = minion.fetchId();
 tankSession.incomingThreatAt = Date.now();
 EffectStore.apply(minion, { key: 'sleep', id: 1069, category: 'sleep', type: 'debuff', duration: 30000 });

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -21,6 +21,7 @@ const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 const BotSupportPlanner = invoke('GameServer/Bot/AI/BotSupportPlanner');
 const BotSkillCapabilities = invoke('GameServer/Bot/AI/BotSkillCapabilities');
 const PartyClassTactics = invoke('GameServer/Bot/AI/PartyClassTactics');
+const BotRaidSafety = invoke('GameServer/Bot/AI/BotRaidSafety');
 const BotPartyChat = invoke('GameServer/Bot/AI/BotPartyChat');
 const C4SkillRules = invoke('GameServer/Skills/C4SkillRules');
 const MarketOpportunity = invoke('GameServer/Bot/Economy/MarketOpportunity');
@@ -266,10 +267,26 @@ try {
 
     const raidBoss = {
         model: { raidBoss: true, raidAttackers: new Set() },
+        destId: undefined,
         fetchId: () => 9100001,
         fetchSelfId: () => 25325,
         fetchName: () => 'party raid target',
         fetchLocX: () => 400,
+        fetchLocY: () => 0,
+        fetchLocZ: () => 0,
+        fetchLevel: () => 40,
+        fetchAttackable: () => true,
+        fetchIsRaidBoss: () => true,
+        fetchDestId() { return this.destId; },
+        isDead: () => false,
+        state: { fetchDead: () => false }
+    };
+    const staleRaidBoss = {
+        model: { raidBoss: true, raidAttackers: new Set() },
+        fetchId: () => 9100000,
+        fetchSelfId: () => 25324,
+        fetchName: () => 'stale party raid target',
+        fetchLocX: () => 500,
         fetchLocY: () => 0,
         fetchLocZ: () => 0,
         fetchLevel: () => 40,
@@ -299,9 +316,19 @@ try {
     raidHealerSession.partyCompanion = true;
     raidHealerSession.plan = 'following';
     leader.destId = raidBoss.fetchId();
+    raidHealerSession.incomingThreatId = raidBoss.fetchId();
+    raidHealerSession.incomingThreatAt = Date.now();
+    leaderSession.partyRaidEngagement = {
+        bossId: staleRaidBoss.fetchId(),
+        bossTemplateId: staleRaidBoss.fetchSelfId(),
+        openerId: raidTank.fetchId(),
+        phase: 'opening',
+        selectedAt: Date.now() - 1000,
+        lastActiveAt: Date.now() - 1000
+    };
     World.user = { sessions: [leaderSession, raidDpsSession, raidTankSession, raidHealerSession] };
-    World.npc = { spawns: [raidBoss] };
-    World.fetchNpcsInRadius = () => [raidBoss];
+    World.npc = { spawns: [staleRaidBoss, raidBoss] };
+    World.fetchNpcsInRadius = () => [staleRaidBoss, raidBoss];
     const raidOpeners = [];
     const raidHeals = [];
     const raidBotAI = {
@@ -314,6 +341,14 @@ try {
     FollowingState.tick(raidHealerSession, raidHealer, {
         skillExec(_session, actor, data) { raidHeals.push({ actor, data }); }
     }, raidBotAI);
+    assert.strictEqual(raidHealerSession.plan, 'following',
+        'a selected boss recorded as a recent opening threat must not make a companion flee');
+    assert.strictEqual(leaderSession.partyRaidEngagement?.bossId, raidBoss.fetchId(),
+        'opening must atomically reconcile a stale engagement to the live selected boss');
+    assert.strictEqual(EffectStore.hasDebuff(raidHealer, 'fear'), false,
+        'raid-safety reconciliation must not apply a Fear effect');
+    delete raidHealerSession.incomingThreatId;
+    delete raidHealerSession.incomingThreatAt;
     FollowingState.tick(raidDpsSession, raidDps, {}, raidBotAI);
     FollowingState.tick(raidTankSession, raidTank, {}, raidBotAI);
     assert.strictEqual(raidHeals.length, 1, 'a healer must recover the selected opener before the raid starts');
@@ -330,8 +365,67 @@ try {
     assert.strictEqual(raidOpeners[0].options.playerPartyRaidLeaderSession, leaderSession,
         'the raid combat exception must remain scoped to this real-player party');
     assert.deepStrictEqual(leaderSession.partyPullState || {}, {}, 'player raid designation must not create a bot pull');
+
+    const raidMinion = {
+        minionBossObjectId: raidBoss.fetchId(),
+        destId: raidDps.fetchId(),
+        fetchId: () => 9100002,
+        fetchSelfId: () => 25326,
+        fetchName: () => 'party raid minion',
+        fetchLocX: () => 420,
+        fetchLocY: () => 0,
+        fetchLocZ: () => 0,
+        fetchLevel: () => 40,
+        fetchAttackable: () => true,
+        fetchIsRaidBoss: () => false,
+        fetchDestId() { return this.destId; },
+        isDead: () => false,
+        state: { fetchDead: () => false }
+    };
+    leader.state.fetchCombats = () => true;
+    raidBoss.destId = leader.fetchId();
+    World.npc = { spawns: [raidBoss, raidMinion] };
+    World.fetchNpcsInRadius = () => [raidBoss, raidMinion];
+    raidOpeners.length = 0;
+    FollowingState.tick(raidDpsSession, raidDps, {}, raidBotAI);
+    assert.strictEqual(BotRaidSafety.syncPlayerPartyRaid(leaderSession)?.phase, 'combat',
+        'live combat with the matching boss must keep the player party raid in combat');
+    assert.strictEqual(raidDpsSession.plan, 'following',
+        'a matching engaged raid boss must not make the companion flee');
+    assert.strictEqual(raidOpeners[0]?.target, raidBoss,
+        'a matching engaged raid boss must flow through normal party assist');
+
+    raidBoss.destId = undefined;
+    raidOpeners.length = 0;
+    FollowingState.tick(raidDpsSession, raidDps, {}, raidBotAI);
+    assert.strictEqual(raidDpsSession.plan, 'following',
+        'a matching engaged raid minion must not make the companion flee');
+    assert.strictEqual(raidOpeners[0]?.target, raidMinion,
+        'a matching engaged raid minion must flow through normal party assist');
+    assert.strictEqual(EffectStore.hasDebuff(raidDps, 'fear'), false,
+        'normal raid assist must not apply a Fear effect');
+
+    const unrelatedRaidBoss = {
+        ...staleRaidBoss,
+        destId: raidDps.fetchId(),
+        fetchId: () => 9100003,
+        fetchSelfId: () => 25327,
+        fetchName: () => 'unrelated raid boss',
+        fetchDestId() { return this.destId; }
+    };
+    raidMinion.destId = undefined;
+    World.npc = { spawns: [raidBoss, raidMinion, unrelatedRaidBoss] };
+    World.fetchNpcsInRadius = () => [raidBoss, raidMinion, unrelatedRaidBoss];
+    FollowingState.tick(raidDpsSession, raidDps, {}, raidBotAI);
+    assert.strictEqual(raidDpsSession.plan, 'fleeing',
+        'an unrelated unengaged raid entity targeting the party must retain raid retreat');
+    assert.strictEqual(EffectStore.hasDebuff(raidDps, 'fear'), false,
+        'raid retreat is an AI plan and must not fabricate a Fear effect');
+
     delete leaderSession.partyRaidEngagement;
     leader.destId = undefined;
+    delete leader.state.fetchCombats;
+    raidBoss.destId = undefined;
     World.npc = { spawns: [] };
     World.fetchNpcsInRadius = () => [];
 

--- a/tests/test_raid_boss_balance.js
+++ b/tests/test_raid_boss_balance.js
@@ -11,7 +11,7 @@ const minion = {
     selfId: 10002,
     template: { kind: 'Monster' },
     stats: { pAtk: 80, mAtk: 40, pDef: 120, mDef: 60 },
-    vitals: { maxHp: 801, maxMp: 200 }
+    vitals: { maxHp: 801, maxMp: 200, revHp: 8 }
 };
 const regular = {
     selfId: 1,
@@ -26,9 +26,9 @@ assert.strictEqual(RaidBossBalance.isRaidEntityTemplate(regular), false);
 
 const [scaledBoss, scaledMinion, unchanged] = RaidBossBalance.weakenTemplates([boss, minion, regular]);
 assert.deepStrictEqual(scaledBoss.stats, { pAtk: 76, mAtk: 152, pDef: 227, mDef: 303, atkSpd: 278 });
-assert.deepStrictEqual(scaledBoss.vitals, { maxHp: 751, maxMp: 500, revHp: 20 });
+assert.deepStrictEqual(scaledBoss.vitals, { maxHp: 751, maxMp: 500, revHp: 15 });
 assert.deepStrictEqual(scaledMinion.stats, { pAtk: 60, mAtk: 30, pDef: 90, mDef: 45 });
-assert.deepStrictEqual(scaledMinion.vitals, { maxHp: 601, maxMp: 200 });
+assert.deepStrictEqual(scaledMinion.vitals, { maxHp: 601, maxMp: 200, revHp: 6 });
 assert.deepStrictEqual(unchanged, regular, 'ordinary NPC templates must not be modified');
 assert.strictEqual(boss.stats.pAtk, 101, 'source templates must not be mutated');
 assert.strictEqual(minion.vitals.maxHp, 801, 'source minion templates must not be mutated');

--- a/tests/test_raid_boss_balance.js
+++ b/tests/test_raid_boss_balance.js
@@ -1,0 +1,36 @@
+const assert = require('assert');
+const RaidBossBalance = require('../src/GameServer/RaidBoss/RaidBossBalance');
+
+const boss = {
+    selfId: 10001,
+    template: { kind: 'Boss', raidBoss: true },
+    stats: { pAtk: 101, mAtk: 202, pDef: 303, mDef: 404, atkSpd: 278 },
+    vitals: { maxHp: 1001, maxMp: 500, revHp: 20 }
+};
+const minion = {
+    selfId: 10002,
+    template: { kind: 'Monster' },
+    stats: { pAtk: 80, mAtk: 40, pDef: 120, mDef: 60 },
+    vitals: { maxHp: 801, maxMp: 200 }
+};
+const regular = {
+    selfId: 1,
+    template: { kind: 'Monster' },
+    stats: { pAtk: 80, mAtk: 40, pDef: 120, mDef: 60 },
+    vitals: { maxHp: 801, maxMp: 200 }
+};
+
+assert.strictEqual(RaidBossBalance.isRaidBossTemplate(boss), true);
+assert.strictEqual(RaidBossBalance.isRaidBossMinionTemplate(minion), true);
+assert.strictEqual(RaidBossBalance.isRaidEntityTemplate(regular), false);
+
+const [scaledBoss, scaledMinion, unchanged] = RaidBossBalance.weakenTemplates([boss, minion, regular]);
+assert.deepStrictEqual(scaledBoss.stats, { pAtk: 76, mAtk: 152, pDef: 227, mDef: 303, atkSpd: 278 });
+assert.deepStrictEqual(scaledBoss.vitals, { maxHp: 751, maxMp: 500, revHp: 20 });
+assert.deepStrictEqual(scaledMinion.stats, { pAtk: 60, mAtk: 30, pDef: 90, mDef: 45 });
+assert.deepStrictEqual(scaledMinion.vitals, { maxHp: 601, maxMp: 200 });
+assert.deepStrictEqual(unchanged, regular, 'ordinary NPC templates must not be modified');
+assert.strictEqual(boss.stats.pAtk, 101, 'source templates must not be mutated');
+assert.strictEqual(minion.vitals.maxHp, 801, 'source minion templates must not be mutated');
+
+console.log('test_raid_boss_balance: ok');


### PR DESCRIPTION
## What changed

- Keep player-led party companions in combat against the selected raid boss or its minions instead of sending them into the generic raid-safety retreat path during the opening/combat handoff.
- Reconcile live raid engagement state with the selected boss entity and preserve the safety retreat for unrelated or unengaged raids.
- Apply a 25% encounter reduction to raid bosses and their linked minions for HP, HP regeneration, physical/magic attack, and physical/magic defense.
- Leave MP, movement speed, rewards, and source datapack data unchanged.

## Why

A timing and entity-mismatch race could classify a player-led raid as an unrelated protected raid, causing companions to flee immediately without a Fear effect or an HP-based trigger. Raid encounters also needed a consistent difficulty scale after reducing maximum HP, so HP regeneration is scaled with it.

## Validation

- Full npm test passed.
- npm run check passed for 955 JavaScript files.
- git diff --check origin/main...HEAD passed.
- Added regressions for raid engagement reconciliation, opening/combat transitions, unrelated raid retreat, Fear-effect absence, and raid boss/minion stat and regeneration scaling.
