### PR TITLE
Fix bot class progression, music support, and dual-sword gear

### DIFF
--- a/src/GameServer/Actor/Generics/LevelUp.js
+++ b/src/GameServer/Actor/Generics/LevelUp.js
@@ -30,7 +30,7 @@ function levelUp(session, actor, nextLevel) {
             characterId: id,
             classId,
             level,
-            seed: actor.fetchName()
+            seed: id
         }).then((progression) => {
             if (Number(progression.classId) !== Number(classId)) actor.setClassId(progression.classId);
             return new Promise((resolve) => actor.skillset.populate(id, resolve));

--- a/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
+++ b/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
@@ -143,6 +143,12 @@ function hasEquippedTwoHandedWeapon(state = {}) {
     ));
 }
 
+function missingRequiredDualSword(state = {}, role = roleFor(state), classId = classIdFor(state)) {
+    const allowedKinds = BotEquipmentCompatibility.weaponKindsFor(role, classId);
+    if (allowedKinds.length !== 1 || allowedKinds[0] !== 'Weapon.Dual') return false;
+    return !equippedInventoryItems(state.inventory).some((item) => item.template?.kind === 'Weapon.Dual');
+}
+
 function itemScore(item, role, classId) {
     const stats = item.stats || {};
     const slot = Number(item.etc?.slot || 0);
@@ -440,6 +446,7 @@ function equipInventoryUpgrades(state = {}, inventory = {}) {
 function preferredTarget(state = {}, options = {}) {
     const role = roleFor(state);
     const classId = classIdFor(state);
+    const missingDualSword = missingRequiredDualSword(state, role, classId);
     const owned = inventoryMap(state.inventory);
     const ownedItems = inventoryItems(state.inventory);
     const stationService = { level: 70, stats: { classId: 57 } };
@@ -462,7 +469,8 @@ function preferredTarget(state = {}, options = {}) {
         .map((item) => ({ item, recipe: recipesByProduct.get(Number(item.selfId)) || null }))
         .filter(({ recipe }) => !options.recipeId || Number(recipe?.recipeId) === Number(options.recipeId))
         .filter(({ item }) => Number(owned.get(Number(item.selfId)) || 0) < 1)
-        .filter(({ item }) => isSlotUpgrade(item, ownedItems, role, classId));
+        .filter(({ item }) => (missingDualSword && item.template?.kind === 'Weapon.Dual')
+            || isSlotUpgrade(item, ownedItems, role, classId));
     const requiredRank = recipeRank || gradeForLevel(state.level);
     const hasCurrentGradeWeapon = ownedItems.some((item) => (
         WEAPON_SLOTS.has(Number(item.etc?.slot || 0))
@@ -471,7 +479,7 @@ function preferredTarget(state = {}, options = {}) {
     // A viable weapon is the first milestone of a new grade. Once it is
     // covered, fill the rest of the kit before considering another weapon of
     // the same grade.
-    const weaponFirst = !hasCurrentGradeWeapon
+    const weaponFirst = !hasCurrentGradeWeapon || missingDualSword
         ? allCandidates.filter(({ item }) => WEAPON_SLOTS.has(Number(item.etc?.slot || 0)))
         : allCandidates.filter(({ item }) => !WEAPON_SLOTS.has(Number(item.etc?.slot || 0)));
     const progressionCandidates = weaponFirst.length ? weaponFirst : allCandidates;
@@ -653,6 +661,7 @@ function equippedItemAtSlot(state = {}, slot) {
 function npcCandidatesForSlot(state = {}, desiredSlot, maxRank, options = {}) {
     const role = roleFor(state);
     const classId = classIdFor(state);
+    const requiredDualSword = Number(desiredSlot) === 14 && missingRequiredDualSword(state, role, classId);
     const current = equippedItemAtSlot(state, desiredSlot);
     const currentRank = rankIndex(current?.etc?.rank);
     const currentScore = current ? itemScore(current, role, classId) : 0;
@@ -661,7 +670,9 @@ function npcCandidatesForSlot(state = {}, desiredSlot, maxRank, options = {}) {
         .filter((item) => itemMatchesDesiredSlot(item, desiredSlot))
         .filter((item) => rankIndex(item.etc?.rank) <= rankIndex(maxRank))
         .filter((item) => suitable(item, state, role, item.etc?.rank))
-        .filter((item) => rankIndex(item.etc?.rank) > currentRank || itemScore(item, role, classId) > currentScore)
+        .filter((item) => requiredDualSword
+            || rankIndex(item.etc?.rank) > currentRank
+            || itemScore(item, role, classId) > currentScore)
         .map((item) => ({ item, offer: npcOfferForTarget(item, state, options) }))
         .filter(({ offer }) => offer)
         .sort((left, right) => rankIndex(right.item.etc?.rank) - rankIndex(left.item.etc?.rank)
@@ -675,6 +686,17 @@ function staticNpcUpgradePlan(state = {}, options = {}) {
     const reserve = operationalAdenaReserve(state);
     const spendable = Math.max(0, Number(state.adena || state.inventory?.[57]?.amount || 0) - reserve);
     const slots = desiredNpcSlots(state);
+
+    if (missingRequiredDualSword(state)) {
+        const dualCandidate = npcCandidatesForSlot(state, 14, targetRank, options)[0];
+        if (dualCandidate) {
+            return marketPlan(state, dualCandidate.item, dualCandidate.offer, {
+                targetSlot: 14,
+                reason: 'required_dual_sword',
+                reserve
+            });
+        }
+    }
 
     // First establish an adequate kit. Missing/under-grade slots select the
     // cheapest compatible item at the highest ordinary NPC grade, even when

--- a/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
+++ b/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
@@ -489,7 +489,8 @@ function preferredTarget(state = {}, options = {}) {
     // grade cap (for example, D bows and daggers). Retain the weapon-first
     // milestone rather than declaring progression complete; shortlisting
     // still prevents a leap to a top-tier option.
-    const entryWeaponFallback = !hasCurrentGradeWeapon && weaponFirst.length > 0;
+    const entryWeaponFallback = (!hasCurrentGradeWeapon || missingDualSword)
+        && weaponFirst.length > 0;
     if (!options.recipeId && Number.isFinite(cap) && affordable.length === 0 && !entryWeaponFallback) return null;
     const effortOptions = options.allowedRecipeIds
         ? options

--- a/src/GameServer/Bot/BotClassProgression.js
+++ b/src/GameServer/Bot/BotClassProgression.js
@@ -1,22 +1,33 @@
 const ClassProgression = invoke('GameServer/ClassProgression');
 
 function stableNumber(value) {
-    return [...String(value || 0)].reduce((sum, character) => sum + character.charCodeAt(0), 0);
+    let hash = 2166136261;
+    for (const character of String(value ?? 0)) {
+        hash ^= character.charCodeAt(0);
+        hash = Math.imul(hash, 16777619);
+    }
+    // FNV is a good stable accumulator, but its low bit remains correlated
+    // for nearby numeric ids with similar suffixes. Avalanche the result so
+    // first- and second-profession decisions stay independent.
+    hash = Math.imul(hash ^ (hash >>> 16), 2246822507);
+    hash = Math.imul(hash ^ (hash >>> 13), 3266489909);
+    return (hash ^ (hash >>> 16)) >>> 0;
 }
 
-function pick(options, seed) {
+function pick(options, seed, stage, currentClassId) {
     if (!options?.length) return null;
-    return options[Math.abs(stableNumber(seed)) % options.length];
+    const branchSeed = `${seed ?? 0}:${stage}:${currentClassId}`;
+    return options[stableNumber(branchSeed) % options.length];
 }
 
 function nextClass(classId, level, seed) {
     const current = Number(classId);
     const currentLevel = Number(level || 1);
     if (currentLevel >= 20 && ClassProgression.firstProfMap[current]) {
-        return pick(ClassProgression.firstProfMap[current], seed);
+        return pick(ClassProgression.firstProfMap[current], seed, 'first', current);
     }
     if (currentLevel >= 40 && ClassProgression.secondProfMap[current]) {
-        return pick(ClassProgression.secondProfMap[current], seed);
+        return pick(ClassProgression.secondProfMap[current], seed, 'second', current);
     }
     if (currentLevel >= 76) {
         return Number(Object.entries(ClassProgression.thirdClasses)

--- a/src/GameServer/Bot/BotManager.js
+++ b/src/GameServer/Bot/BotManager.js
@@ -511,7 +511,7 @@ const BotManager = {
             characterId,
             classId: currentClassId,
             level,
-            seed: botData.name || characterId
+            seed: characterId
         });
     },
 

--- a/src/GameServer/Bot/Population/BackgroundPartyResolver.js
+++ b/src/GameServer/Bot/Population/BackgroundPartyResolver.js
@@ -156,6 +156,7 @@ const BackgroundPartyResolver = {
         let combatActions = 0;
         let skillUses = 0;
         let heals = 0;
+        let musicUses = 0;
         const defeatedNpcIds = [];
         let combatMembers = members.map((state) => ({ ...state }));
         for (let i = 0; i < fights; i++) {
@@ -163,6 +164,7 @@ const BackgroundPartyResolver = {
             combatActions += Number(encounter.debug?.actions || 0);
             skillUses += encounter.members.reduce((sum, member) => sum + Number(member.skillUses || 0), 0);
             heals += encounter.members.reduce((sum, member) => sum + Number(member.heals || 0), 0);
+            musicUses += encounter.members.reduce((sum, member) => sum + Number(member.musicUses || 0), 0);
             combatMembers = encounter.members.map((member) => ({
                 ...member.state,
                 vitals: { ...member.vitals },
@@ -170,6 +172,7 @@ const BackgroundPartyResolver = {
                     ...(member.state.stats || {}),
                     coldCombat: {
                         ...(member.state.stats?.coldCombat || member.profile),
+                        effects: member.profile.effects || member.state.stats?.coldCombat?.effects || [],
                         cooldowns: member.cooldowns,
                         charges: member.charges || 0,
                         chargeExpiresAt: member.chargeExpiresAt || null
@@ -376,6 +379,7 @@ const BackgroundPartyResolver = {
                 combatActions,
                 skillUses,
                 heals,
+                musicUses,
                 targetNpcId: Number(targetNpcId) || null,
                 defeatedNpcIds
             }

--- a/src/GameServer/Bot/Population/BackgroundResolver.js
+++ b/src/GameServer/Bot/Population/BackgroundResolver.js
@@ -296,8 +296,93 @@ function chooseChargeSkill(profile, mp, cooldowns, time, charges = 0) {
     }).sort((a, b) => Number(b.level || 0) - Number(a.level || 0))[0] || null;
 }
 
+function activeMusicEffectForSkill(profile, skill, timestamp) {
+    const skillId = Number(skill.selfId) || 0;
+    const semantic = C4SkillRules.resolve(skill);
+    return (profile.effects || []).some((effect) => (
+        effect
+        && effect.type !== 'debuff'
+        && effect.toggle !== true
+        && (!effect.expiresAt || Number(effect.expiresAt) > timestamp)
+        && (Number(effect.id) === skillId || effect.key === semantic.effect)
+    ));
+}
+
+function actorLocation(state = {}) {
+    return state.loc || state.location || state;
+}
+
+function withinSkillRadius(source, target, semantic) {
+    const radius = Math.max(0, Number(semantic.radius) || 0);
+    if (!radius) return true;
+    const sourceLoc = actorLocation(source.state);
+    const targetLoc = actorLocation(target.state);
+    const coordinates = ['locX', 'locY'].map((key) => [Number(sourceLoc?.[key]), Number(targetLoc?.[key])]);
+    if (coordinates.some(([from, to]) => !Number.isFinite(from) || !Number.isFinite(to))) return true;
+    const dx = coordinates[0][0] - coordinates[0][1];
+    const dy = coordinates[1][0] - coordinates[1][1];
+    return (dx * dx) + (dy * dy) <= radius * radius;
+}
+
+function chooseMusicAction(provider, targets, timestamp) {
+    const skill = ColdCombatProfile.partyMusicSkills(provider.profile)
+        .map((candidate) => {
+            const semantic = C4SkillRules.resolve(candidate);
+            const affected = targets.filter((target) => target.vitals.hp > 0
+                && withinSkillRadius(provider, target, semantic)
+                && !activeMusicEffectForSkill(target.profile, candidate, timestamp));
+            return {
+                skill: candidate,
+                affected,
+                cost: ColdCombatProfile.partyMusicMpCost(provider.profile, candidate, timestamp)
+            };
+        })
+        .filter((candidate) => candidate.cost <= provider.vitals.mp && candidate.affected.length > 0)
+        .sort((a, b) => Number(a.skill.selfId) - Number(b.skill.selfId))[0];
+    return skill || null;
+}
+
+function replaceMusicEffect(effects, nextEffect) {
+    return [
+        ...(effects || []).filter((effect) => Number(effect.id) !== Number(nextEffect.id) && effect.key !== nextEffect.key),
+        nextEffect
+    ];
+}
+
+function refreshFighterProfile(fighter, effects, timestamp) {
+    const coldCombat = {
+        ...(fighter.state.stats?.coldCombat || {}),
+        classId: fighter.profile.classId,
+        skills: fighter.profile.skills,
+        effects
+    };
+    fighter.state = {
+        ...fighter.state,
+        stats: { ...(fighter.state.stats || {}), coldCombat }
+    };
+    const hp = fighter.vitals.hp;
+    const mp = fighter.vitals.mp;
+    fighter.profile = botCombatStats(fighter.state, timestamp);
+    fighter.vitals.maxHp = fighter.profile.maxHp;
+    fighter.vitals.maxMp = fighter.profile.maxMp;
+    fighter.vitals.hp = Math.min(hp, fighter.vitals.maxHp);
+    fighter.vitals.mp = Math.min(mp, fighter.vitals.maxMp);
+}
+
+function applyMusicAction(provider, action, timestamp) {
+    if (!action?.affected?.length) return 0;
+    const effect = ColdCombatProfile.partyMusicEffect(action.skill, timestamp);
+    const semantic = C4SkillRules.resolve(action.skill);
+    const targets = action.affected.length === 1 && action.affected[0] === provider
+        ? action.affected
+        : [provider, ...action.affected.filter((target) => target !== provider)];
+    targets.filter((target) => target.vitals.hp > 0 && withinSkillRadius(provider, target, semantic))
+        .forEach((target) => refreshFighterProfile(target, replaceMusicEffect(target.profile.effects, effect), timestamp));
+    return action.cost;
+}
+
 function resolveFight({ state, spot, pressure, targetNpcId = 0, rng, timestamp = Date.now() }) {
-    const bot = botCombatStats(state, timestamp);
+    let bot = botCombatStats(state, timestamp);
     const mob = ColdCombatProfile.npcForSpot(spot, rng, { preferredNpcId: targetNpcId }) || {
         level: Number(spot.avgLevel || bot.level), maxHp: Math.max(1, Number(spot.mob?.hp || 1)),
         pAtk: Math.max(1, Number(spot.mob?.damage || 1)), pAtkRnd: 0, pDef: 1, mDef: 1,
@@ -309,12 +394,14 @@ function resolveFight({ state, spot, pressure, targetNpcId = 0, rng, timestamp =
         maxHp: bot.maxHp,
         maxMp: bot.maxMp
     };
+    const soloFighter = { state, profile: bot, vitals };
     let botReadyAt = 0;
     let mobReadyAt = 0;
     let time = 0;
     let mobHp = mob.maxHp;
     let actions = 0;
     let skillUses = 0;
+    let musicUses = 0;
     const chargeState = coldChargeState(state, timestamp);
     let charges = chargeState.charges;
     let chargeExpiresAt = chargeState.chargeExpiresAt;
@@ -335,6 +422,17 @@ function resolveFight({ state, spot, pressure, targetNpcId = 0, rng, timestamp =
             expireCharges(heldCharges, timestamp + time);
             charges = heldCharges.charges;
             chargeExpiresAt = heldCharges.chargeExpiresAt;
+            const music = chooseMusicAction(soloFighter, [soloFighter], timestamp + time);
+            if (music) {
+                applyMusicAction(soloFighter, music, timestamp + time);
+                bot = soloFighter.profile;
+                vitals.mp = Math.max(0, vitals.mp - music.cost);
+                cooldowns[music.skill.selfId] = timestamp + time + Math.max(0, Number(music.skill.reuse || 0));
+                skillUses += 1;
+                musicUses += 1;
+                botReadyAt += actionDelayMs(bot, music.skill);
+                continue;
+            }
             const chargeSkill = chooseChargeSkill(bot, vitals.mp, cooldowns, timestamp + time, charges);
             if (chargeSkill) {
                 const semantic = C4SkillRules.resolve(chargeSkill);
@@ -393,7 +491,9 @@ function resolveFight({ state, spot, pressure, targetNpcId = 0, rng, timestamp =
             won: false,
             died,
             hp: Math.max(0, Math.round(vitals.hp)),
+            maxHp: Math.max(1, Math.round(vitals.maxHp)),
             mp: Math.max(0, Math.round(vitals.mp)),
+            maxMp: Math.max(1, Math.round(vitals.maxMp)),
             exp: 0,
             sp: 0,
             adena: 0,
@@ -401,7 +501,8 @@ function resolveFight({ state, spot, pressure, targetNpcId = 0, rng, timestamp =
             cooldowns,
             charges: died ? 0 : charges,
             chargeExpiresAt: died ? null : chargeExpiresAt,
-            debug: { actions, skillUses, mobSelfId: mob.selfId || null, timedOut: !died }
+            effects: soloFighter.profile.effects,
+            debug: { actions, skillUses, musicUses, mobSelfId: mob.selfId || null, timedOut: !died }
         };
     }
 
@@ -420,7 +521,9 @@ function resolveFight({ state, spot, pressure, targetNpcId = 0, rng, timestamp =
         won: true,
         died: false,
         hp: Math.max(1, Math.round(vitals.hp)),
+        maxHp: Math.max(1, Math.round(vitals.maxHp)),
         mp: Math.max(0, Math.round(vitals.mp)),
+        maxMp: Math.max(1, Math.round(vitals.maxMp)),
         exp: Math.round(rewards.exp * expMultiplier * rates.exp),
         sp: Math.round(rewards.sp * expMultiplier * rates.sp),
         adena,
@@ -428,7 +531,8 @@ function resolveFight({ state, spot, pressure, targetNpcId = 0, rng, timestamp =
         cooldowns,
         charges,
         chargeExpiresAt,
-        debug: { actions, skillUses, mobSelfId: mob.selfId || null, timedOut: false }
+        effects: soloFighter.profile.effects,
+        debug: { actions, skillUses, musicUses, mobSelfId: mob.selfId || null, timedOut: false }
     };
 }
 
@@ -469,6 +573,7 @@ function resolvePartyFight({ members, spot, targetNpcId = 0, rng = Math.random, 
             actions: 0,
             skillUses: 0,
             heals: 0,
+            musicUses: 0,
             charges: chargeState.charges,
             chargeExpiresAt: chargeState.chargeExpiresAt
         };
@@ -499,6 +604,17 @@ function resolvePartyFight({ members, spot, targetNpcId = 0, rng = Math.random, 
                 next.skillUses += 1;
                 next.heals += 1;
                 next.readyAt += actionDelayMs(next.profile, heal.skill);
+                continue;
+            }
+
+            const music = chooseMusicAction(next, fighters, timestamp + time);
+            if (music) {
+                applyMusicAction(next, music, timestamp + time);
+                next.vitals.mp = Math.max(0, next.vitals.mp - music.cost);
+                next.cooldowns[music.skill.selfId] = timestamp + time + Math.max(0, Number(music.skill.reuse || 0));
+                next.skillUses += 1;
+                next.musicUses += 1;
+                next.readyAt += actionDelayMs(next.profile, music.skill);
                 continue;
             }
 
@@ -555,7 +671,12 @@ function resolvePartyFight({ members, spot, targetNpcId = 0, rng = Math.random, 
         won: mobHp <= 0,
         timedOut: mobHp > 0 && fighters.some((fighter) => fighter.vitals.hp > 0),
         members: fighters,
-        debug: { actions, mobSelfId: mob.selfId || null }
+        debug: {
+            actions,
+            skillUses: fighters.reduce((sum, fighter) => sum + fighter.skillUses, 0),
+            musicUses: fighters.reduce((sum, fighter) => sum + fighter.musicUses, 0),
+            mobSelfId: mob.selfId || null
+        }
     };
 }
 
@@ -693,6 +814,7 @@ const BackgroundResolver = {
         let died = false;
         let combatActions = 0;
         let skillUses = 0;
+        let musicUses = 0;
         const foughtNpcIds = [];
 
         for (let i = 0; i < fights; i++) {
@@ -703,12 +825,15 @@ const BackgroundResolver = {
             };
             const result = resolveFight({ state: fightState, spot, pressure, targetNpcId, rng, timestamp });
             patch.vitals.hp = result.hp;
+            patch.vitals.maxHp = result.maxHp;
             patch.vitals.mp = result.mp;
+            patch.vitals.maxMp = result.maxMp;
             patch.stats = {
                 ...(patch.stats || state.stats || {}),
                 coldCombat: {
                     ...(state.stats?.coldCombat || ColdCombatProfile.profileFor(fightState, timestamp)),
                     ...(patch.stats?.coldCombat || {}),
+                    effects: result.effects || patch.stats?.coldCombat?.effects || [],
                     cooldowns: result.cooldowns || {},
                     charges: result.charges || 0,
                     chargeExpiresAt: result.chargeExpiresAt || null
@@ -720,6 +845,7 @@ const BackgroundResolver = {
             materialize.items.push(...result.loot);
             combatActions += Number(result.debug?.actions || 0);
             skillUses += Number(result.debug?.skillUses || 0);
+            musicUses += Number(result.debug?.musicUses || 0);
 
             if (result.won) {
                 wins += 1;
@@ -781,6 +907,7 @@ const BackgroundResolver = {
                 route: spot.route || null,
                 combatActions,
                 skillUses,
+                musicUses,
                 targetNpcId: Number(targetNpcId) || null,
                 foughtNpcIds
             }

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -671,7 +671,7 @@ function applyClassProgression(state, profile = {}) {
         characterId: state.characterId,
         classId: currentClassId,
         level,
-        seed: state.name || state.characterId
+        seed: state.characterId
     }).then((resolved) => {
         const classId = Number(resolved.classId || currentClassId);
         const role = BotRoles.inferRole(classId);
@@ -2041,12 +2041,12 @@ const BotLifeState = {
             ? (options.projectClassProgression === true ? Promise.resolve(BotClassProgression.plan({
                 classId: currentClassId,
                 level,
-                seed: nextState.name || nextState.characterId
+                seed: nextState.characterId
             })) : BotClassProgression.reconcile({
                 characterId: nextState.characterId,
                 classId: currentClassId,
                 level,
-                seed: nextState.name || nextState.characterId
+                seed: nextState.characterId
             }))
             : Promise.resolve({ classId: currentClassId, transitions: [] });
 

--- a/src/GameServer/Bot/Population/ColdCombatProfile.js
+++ b/src/GameServer/Bot/Population/ColdCombatProfile.js
@@ -331,6 +331,55 @@ function profileFor(state = {}, timestamp = Date.now()) {
     };
 }
 
+function activeMusicEffects(profile = {}, timestamp = Date.now()) {
+    return activeEffects(profile.effects, timestamp).filter((effect) => (
+        C4SkillRules.resolve({
+            selfId: effect.id,
+            name: effect.name,
+            level: effect.level
+        }).isDance === true
+    ));
+}
+
+function partyMusicSkills(profile = {}) {
+    return (profile.skills || []).filter((skill) => {
+        if (skill.passive) return false;
+        const semantic = C4SkillRules.resolve(skill);
+        const required = number(semantic.requires?.weaponsAllowed);
+        return semantic.isDance === true
+            && semantic.target === 'party'
+            && !semantic.notUsedInC4
+            && (!required || (required & number(profile.weaponMask)) !== 0);
+    });
+}
+
+function partyMusicMpCost(profile, skill, timestamp = Date.now()) {
+    const semantic = C4SkillRules.resolve(skill);
+    let cost = Math.max(0, number(skill.mp));
+    if (semantic.isDance === true) {
+        cost += activeMusicEffects(profile, timestamp).length * Math.max(0, number(semantic.nextDanceCost));
+    }
+    return Math.max(0, Math.floor(cost * multiplier(profile, 'danceMpConsumeMul', timestamp)));
+}
+
+function partyMusicEffect(skill, timestamp = Date.now()) {
+    const semantic = C4SkillRules.resolve(skill);
+    const durationMs = Math.max(0, number(semantic.durationMs ?? skill.buffTime, 120000));
+    const skillId = number(skill.selfId);
+    return {
+        key: String(semantic.effect || `skill_${skillId}`),
+        id: skillId,
+        name: skill.name || semantic.effect || `Skill ${skillId}`,
+        level: number(skill.level, 1),
+        type: 'buff',
+        durationMs,
+        expiresAt: timestamp + durationMs,
+        stackFamily: semantic.stackFamily || null,
+        stackOrder: semantic.stackOrder ?? null,
+        stats: { ...(semantic.stats || {}) }
+    };
+}
+
 function offensiveSkills(profile) {
     const allowed = new Set([C4SkillRules.DAMAGE, C4SkillRules.DAMAGE_EFFECT, C4SkillRules.DEATH_LINK, C4SkillRules.FATAL, C4SkillRules.DRAIN, C4SkillRules.BLOW, C4SkillRules.AGGRO_DAMAGE]);
     return (profile.skills || []).filter((skill) => {
@@ -386,5 +435,6 @@ function npcForSpot(spot = {}, rng = Math.random, options = {}) {
 
 module.exports = {
     PROFILE_VERSION, capture, legacySnapshot, treeSnapshot, needsDatabaseBackfill, profileFor,
-    offensiveSkills, npcForSpot, skillSnapshotsFromRecords, skillRecordsFromTree
+    offensiveSkills, activeMusicEffects, partyMusicSkills, partyMusicMpCost, partyMusicEffect,
+    npcForSpot, skillSnapshotsFromRecords, skillRecordsFromTree
 };

--- a/tests/test_bot_class_progression.js
+++ b/tests/test_bot_class_progression.js
@@ -4,7 +4,9 @@ require('../src/Global');
 
 const DataCache = invoke('GameServer/DataCache');
 const Database = invoke('Database');
+const ClassProgression = invoke('GameServer/ClassProgression');
 const BotClassProgression = invoke('GameServer/Bot/BotClassProgression');
+const GeneratedColdSeeder = invoke('GameServer/Bot/Population/GeneratedColdSeeder');
 const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 
 DataCache.init();
@@ -13,6 +15,30 @@ const firstProfessionChoices = new Set(Array.from({ length: 30 }, (_, index) => 
     BotClassProgression.nextClass(0, 20, `starter_${index}`)
 )));
 assert(firstProfessionChoices.size > 1, 'first-profession choices must vary across a generated fighter cohort');
+
+// Exercise the same racial starter slots as generated population, but use the
+// durable character id for profession choice. This must cover every branch,
+// including the previously starved Swordsinger and Bladedancer paths.
+const secondProfessionChoices = new Map();
+const starterRegions = ['human', 'elf', 'dark_elf', 'orc', 'dwarf'];
+for (let index = 2000000; index < 2005000; index++) {
+    const characterId = index;
+    starterRegions.forEach((starterRegion) => {
+        const base = GeneratedColdSeeder.baseForIndex(index, starterRegion);
+        const firstClass = BotClassProgression.nextClass(base.classId, 20, characterId);
+        const secondOptions = ClassProgression.secondProfMap[firstClass] || [];
+        if (!secondOptions.length) return;
+        if (!secondProfessionChoices.has(firstClass)) secondProfessionChoices.set(firstClass, new Set());
+        secondProfessionChoices.get(firstClass).add(
+            BotClassProgression.nextClass(firstClass, 40, characterId)
+        );
+    });
+}
+Object.entries(ClassProgression.secondProfMap).forEach(([classId, options]) => {
+    const observed = [...(secondProfessionChoices.get(Number(classId)) || [])].sort((a, b) => a - b);
+    assert.deepStrictEqual(observed, [...options].sort((a, b) => a - b),
+        `generated population IDs must reach every second-profession branch from ${classId}`);
+});
 
 const original = {
     fetchSkill: Database.fetchSkill,
@@ -51,7 +77,8 @@ try {
         BotClassProgression.reconcile({ characterId: 2, classId: 49, level: 42, seed: 'Bren1465' }),
         BotClassProgression.reconcile({ characterId: 3, classId: 2, level: 76, seed: 'Veteran' })
     ]).then(([darkFighter, orcMystic, veteran]) => {
-        assert.ok([36, 37].includes(darkFighter.classId), 'a level 42 Dark Fighter must pass both profession transfers');
+        assert.ok([33, 34, 36, 37].includes(darkFighter.classId),
+            'a level 42 Dark Fighter must pass both profession transfers through a valid branch');
         assert.ok([51, 52].includes(orcMystic.classId), 'a level 42 Orc Mystic must pass both profession transfers');
         assert.strictEqual(veteran.classId, 88, 'a level 76 second-class bot must take its third profession');
         assert.strictEqual(skillsFor(1).find((skill) => skill.selfId === 239)?.level, 2, 'a C-grade bot must receive Expertise C through its real profession tree');

--- a/tests/test_bot_cold_combat.js
+++ b/tests/test_bot_cold_combat.js
@@ -58,6 +58,64 @@ assert.strictEqual(ColdCombatProfile.needsDatabaseBackfill({ skillSource: 'datab
 assert.strictEqual(ColdCombatProfile.needsDatabaseBackfill(migratedSnapshot), false, 'a current database snapshot must not be rescanned on every migration tick');
 assert.strictEqual(ColdCombatProfile.needsDatabaseBackfill({ version: ColdCombatProfile.PROFILE_VERSION }), true, 'a class-tree fallback without a database source must still be migrated');
 
+function musicSkill(selfId) {
+    return { selfId, level: 1, passive: false, spell: false, power: 0, mp: 60, hp: 0, hitTime: 1000, reuse: 0, buffTime: 120000 };
+}
+
+const singer = {
+    ...fighter,
+    characterId: 904,
+    name: 'ColdSinger',
+    level: 75,
+    vitals: { hp: 1000, maxHp: 1000, mp: 1000, maxMp: 1000 },
+    party: { role: 'buffer' },
+    stats: {
+        ...fighter.stats,
+        classId: 21,
+        coldCombat: {
+            ...fighter.stats.coldCombat,
+            classId: 21,
+            effects: [],
+            skills: [musicSkill(264), musicSkill(265)]
+        }
+    }
+};
+const singerProfile = ColdCombatProfile.profileFor(singer, timestamp);
+assert.deepStrictEqual(ColdCombatProfile.partyMusicSkills(singerProfile).map((skill) => skill.selfId), [264, 265],
+    'a cold Swordsinger must retain learned songs as party music skills');
+assert.strictEqual(ColdCombatProfile.partyMusicMpCost(singerProfile, musicSkill(264), timestamp), 60,
+    'the first cold song must use its base MP cost');
+const firstSong = ColdCombatProfile.partyMusicEffect(musicSkill(264), timestamp);
+assert.strictEqual(ColdCombatProfile.partyMusicMpCost({ ...singerProfile, effects: [firstSong] }, musicSkill(265), timestamp), 90,
+    'cold song MP cost must include the native next-dance surcharge');
+
+const dancer = {
+    ...singer,
+    characterId: 905,
+    name: 'ColdDancer',
+    stats: {
+        ...singer.stats,
+        classId: 34,
+        coldCombat: {
+            ...singer.stats.coldCombat,
+            classId: 34,
+            equipment: { ...singer.stats.coldCombat.equipment, weaponKind: 'Weapon.Dual' },
+            effects: [],
+            skills: [musicSkill(271), musicSkill(272)]
+        }
+    }
+};
+const dancerProfile = ColdCombatProfile.profileFor(dancer, timestamp);
+assert.deepStrictEqual(ColdCombatProfile.partyMusicSkills(dancerProfile).map((skill) => skill.selfId), [271, 272],
+    'a cold Bladedancer with dual swords must retain learned dances');
+assert.strictEqual(ColdCombatProfile.partyMusicSkills(ColdCombatProfile.profileFor({
+    ...dancer,
+    stats: {
+        ...dancer.stats,
+        coldCombat: { ...dancer.stats.coldCombat, equipment: { ...dancer.stats.coldCombat.equipment, weaponKind: 'Weapon.Sword' } }
+    }
+}, timestamp)).length, 0, 'cold dances must preserve the dual-sword requirement');
+
 const coldFatalProfile = { ...buffed, maxHp: 1000 };
 const coldFatal = { selfId: 314, level: 1, power: 2908 };
 assert.strictEqual(BackgroundResolver.effectiveSkillPower(coldFatalProfile, coldFatal, 1000), 0,
@@ -157,6 +215,16 @@ const focusedResult = BackgroundResolver.resolveSolo({
 });
 assert.deepStrictEqual(focusedResult.debug.foughtNpcIds, [1], 'solo direct-drop farming must fight the requested NPC, not a random spot entry');
 
+const musicSpot = { ...spot, npcSelfIds: [], mob: { hp: 100000, damage: 1 } };
+const singerResult = BackgroundResolver.resolveSolo({ state: singer, spot: musicSpot, elapsedMs: 12000, timestamp, rng: () => 0.1 });
+assert(singerResult.debug.musicUses >= 2, 'cold solo combat must cast the Swordsinger songs it learned');
+assert(singerResult.patch.stats.coldCombat.effects.some((effect) => effect.id === 264),
+    'a cold solo song must persist on the singer after the fight');
+const dancerResult = BackgroundResolver.resolveSolo({ state: dancer, spot: musicSpot, elapsedMs: 12000, timestamp, rng: () => 0.1 });
+assert(dancerResult.debug.musicUses >= 2, 'cold solo combat must cast the Bladedancer dances it learned');
+assert(dancerResult.patch.stats.coldCombat.effects.some((effect) => effect.id === 271),
+    'a cold solo dance must persist on the dancer after the fight');
+
 const injuredTank = {
     ...fighter,
     characterId: 902,
@@ -194,6 +262,18 @@ const focusedPartyFight = BackgroundResolver.resolvePartyFight({
 assert.strictEqual(focusedPartyFight.debug.mobSelfId, 1, 'party direct-drop farming must use the party target NPC');
 assert.strictEqual(focusedPartyFight.members[0].charges, 2, 'unspent charges must survive a party cold fight');
 
+const musicPartyFight = BackgroundResolver.resolvePartyFight({
+    members: [singer, fighter],
+    spot: musicSpot,
+    timestamp,
+    rng: () => 0.1
+});
+assert(musicPartyFight.debug.musicUses >= 2, 'cold party combat must cast the provider songs');
+assert(musicPartyFight.members[0].profile.effects.some((effect) => effect.id === 264),
+    'the cold song provider must receive its own party aura');
+assert(musicPartyFight.members[1].profile.effects.some((effect) => effect.id === 264),
+    'cold party songs must reach another party member');
+
 const expiredChargeFight = BackgroundResolver.resolvePartyFight({
     members: [{
         ...fighter,
@@ -226,6 +306,17 @@ const partyResult = BackgroundPartyResolver.resolve({
 });
 assert(partyResult.debug.combatActions > 0, 'the party lifecycle must use the cold action simulation');
 assert(partyResult.debug.heals > 0, 'party support casts must be reflected in the persisted combat telemetry');
+const musicPartyResult = BackgroundPartyResolver.resolve({
+    party: { partyId: 'cold_music_party', leaderId: singer.characterId, cohesion: 1, risk: 0, roleCoverage: {}, stats: {} },
+    members: [singer, fighter],
+    spot: musicSpot,
+    elapsedMs: 12000,
+    timestamp,
+    rng: () => 0.1
+});
+assert(musicPartyResult.debug.musicUses >= 2, 'the cold party lifecycle must report song casts');
+assert(musicPartyResult.memberResults[1].result.patch.stats.coldCombat.effects.some((effect) => effect.id === 264),
+    'the cold party lifecycle must persist a song on the buffed member');
 const focusedPartyResult = BackgroundPartyResolver.resolve({
     party: {
         partyId: 'focused_cold_combat_party',

--- a/tests/test_bot_gear.js
+++ b/tests/test_bot_gear.js
@@ -187,6 +187,16 @@ const promotionDual = DataCache.items.find((item) => item.template?.kind === 'We
     && String(item.etc?.rank).toLowerCase() === 'c' && item.template?.name && item.template.name !== '0');
 assert(promotionSword && promotionDual, 'the datapack must expose C-grade sword and dual fixtures for profession gear progression');
 const fakeMarketOffer = (item) => ({ selfId: item.selfId, price: 1, town: 'Giran', sourceType: 'npc' });
+const promotionCap = GearAcquisitionPlanner.progressionPriceCap('c', 40);
+const affordableDualIds = DataCache.items
+    .filter((item) => item.template?.kind === 'Weapon.Dual'
+        && String(item.etc?.rank).toLowerCase() === 'c'
+        && Number(item.template?.price || 0) <= promotionCap)
+    .map((item) => Number(item.selfId));
+const overCapDual = DataCache.items.find((item) => item.template?.kind === 'Weapon.Dual'
+    && String(item.etc?.rank).toLowerCase() === 'c'
+    && Number(item.template?.price || 0) > promotionCap);
+assert(overCapDual, 'the datapack must expose an over-cap C-grade dual fixture');
 const missingDualPlan = GearAcquisitionPlanner.planFor({
     level: 40,
     adena: 1000000,
@@ -198,6 +208,24 @@ const missingDualPlan = GearAcquisitionPlanner.planFor({
 }, { spots: [], findMarketOffer: fakeMarketOffer });
 assert.strictEqual(itemTemplate(missingDualPlan.target?.selfId)?.template?.kind, 'Weapon.Dual',
     'a newly promoted Bladedancer without duals must immediately receive a dual-sword acquisition target');
+const overCapDualPlan = GearAcquisitionPlanner.planFor({
+    level: 40,
+    adena: 1000000,
+    stats: { classId: 34, role: 'buffer' },
+    inventory: {
+        57: { selfId: 57, amount: 1000000 },
+        [promotionSword.selfId]: { selfId: promotionSword.selfId, amount: 1, equipped: true, slot: 7 }
+    }
+}, {
+    spots: [],
+    findMarketOffer: () => null,
+    excludedTargetIds: affordableDualIds
+});
+const overCapTarget = itemTemplate(overCapDualPlan.target?.selfId);
+assert.strictEqual(overCapTarget?.template?.kind, 'Weapon.Dual',
+    'a same-grade sword must not suppress the required dual-sword target when no NPC offer exists');
+assert(Number(overCapTarget?.template?.price || 0) > promotionCap,
+    'the required dual-sword target must be retained even when every remaining dual is over the progression cap');
 const equippedDualPlan = GearAcquisitionPlanner.planFor({
     level: 40,
     adena: 1000000,

--- a/tests/test_bot_gear.js
+++ b/tests/test_bot_gear.js
@@ -181,6 +181,34 @@ for (const [classId, level] of [[34, 61], [107, 76]]) {
     assert.strictEqual(dancerWeapon?.template?.kind, 'Weapon.Dual',
         `class ${classId} must retain a compatible dual weapon when the catalog has no ${dancerPlan.rank.toUpperCase()}-grade dual`);
 }
+const promotionSword = DataCache.items.find((item) => item.template?.kind === 'Weapon.Sword'
+    && String(item.etc?.rank).toLowerCase() === 'c' && item.template?.name && item.template.name !== '0');
+const promotionDual = DataCache.items.find((item) => item.template?.kind === 'Weapon.Dual'
+    && String(item.etc?.rank).toLowerCase() === 'c' && item.template?.name && item.template.name !== '0');
+assert(promotionSword && promotionDual, 'the datapack must expose C-grade sword and dual fixtures for profession gear progression');
+const fakeMarketOffer = (item) => ({ selfId: item.selfId, price: 1, town: 'Giran', sourceType: 'npc' });
+const missingDualPlan = GearAcquisitionPlanner.planFor({
+    level: 40,
+    adena: 1000000,
+    stats: { classId: 34, role: 'buffer' },
+    inventory: {
+        57: { selfId: 57, amount: 1000000 },
+        [promotionSword.selfId]: { selfId: promotionSword.selfId, amount: 1, equipped: true, slot: 7 }
+    }
+}, { spots: [], findMarketOffer: fakeMarketOffer });
+assert.strictEqual(itemTemplate(missingDualPlan.target?.selfId)?.template?.kind, 'Weapon.Dual',
+    'a newly promoted Bladedancer without duals must immediately receive a dual-sword acquisition target');
+const equippedDualPlan = GearAcquisitionPlanner.planFor({
+    level: 40,
+    adena: 1000000,
+    stats: { classId: 34, role: 'buffer' },
+    inventory: {
+        57: { selfId: 57, amount: 1000000 },
+        [promotionDual.selfId]: { selfId: promotionDual.selfId, amount: 1, equipped: true, slot: 14 }
+    }
+}, { spots: [], findMarketOffer: fakeMarketOffer });
+assert.notStrictEqual(itemTemplate(equippedDualPlan.target?.selfId)?.template?.kind, 'Weapon.Dual',
+    'an equipped Bladedancer dual must not trigger a duplicate dual-sword goal');
 upgrades = BotEquipmentUpgrade.findBestUpgrades(upgradeSession({
     classId: 29,
     level: 33,


### PR DESCRIPTION
## Summary

- Make bot first- and second-profession selection deterministic and evenly distributed across all valid class branches.
- Keep profession selection independent of currently equipped weapons.
- Add cold-bot song and dance simulation for solo and party combat, including party radius, stacked MP cost, effects, persistence, and telemetry.
- Make dual swords an explicit acquisition goal for Bladedancer and Spectral Dancer when the required weapon is not equipped.
- Keep classes with multiple valid weapon families unaffected.

## Root cause

Profession selection was seeded from bot names, which produced an uneven distribution and left some branches underrepresented. The gear planner also treated any same-grade weapon as sufficient for an exact dual-sword class. Cold combat had no equivalent song/dance action or persisted party-aura state.

## Player impact

Cold bots can now reach all intended profession branches, Bladedancers pursue compatible dual swords immediately after promotion, and Sword Singers/Bladedancers contribute their learned songs and dances in solo and party background combat. Existing equipped dual swords do not create duplicate acquisition goals.

## Validation

- `npm test`
- `npm run check` — syntax check passed for 961 JavaScript files
- `node tests/test_bot_class_progression.js`
- `node tests/test_bot_cold_combat.js`
- `node tests/test_bot_gear.js`
- `node tests/test_bot_gear_acquisition.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for party music abilities, including songs and dances that affect solo and group combat.
  - Music effects now apply for their duration, consume MP, observe cooldowns, and appear in combat results.
  - Improved dual-weapon acquisition for classes that require paired weapons.

- **Bug Fixes**
  - Character progression is now more consistent across sessions and no longer depends on character names.
  - Improved profession branching and weapon progression behavior for advanced classes.

- **Tests**
  - Expanded coverage for party music, combat effects, profession progression, and dual-weapon gear selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->