### PR TITLE
Coordinate autonomous clan equipment progression

### DIFF
--- a/src/Database.js
+++ b/src/Database.js
@@ -1357,6 +1357,11 @@ const Database = {
             }).map((entry) => Number(entry.row.characterId));
             if (conflicts.length) return { ok: false, reason: 'membership_conflict', conflicts };
 
+            const reserved = all(`SELECT characterId FROM clan_operation_members
+                WHERE characterId IN (${placeholders}) AND status = 'active'`, characterIds)
+                .map((row) => Number(row.characterId));
+            if (reserved.length) return { ok: false, reason: 'clan_operation_reserved', conflicts: reserved };
+
             write(`INSERT INTO bot_background_parties (
                 partyId, leaderId, memberIdsJson, spotId, startedAt, nextResolveAt,
                 cohesion, risk, status, roleCoverageJson, statsJson, updatedAt

--- a/src/GameServer/Bot/AI/BotHuntingTargetPolicy.js
+++ b/src/GameServer/Bot/AI/BotHuntingTargetPolicy.js
@@ -1,5 +1,6 @@
 const SIEGE_CLAN = /\bsiege\b/i;
 const CASTLE_ROYAL_GATEKEEPER = /^(?:Gludio|Dion|Giran|Oren|Aden) Royal Gatekeeper$/i;
+const BotRaidSafety = invoke('GameServer/Bot/AI/BotRaidSafety');
 
 function npcName(npc) {
     if (!npc) return '';
@@ -28,7 +29,10 @@ function isCastleUtility(npc) {
 }
 
 function canHunt(npc) {
-    return !!npc && !isSiegeGuard(npc) && !isCastleUtility(npc);
+    return !!npc
+        && !BotRaidSafety.isProtectedRaidEntity(npc)
+        && !isSiegeGuard(npc)
+        && !isCastleUtility(npc);
 }
 
 module.exports = { npcName, clanName, isSiegeGuard, isCastleUtility, canHunt };

--- a/src/GameServer/Bot/AI/BotRaidSafety.js
+++ b/src/GameServer/Bot/AI/BotRaidSafety.js
@@ -8,6 +8,10 @@ const RaidEntityIndex = invoke('GameServer/World/RaidEntityIndex');
 const DEFAULT_RETREAT_DISTANCE = 1100;
 const RAID_DISENGAGE_GRACE_MS = 15000;
 const RAID_OPENER_MIN_HP_RATIO = 0.55;
+// Bots currently have no supported raid-boss progression path. Keep the raid
+// index for avoidance and retreat, but never authorize autonomous or
+// player-led companion combat against a raid entity.
+const BOT_RAID_PARTICIPATION_ENABLED = false;
 
 function world() {
     return invoke('GameServer/World/World');
@@ -30,7 +34,10 @@ function templateId(target) {
 function isRaidBoss(target) {
     return target?.fetchIsRaidBoss?.() === true
         || target?.model?.raidBoss === true
-        || target?.template?.raidBoss === true;
+        || target?.template?.raidBoss === true
+        || String(target?.fetchKind?.() || '').toLowerCase() === 'boss'
+        || String(target?.template?.kind || '').toLowerCase() === 'boss'
+        || String(target?.model?.template?.kind || '').toLowerCase() === 'boss';
 }
 
 function isRaidMinion(target) {
@@ -124,6 +131,7 @@ function selectRaidOpener(leaderSession) {
 }
 
 function leaderDesignatedRaidTarget(leaderSession) {
+    if (!BOT_RAID_PARTICIPATION_ENABLED) return null;
     const leader = leaderSession?.actor;
     if (!leader || leader.fetchIsOnline?.() !== true || leader.isDead?.() || leader.state?.fetchDead?.()) return null;
     const targetId = Number(leader.fetchDestId?.() || 0);
@@ -183,6 +191,10 @@ function startPlayerPartyRaid(leaderSession, boss, target, now) {
 }
 
 function syncPlayerPartyRaid(leaderSession, now = Date.now()) {
+    if (!BOT_RAID_PARTICIPATION_ENABLED) {
+        if (leaderSession) leaderSession.partyRaidEngagement = undefined;
+        return null;
+    }
     if (playerPartySessions(leaderSession).length === 0) {
         if (leaderSession) leaderSession.partyRaidEngagement = undefined;
         return null;
@@ -247,6 +259,7 @@ function syncPlayerPartyRaid(leaderSession, now = Date.now()) {
 }
 
 function canEngagePlayerPartyRaid(session, target, leaderSession = session?.followPlayerSession) {
+    if (!BOT_RAID_PARTICIPATION_ENABLED) return false;
     if (!isOnlineCompanion(session, leaderSession)) return false;
     const raid = syncPlayerPartyRaid(leaderSession);
     if (!raid || !belongsToRaid(target, raid)) return false;
@@ -257,6 +270,7 @@ function canEngagePlayerPartyRaid(session, target, leaderSession = session?.foll
 }
 
 function isEngagedPlayerPartyRaidTarget(leaderSession, target) {
+    if (!BOT_RAID_PARTICIPATION_ENABLED) return false;
     const raid = syncPlayerPartyRaid(leaderSession);
     return raid?.phase === 'combat' && belongsToRaid(target, raid);
 }
@@ -325,6 +339,7 @@ function retreat(session, bot, threat, options = {}) {
 }
 
 module.exports = {
+    BOT_RAID_PARTICIPATION_ENABLED,
     RAID_MINION_TEMPLATE_IDS,
     isRaidBoss,
     isRaidMinion,

--- a/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
+++ b/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
@@ -15,12 +15,13 @@ const GearLifecycle = invoke('GameServer/Bot/AI/GearLifecycle');
 const MarketOpportunity = invoke('GameServer/Bot/Economy/MarketOpportunity');
 const NpcShopBuyLists = invoke('GameServer/World/Generics/NpcShopBuyLists');
 const BotRaidSafety = invoke('GameServer/Bot/AI/BotRaidSafety');
+const BotHuntingTargetPolicy = invoke('GameServer/Bot/AI/BotHuntingTargetPolicy');
 
 const RANKS = ['none', 'd', 'c', 'b', 'a', 's'];
 const WEAPON_SLOTS = new Set([7, 14]);
 const ARMOR_SLOTS = new Set([6, 9, 10, 11, 12, 15]);
 const JEWEL_SLOTS = new Set([1, 2, 3, 4, 5]);
-const RATE_MODEL_VERSION = 6;
+const RATE_MODEL_VERSION = 7;
 const DIRECT_FAILURE_RESOLVE_LIMIT = 8;
 const DIRECT_DROP_EXHAUSTION_MULTIPLIER = 3;
 const DIRECT_ROUTE_COOLDOWN_MS = 60 * 60 * 1000;
@@ -830,7 +831,16 @@ function equipmentTargetFulfilled(state = {}, plan = {}) {
 }
 
 function clanGoalPlanLocked(state = {}, plan = state?.stats?.equipmentPlan) {
-    return isClanOwnedPlan(plan) && !equipmentTargetFulfilled(state, plan);
+    const npcId = Number(plan?.next?.npcId || 0);
+    return isClanOwnedPlan(plan)
+        && plan?.status !== 'blocked'
+        && !equipmentTargetFulfilled(state, plan)
+        && (!npcId || isBotEligibleSourceNpcId(npcId));
+}
+
+function isBotEligibleSourceNpcId(npcId) {
+    const npc = (DataCache.npcs || []).find((entry) => Number(entry.selfId) === Number(npcId));
+    return !!npc && BotHuntingTargetPolicy.canHunt(npc);
 }
 
 function directPlanFailure(state = {}, plan = {}, timestamp = Date.now()) {
@@ -892,6 +902,9 @@ function replanContextFor(state = {}, previousPlan = null, timestamp = Date.now(
     const currentGrade = gradeForLevel(state.level);
     const currentLevel = Number(state.level || 1);
     const sameGrade = previousPlan?.grade === currentGrade;
+    const sourceNpcId = Number(previousPlan?.next?.npcId || 0);
+    const sourceAllowed = !sourceNpcId || isBotEligibleSourceNpcId(sourceNpcId);
+    const modelCurrent = Number(previousPlan?.rateModelVersion || 0) >= RATE_MODEL_VERSION;
     const recoveryTargets = sameGrade ? (previousPlan.recoveryTargets || [])
         .filter((entry) => Number(entry.until || 0) > timestamp && Number(entry.targetId || 0) > 0)
         : [];
@@ -918,6 +931,12 @@ function replanContextFor(state = {}, previousPlan = null, timestamp = Date.now(
         planCurrent: Boolean(previousPlan)
             && sameGrade
             && Number(previousPlan.plannedForLevel || 0) === currentLevel,
+        routeCurrent: Boolean(previousPlan)
+            && sameGrade
+            && sourceAllowed
+            && modelCurrent
+            && Number(previousPlan.plannedForLevel || 0) === currentLevel,
+        invalidSource: sourceAllowed ? null : { npcId: sourceNpcId, reason: 'protected_raid_source' },
         failure,
         recoveryTargets,
         excludedTargetIds: recoveryTargets.map((entry) => Number(entry.targetId)),
@@ -1434,4 +1453,4 @@ function sameObjective(left, right) {
     );
 }
 
-module.exports = { RATE_MODEL_VERSION, DIRECT_FAILURE_RESOLVE_LIMIT, PARTY_ROUTE_FAILURE_ATTEMPT_LIMIT, gradeForLevel, isCraftService, roleFor, itemScore, isRealCatalogItem, suitable, isSlotUpgrade, combatReadiness, progressionPriceCap, operationalAdenaReserve, equippedSlotsFor, equipInventoryUpgrades, preferredTarget, preferredDropTarget, preferredNoGradeTarget, marketOfferForTarget, marketPlanForTarget, marketRecoveryPlanForTarget, staticNpcUpgradePlan, staticNpcKitAdequate, itemDropChance, itemDropYield, partyNeedForSource, partyNeedReasonForSource, soloSafeForSource, bestSourceForState, bestSourceForPlan, safeFallbackForPlan, sourceForItem, farmSourceForMaterial, missingMaterials, directPlanFailure, partyRouteFailure, replanContextFor, isClanOwnedPlan, equipmentTargetFulfilled, clanGoalPlanLocked, finalizePlan, planFor, shouldFinishPreviousPlan, scoreSpot, sameObjective };
+module.exports = { RATE_MODEL_VERSION, DIRECT_FAILURE_RESOLVE_LIMIT, PARTY_ROUTE_FAILURE_ATTEMPT_LIMIT, gradeForLevel, isCraftService, roleFor, itemScore, isRealCatalogItem, suitable, isSlotUpgrade, combatReadiness, progressionPriceCap, operationalAdenaReserve, equippedSlotsFor, equipInventoryUpgrades, preferredTarget, preferredDropTarget, preferredNoGradeTarget, marketOfferForTarget, marketPlanForTarget, marketRecoveryPlanForTarget, staticNpcUpgradePlan, staticNpcKitAdequate, itemDropChance, itemDropYield, partyNeedForSource, partyNeedReasonForSource, soloSafeForSource, bestSourceForState, bestSourceForPlan, safeFallbackForPlan, sourceForItem, farmSourceForMaterial, missingMaterials, directPlanFailure, partyRouteFailure, replanContextFor, isBotEligibleSourceNpcId, isClanOwnedPlan, equipmentTargetFulfilled, clanGoalPlanLocked, finalizePlan, planFor, shouldFinishPreviousPlan, scoreSpot, sameObjective };

--- a/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
+++ b/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
@@ -31,6 +31,8 @@ const NPC_GEAR_MAX_RANK = 'd';
 let staticNpcItemIdsCache = null;
 let itemCatalogSource = null;
 let itemCatalogById = new Map();
+let npcCatalogSource = null;
+let npcCatalogById = new Map();
 
 function catalogItem(selfId) {
     const items = DataCache.items || [];
@@ -39,6 +41,15 @@ function catalogItem(selfId) {
         itemCatalogById = new Map(items.map((item) => [Number(item.selfId), item]));
     }
     return itemCatalogById.get(Number(selfId)) || null;
+}
+
+function catalogNpc(selfId) {
+    const npcs = DataCache.npcs || [];
+    if (npcCatalogSource !== npcs) {
+        npcCatalogSource = npcs;
+        npcCatalogById = new Map(npcs.map((npc) => [Number(npc.selfId), npc]));
+    }
+    return npcCatalogById.get(Number(selfId)) || null;
 }
 
 function isRealCatalogItem(item = {}) {
@@ -839,7 +850,7 @@ function clanGoalPlanLocked(state = {}, plan = state?.stats?.equipmentPlan) {
 }
 
 function isBotEligibleSourceNpcId(npcId) {
-    const npc = (DataCache.npcs || []).find((entry) => Number(entry.selfId) === Number(npcId));
+    const npc = catalogNpc(npcId);
     return !!npc && BotHuntingTargetPolicy.canHunt(npc);
 }
 

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -273,6 +273,10 @@ function enqueueEquipmentGoalAdvance(signal) {
     });
 }
 
+function enqueueEquipmentGoalAdvanceForState(state = {}) {
+    return enqueueEquipmentGoalAdvance(equipmentCompletionSignal(state));
+}
+
 function hasEquippedTwoHandedWeapon(state = {}) {
     return Object.values(state.inventory || {}).some((item) => {
         const template = itemTemplate(item?.selfId);
@@ -1218,12 +1222,18 @@ function discardInvalidEquipmentPlans() {
         AND (
             COALESCE(CAST(json_extract(statsJson, '$.equipmentPlan.target.selfId') AS INTEGER), 0) <= 0
             OR TRIM(COALESCE(json_extract(statsJson, '$.equipmentPlan.target.name'), '')) IN ('', '0')
+            OR (
+                activity = 'hunting'
+                AND json_extract(statsJson, '$.equipmentPlan.status') = 'active'
+                AND json_extract(statsJson, '$.equipmentPlan.expectedKills') IS NOT NULL
+                AND COALESCE(CAST(json_extract(statsJson, '$.equipmentPlan.rateModelVersion') AS INTEGER), 0) < ?
+            )
         )`,
-        [timestamp]
+        [timestamp, GearAcquisitionPlanner.RATE_MODEL_VERSION]
     ]).then((result) => {
         const discarded = Number(result?.affectedRows || 0);
         if (discarded > 0) {
-            utils.infoWarn('BotLife', 'discarded %d invalid equipment plans on startup', discarded);
+            utils.infoWarn('BotLife', 'discarded %d invalid or stale equipment plans on startup', discarded);
         }
         return discarded;
     });
@@ -2323,8 +2333,11 @@ const BotLifeState = {
         return Database.updateCharacterExperience(row.characterId, row.level, row.exp, row.sp)
             .then(() => Database.updateCharacterVitals(row.characterId, row.hp, row.maxHp, row.mp, row.maxMp))
             .then(() => syncInventorySummary(row.characterId, state.inventory || {}))
+            .then(() => enqueueEquipmentGoalAdvance(row.equipmentAdvance))
             .then(() => state);
     },
+
+    enqueueEquipmentGoalAdvanceForState,
 
     marketGoalCandidates(limit = 8, timestamp = now()) {
         if (!initialized) return Promise.resolve([]);
@@ -2397,6 +2410,11 @@ const BotLifeState = {
             WHERE phase = 'cold'
             AND simulationOwner = 'legacy_main'
             AND (partyId IS NULL OR partyId = '')
+            AND NOT EXISTS (
+                SELECT 1 FROM clan_operation_members reserved
+                WHERE reserved.characterId = bot_life_state.characterId
+                AND reserved.status = 'active'
+            )
             AND spotId IS NOT NULL
             AND activity IN ('hunting', 'resting', 'party_wait')`,
             [],
@@ -2449,7 +2467,12 @@ const BotLifeState = {
         const placeholders = ids.map(() => '?').join(', ');
         const ownerId = options.ownerId ? String(options.ownerId) : null;
         const ownerClause = ownerId ? 'AND simulationOwner = ?' : '';
-        const unassignedClause = options.unassigned ? "AND (partyId IS NULL OR partyId = '')" : '';
+        const unassignedClause = options.unassigned ? `AND (partyId IS NULL OR partyId = '')
+            AND NOT EXISTS (
+                SELECT 1 FROM clan_operation_members reserved
+                WHERE reserved.characterId = bot_life_state.characterId
+                AND reserved.status = 'active'
+            )` : '';
         const params = [...ids, ...(ownerId ? [ownerId] : [])];
 
         return Database.execute([

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -246,6 +246,29 @@ function reconcileEquipmentInventory(state = {}) {
     });
 }
 
+function preserveClanOwnedEquipmentState(incoming = {}, reason = '', current = null) {
+    const authoritative = current || cache.get(Number(incoming.characterId)) || null;
+    const currentPlan = authoritative?.stats?.equipmentPlan;
+    if (!GearAcquisitionPlanner.clanGoalPlanLocked(authoritative || {}, currentPlan)) return incoming;
+    if (['clan_equipment_goal', 'clan_equipment_beneficiary_rotated'].includes(String(reason))) return incoming;
+    if (equipmentTargetFulfilled(authoritative.stats || {}, incoming.inventory || {})) return incoming;
+
+    const currentGoalKey = String(currentPlan?.clanGoal?.goalKey || '');
+    const incomingGoalKey = String(incoming?.stats?.equipmentPlan?.clanGoal?.goalKey || '');
+    if (currentGoalKey && incomingGoalKey === currentGoalKey) return incoming;
+
+    const stats = {
+        ...(incoming.stats || {}),
+        equipmentPlan: currentPlan
+    };
+    const currentObjective = authoritative.stats?.clanPartyObjective;
+    if (!stats.clanPartyObjective
+        && String(currentObjective?.clanGoalKey || '') === currentGoalKey) {
+        stats.clanPartyObjective = currentObjective;
+    }
+    return { ...incoming, stats };
+}
+
 function equipmentCompletionSignal(state = {}) {
     const clanGoal = state.stats?.equipmentPlan?.clanGoal;
     if (!clanGoal?.clanId || !clanGoal?.goalKey) return null;
@@ -2404,6 +2427,7 @@ const BotLifeState = {
                 json_extract(statsJson, '$.role') AS role,
                 json_extract(statsJson, '$.generatedIndex') AS generatedIndex,
                 json_extract(statsJson, '$.partyRequest') AS partyRequestJson,
+                json_extract(statsJson, '$.clanPartyObjective') AS clanPartyObjectiveJson,
                 json_extract(statsJson, '$.equipmentPlan') AS equipmentPlanJson,
                 json_extract(statsJson, '$.partyHistory') AS partyHistoryJson
             FROM ${TABLE} INDEXED BY bot_life_state_party_candidate_projection
@@ -2422,6 +2446,7 @@ const BotLifeState = {
         ], 'bot-life:party-candidate-projection').then((rows) => rows.map((row) => {
             const role = row.role || null;
             const partyRequest = parseJson(row.partyRequestJson, null);
+            const clanPartyObjective = parseJson(row.clanPartyObjectiveJson, null);
             const equipmentPlan = parseJson(row.equipmentPlanJson, null);
             const partyHistory = parseJson(row.partyHistoryJson, null);
             return {
@@ -2441,6 +2466,7 @@ const BotLifeState = {
                         ? { generatedIndex: row.generatedIndex }
                         : {}),
                     ...(partyRequest ? { partyRequest } : {}),
+                    ...(clanPartyObjective ? { clanPartyObjective } : {}),
                     ...(equipmentPlan ? { equipmentPlan } : {}),
                     ...(partyHistory ? { partyHistory } : {})
                 },
@@ -3014,22 +3040,23 @@ const BotLifeState = {
             },
             updatedAt: timestamp
         };
-        const row = rowFromState(nextState);
-        const characterId = row.characterId;
+        const characterId = Number(nextState.characterId);
         const previous = pendingWrites.get(characterId) || Promise.resolve();
         const ready = initialized ? Promise.resolve(true) : this.init();
         const next = previous.then(() => ready).then((isReady) => {
             if (!isReady) {
                 throw new Error('state table unavailable');
             }
-            return save(row);
-        }).then(() => Database.updateCharacterLocation(row.characterId, {
+            const protectedState = preserveClanOwnedEquipmentState(nextState, reason, cache.get(characterId));
+            const row = rowFromState(protectedState);
+            return save(row).then(() => row);
+        }).then((row) => Database.updateCharacterLocation(row.characterId, {
             locX: row.locX,
             locY: row.locY,
             locZ: row.locZ
-        })).then(() => Database.updateCharacterExperience(row.characterId, row.level, row.exp, row.sp))
-            .then(() => Database.updateCharacterVitals(row.characterId, row.hp, row.maxHp, row.mp, row.maxMp))
-            .then(() => {
+        }).then(() => row)).then((row) => Database.updateCharacterExperience(row.characterId, row.level, row.exp, row.sp).then(() => row))
+            .then((row) => Database.updateCharacterVitals(row.characterId, row.hp, row.maxHp, row.mp, row.maxMp).then(() => row))
+            .then((row) => {
                 const snapshot = normalize(row);
                 cache.set(characterId, snapshot);
                 notifyColdSnapshot(snapshot, reason);
@@ -3037,7 +3064,7 @@ const BotLifeState = {
             })
             .catch((err) => {
                 if (err?.code !== 'BOT_LIFE_STATE_OWNERSHIP_CONFLICT') {
-                    utils.infoWarn('BotLife', 'failed to upsert %s: %s', row.characterName, err.message);
+                    utils.infoWarn('BotLife', 'failed to upsert %s: %s', nextState.name || characterId, err.message);
                 }
                 return null;
             });
@@ -3215,6 +3242,7 @@ BotLifeState.canonicalizeAreaState = canonicalizeAreaState;
 BotLifeState.inventorySummaryFromItems = inventorySummaryFromItems;
 BotLifeState.marketPurchaseBlocker = marketPurchaseBlocker;
 BotLifeState.normalizeInventoryStackability = normalizeInventoryStackability;
+BotLifeState.preserveClanOwnedEquipmentState = preserveClanOwnedEquipmentState;
 BotLifeState.reconcileEquipmentInventory = reconcileEquipmentInventory;
 BotLifeState.reconcileFulfilledEquipmentPlan = reconcileFulfilledEquipmentPlan;
 BotLifeState.reconcileIncompatibleShieldState = reconcileIncompatibleShieldState;

--- a/src/GameServer/Bot/Population/ColdSimulationCoordinator.js
+++ b/src/GameServer/Bot/Population/ColdSimulationCoordinator.js
@@ -610,8 +610,11 @@ class ColdSimulationCoordinator {
     }
 
     async sendFullSnapshot() {
-        const states = LifeState.allStates(Math.max(1, Number(Config.maxPlayingPopulation) + 300 || 2000));
         await this.reconcileOrphanedBackgroundParties();
+        // Re-read after reconciliation: releasing an invalid party updates
+        // cached member ownership and membership. Sending the pre-repair
+        // array would immediately seed the worker with the stale party again.
+        const states = LifeState.allStates(Math.max(1, Number(Config.maxPlayingPopulation) + 300 || 2000));
         const compactPartyMemberIds = new Set(states.map((state) => Number(state.characterId || 0)).filter(Boolean));
         const index = this.contextIndex({ compactPartyMemberIds });
         const pageSize = this.snapshotQueue.pageSize;
@@ -651,24 +654,49 @@ class ColdSimulationCoordinator {
     }
 
     async reconcileOrphanedBackgroundParties() {
-        const orphaned = BackgroundPartyState.active().filter((party) => {
+        const allStates = typeof LifeState.allStates === 'function'
+            ? LifeState.allStates(Math.max(2000, Number(Config.maxPlayingPopulation || 0) + 300))
+            : [];
+        const invalid = BackgroundPartyState.active().map((party) => {
             const memberIds = (party.memberIds || []).map((id) => Number(id)).filter(Boolean);
-            return !memberIds.length || memberIds.every((id) => !LifeState.cachedState(id));
-        });
-        for (const party of orphaned) {
+            const states = memberIds.map((id) => LifeState.cachedState(id)).filter(Boolean);
+            const hasPartyField = (state) => (
+                Object.prototype.hasOwnProperty.call(state?.party || {}, 'partyId')
+                || Object.prototype.hasOwnProperty.call(state || {}, 'partyId')
+            );
+            const statePartyId = (state) => state?.party?.partyId ?? state?.partyId ?? null;
+            const attached = states.filter((state) => (
+                !hasPartyField(state) || String(statePartyId(state) || '') === String(party.partyId)
+            ));
+            const leaderAttached = attached.some((state) => Number(state.characterId) === Number(party.leaderId));
+            const declared = new Set(memberIds);
+            const extraAttached = allStates.some((state) => (
+                String(statePartyId(state) || '') === String(party.partyId)
+                && !declared.has(Number(state.characterId))
+            ));
+            const reason = !memberIds.length || !states.length
+                ? 'orphaned_dissolved_party'
+                : !leaderAttached || attached.length !== memberIds.length || extraAttached
+                    ? 'party_membership_mismatch'
+                    : null;
+            return reason ? { party, reason } : null;
+        }).filter(Boolean);
+        for (const entry of invalid) {
+            const { party, reason } = entry;
             const dissolved = await BackgroundPartyState.setStatus(party.partyId, 'dissolved');
             if (dissolved) {
                 const released = await LifeState.releaseDissolvedPartyMembers(
                     party.partyId,
-                    'orphaned_dissolved_party'
+                    reason
                 );
-                console.info('ColdWorker :: dissolved orphaned background party %s declaredMembers=%d releasedMembers=%d',
+                console.info('ColdWorker :: dissolved invalid background party %s reason=%s declaredMembers=%d releasedMembers=%d',
                     party.partyId,
+                    reason,
                     party.memberIds?.length || 0,
                     released);
             }
         }
-        return orphaned;
+        return invalid.map((entry) => entry.party);
     }
 
     startSnapshotJob(mode, work, pressure = {}) {
@@ -937,6 +965,7 @@ class ColdSimulationCoordinator {
     async afterCommit(entry) {
         const state = LifeState.cachedState(entry.nextState.characterId) || entry.nextState;
         await LifeEvents.recordMany(state.characterId, entry.proposal.result?.events || []);
+        await LifeState.enqueueEquipmentGoalAdvanceForState(state);
         if (entry.proposal.partyResolution?.party) {
             const party = entry.proposal.partyResolution.party;
             await BackgroundPartyState.createOrUpdate(party);

--- a/src/GameServer/Bot/Population/ColdSimulationCoordinator.js
+++ b/src/GameServer/Bot/Population/ColdSimulationCoordinator.js
@@ -662,13 +662,9 @@ class ColdSimulationCoordinator {
         const invalid = BackgroundPartyState.active().map((party) => {
             const memberIds = (party.memberIds || []).map((id) => Number(id)).filter(Boolean);
             const states = memberIds.map((id) => LifeState.cachedState(id)).filter(Boolean);
-            const hasPartyField = (state) => (
-                Object.prototype.hasOwnProperty.call(state?.party || {}, 'partyId')
-                || Object.prototype.hasOwnProperty.call(state || {}, 'partyId')
-            );
             const statePartyId = (state) => state?.party?.partyId ?? state?.partyId ?? null;
             const attached = states.filter((state) => (
-                !hasPartyField(state) || String(statePartyId(state) || '') === String(party.partyId)
+                String(statePartyId(state) || '') === String(party.partyId)
             ));
             const leaderAttached = attached.some((state) => Number(state.characterId) === Number(party.leaderId));
             const declared = new Set(memberIds);

--- a/src/GameServer/Bot/Population/ColdSimulationCoordinator.js
+++ b/src/GameServer/Bot/Population/ColdSimulationCoordinator.js
@@ -967,7 +967,11 @@ class ColdSimulationCoordinator {
     async afterCommit(entry) {
         const state = LifeState.cachedState(entry.nextState.characterId) || entry.nextState;
         await LifeEvents.recordMany(state.characterId, entry.proposal.result?.events || []);
-        await LifeState.enqueueEquipmentGoalAdvanceForState(state);
+        await LifeState.enqueueEquipmentGoalAdvanceForState(state)
+            .catch((error) => {
+                utils.infoWarn('BotGoals', 'equipment goal advance enqueue failed for %s: %s',
+                    state.characterId, error?.message || error);
+            });
         if (entry.proposal.partyResolution?.party) {
             const party = entry.proposal.partyResolution.party;
             await BackgroundPartyState.createOrUpdate(party);

--- a/src/GameServer/Bot/Population/ColdSimulationCoordinator.js
+++ b/src/GameServer/Bot/Population/ColdSimulationCoordinator.js
@@ -368,7 +368,9 @@ class ColdSimulationCoordinator {
         return {
             maxBatch: Math.max(1, Math.min(64, Number(Config.coldWorkerBatchSize) || 64)),
             maxInFlight: this.desiredWorkerPressure().maxInFlight,
-            maxAtomicPartySize: Math.max(2, Number(Config.partyMaxSize) || 5),
+            // Normal ambient parties keep their configured cap, while a clan
+            // equipment operation may use the native C4 party limit of nine.
+            maxAtomicPartySize: Math.max(9, Number(Config.partyMaxSize) || 5),
             claimAckTimeoutMs: 5000,
             flushTargetMs: Math.max(100, Number(Config.coldWorkerOrdinaryFlushMs) || 2000),
             flushHardMs: Math.max(1000, Number(Config.coldWorkerOrdinaryHardMaxMs) || 5000),

--- a/src/GameServer/Bot/Population/ColdSimulationWorker.js
+++ b/src/GameServer/Bot/Population/ColdSimulationWorker.js
@@ -22,6 +22,8 @@ const stubs = new Map([
     ['GameServer/Bot/AI/BotRaidSafety', {
         isProtectedRaidEntity: (target) => target?.raidBoss === true
             || target?.template?.raidBoss === true
+            || String(target?.kind || '').toLowerCase() === 'boss'
+            || String(target?.template?.kind || '').toLowerCase() === 'boss'
             || Number(target?.minionBossObjectId || target?.minionBossTemplateId || 0) > 0
     }],
     ['GameServer/Bot/Economy/CraftShopService', {
@@ -135,7 +137,7 @@ function startKernel(config = {}) {
             const clanGoalLocked = GearAcquisitionPlanner.clanGoalPlanLocked(state, previousPlan);
             const reusablePartyRequest = !state.party?.partyId
                 && previousPlan?.next
-                && replanContext.planCurrent
+                && replanContext.routeCurrent
                 && !replanContext.failure
                 && state.stats?.partyRequest?.status === 'open'
                 && Number(state.stats.partyRequest.reviewAt || 0) > timestamp;

--- a/src/GameServer/Bot/Population/PartyRequestPlanner.js
+++ b/src/GameServer/Bot/Population/PartyRequestPlanner.js
@@ -93,10 +93,19 @@ function partyRequestForPlan(state, plan, timestamp = Date.now()) {
 }
 
 function partyObjectiveForState(state) {
-    if (state?.stats?.partyRequest) {
-        return state.stats.partyRequest.status === 'open' ? state.stats.partyRequest : null;
+    const request = state?.stats?.partyRequest;
+    const clanObjective = clanPartyObjectiveForState(state);
+    if (clanObjective?.status === 'open') {
+        if (request?.status === 'open'
+            && String(request.clanGoalKey || '') === String(clanObjective.clanGoalKey || '')) {
+            return { ...request, ...clanObjective, requestedAt: request.requestedAt || clanObjective.requestedAt };
+        }
+        return clanObjective;
     }
-    return partyObjectiveForPlan(state?.stats?.equipmentPlan) || clanPartyObjectiveForState(state);
+    if (request) {
+        return request.status === 'open' ? request : null;
+    }
+    return partyObjectiveForPlan(state?.stats?.equipmentPlan) || clanObjective;
 }
 
 module.exports = {

--- a/src/GameServer/Bot/Population/PopulationService.js
+++ b/src/GameServer/Bot/Population/PopulationService.js
@@ -3013,7 +3013,7 @@ const PopulationService = {
         if (!acquisitionPlan) {
             const reusablePartyRequest = !state.party?.partyId
                 && previousPlan?.next
-                && replanContext.planCurrent
+                && replanContext.routeCurrent
                 && !replanContext.failure
                 && state.stats?.partyRequest?.status === 'open'
                 && Number(state.stats.partyRequest.reviewAt || 0) > startedAt;

--- a/src/GameServer/Bot/Population/PopulationService.js
+++ b/src/GameServer/Bot/Population/PopulationService.js
@@ -297,6 +297,11 @@ function acquisitionRequirementKey(plan) {
 }
 
 function partyObjectivesShareRoute(left, right) {
+    const leftClanGoal = String(left?.clanGoalKey || '');
+    const rightClanGoal = String(right?.clanGoalKey || '');
+    if (leftClanGoal || rightClanGoal) {
+        return Boolean(leftClanGoal && leftClanGoal === rightClanGoal);
+    }
     return Boolean(left && right
         && String(left.spotId || '') === String(right.spotId || '')
         && Number(left.npcId || 0) > 0
@@ -338,8 +343,13 @@ function expirePartyRequestForState(state, timestamp = Date.now()) {
     };
 }
 
+function partyObjectiveGroupingKey(objective) {
+    const clanGoalKey = String(objective?.clanGoalKey || '');
+    return clanGoalKey ? `clan-goal:${clanGoalKey}` : objective?.objectiveKey;
+}
+
 function partyObjectiveKeyForState(state) {
-    return partyObjectiveForState(state)?.objectiveKey
+    return partyObjectiveGroupingKey(partyObjectiveForState(state))
         || `spot:${state?.spotId || 'unknown'}`;
 }
 
@@ -424,6 +434,29 @@ function dissolveBackgroundParty(party, reason, memberCount = 0) {
             );
             return { ok: false, reason, party, cleared };
         });
+}
+
+function partyLimitsForObjective(objective = null) {
+    const clanEquipment = objective?.clanOperation === 'equipment'
+        && Number(objective?.clanId || 0) > 0;
+    const maxSize = clanEquipment
+        ? Math.max(2, Math.min(9, Number(objective.maxPartySize) || Config.partyMaxSize))
+        : Config.partyMaxSize;
+    return {
+        maxSize,
+        minSize: clanEquipment
+            ? Math.max(2, Math.min(maxSize, Number(objective.minPartySize) || Config.partyMinSize))
+            : Config.partyMinSize,
+        levelRange: clanEquipment ? Math.max(4, Number(objective.levelRange) || 99) : undefined
+    };
+}
+
+function requiresClanEquipmentParty(state) {
+    const objective = partyObjectiveForState(state);
+    return objective?.status === 'open'
+        && objective?.priority === 'required'
+        && objective?.clanOperation === 'equipment'
+        && Number(objective?.clanId || 0) > 0;
 }
 
 async function reconcileWorkerPartyGoals(party, timestamp = Date.now()) {
@@ -1756,17 +1789,20 @@ const PopulationService = {
             .then(() => timedStage('candidate_projection', () => LifeState.coldPartyCandidateProjections()
                 .then((states) => ({
                     states,
-                    partyRequestBacklog: states.some((state) => state.stats?.partyRequest?.status === 'open'),
+                    partyRequestBacklog: states.some((state) => partyObjectiveForState(state)?.status === 'open'),
                     requiredPartyRequestCount: states.filter((state) => (
-                        state.stats?.partyRequest?.status === 'open'
-                        && state.stats?.partyRequest?.priority === 'required'
+                        partyObjectiveForState(state)?.status === 'open'
+                        && partyObjectiveForState(state)?.priority === 'required'
                     )).length
                 }))))
             .then(({ states, partyRequestBacklog, requiredPartyRequestCount }) => {
-                const willingStates = states.filter((state) => PersonaPartyPolicy.backgroundIntent(state).accept);
+                const willingStates = states.filter((state) => (
+                    requiresClanEquipmentParty(state)
+                    || PersonaPartyPolicy.backgroundIntent(state).accept
+                ));
                 const requiredStates = willingStates.filter((state) => (
-                    state.stats?.partyRequest?.status === 'open'
-                    && state.stats?.partyRequest?.priority === 'required'
+                    partyObjectiveForState(state)?.status === 'open'
+                    && partyObjectiveForState(state)?.priority === 'required'
                 ));
                 const reclaim = activity.protected
                     ? Promise.resolve([])
@@ -1808,13 +1844,19 @@ const PopulationService = {
 
                 return groups.reduce((chain, group) => chain.then(() => {
                     if (created.length >= maxNewParties || budgetReached()) return null;
-                    if (group.length < Config.partyMinSize) return null;
+                    const requestedObjective = group
+                        .map((state) => partyObjectiveForState(state))
+                        .find((objective) => objective?.priority === 'required')
+                        || partyObjectiveForState(group[0]);
+                    const partyLimits = partyLimitsForObjective(requestedObjective);
+                    if (group.length < partyLimits.minSize) return null;
 
                     const selectedMembers = PartyComposition.selectMembers(group, {
-                        minSize: Config.partyMinSize,
-                        maxSize: Config.partyMaxSize
+                        minSize: partyLimits.minSize,
+                        maxSize: partyLimits.maxSize,
+                        levelRange: partyLimits.levelRange
                     });
-                    if (selectedMembers.length < Config.partyMinSize) {
+                    if (selectedMembers.length < partyLimits.minSize) {
                         const requiredIds = group
                             .filter((state) => state.stats?.partyRequest?.status === 'open'
                                 && state.stats?.partyRequest?.priority === 'required')
@@ -1995,10 +2037,12 @@ const PopulationService = {
                 key,
                 spotId: partyObjectiveSpotForState(group[0]),
                 states: group.sort((a, b) => Number(a.level || 1) - Number(b.level || 1)),
+                clanEquipment: partyObjectiveForState(group[0])?.clanOperation === 'equipment',
                 partyWaiters: group.filter((state) => state.activity === 'party_wait'
-                    || state.stats?.partyRequest?.status === 'open').length
+                    || partyObjectiveForState(state)?.status === 'open').length
             }))
             .sort((a, b) => {
+                if (a.clanEquipment !== b.clanEquipment) return a.clanEquipment ? -1 : 1;
                 if (options.prioritizePartyWait && a.partyWaiters !== b.partyWaiters) {
                     return b.partyWaiters - a.partyWaiters;
                 }
@@ -2128,6 +2172,15 @@ const PopulationService = {
         );
         const reclaimCount = Math.max(0, wantedSlots - availableSlots);
         if (!reclaimCount || !activeParties.length) return Promise.resolve([]);
+        const requestedClanGoals = new Set(partyWaitStates
+            .map((state) => partyObjectiveForState(state))
+            .filter((objective) => objective?.clanOperation === 'equipment' && objective.clanGoalKey)
+            .map((objective) => String(objective.clanGoalKey)));
+        activeParties.forEach((party) => {
+            const goalKey = String(party?.stats?.objective?.clanGoalKey || '');
+            if (goalKey) requestedClanGoals.delete(goalKey);
+        });
+        const clanPrioritySlots = requestedClanGoals.size;
 
         return this.refreshBackgroundPartyRequirements(activeParties, options)
             .then(() => {
@@ -2140,10 +2193,18 @@ const PopulationService = {
             .then((counts) => {
                 if (!counts) return [];
                 const countByPartyId = new Map(counts.map((count) => [count.partyId, count]));
-                return activeParties
+                const elective = activeParties
                     .filter((party) => Number(countByPartyId.get(party.partyId)?.requiredMembers || 0) === 0)
                     .sort((a, b) => Number(a.startedAt || 0) - Number(b.startedAt || 0))
                     .slice(0, reclaimCount);
+                if (elective.length >= reclaimCount || clanPrioritySlots <= 0) return elective;
+                const selected = new Set(elective.map((party) => String(party.partyId)));
+                const clanFallback = activeParties
+                    .filter((party) => !selected.has(String(party.partyId)))
+                    .filter((party) => party?.stats?.objective?.clanOperation !== 'equipment')
+                    .sort((a, b) => Number(a.startedAt || 0) - Number(b.startedAt || 0))
+                    .slice(0, Math.min(clanPrioritySlots, reclaimCount - elective.length));
+                return [...elective, ...clanFallback];
             })
             .then((parties) => parties.reduce((chain, party) => (
                 chain.then((reclaimed) => dissolveBackgroundParty(party, 'party_capacity_reclaimed', party.memberIds?.length || 0)
@@ -2160,17 +2221,21 @@ const PopulationService = {
         };
         const claimed = new Set();
         const parties = BackgroundPartyState.active()
-            .filter((party) => (party.memberIds || []).length < Config.partyMaxSize)
+            .filter((party) => {
+                const limits = partyLimitsForObjective(party?.stats?.objective || null);
+                return (party.memberIds || []).length < limits.maxSize;
+            })
             .sort((a, b) => (a.memberIds || []).length - (b.memberIds || []).length);
 
         return statesForParties(parties.map((party) => party.partyId)).then((membersByParty) => parties.reduce((chain, party) => chain.then(() => {
             if (budgetReached()) return null;
-            const members = membersByParty.get(String(party.partyId)) || [];
+                const members = membersByParty.get(String(party.partyId)) || [];
+                const partyLimits = partyLimitsForObjective(party?.stats?.objective || null);
                 if (members.length < Config.partyMinSize) return null;
                 const persistedMemberIds = new Set((party.memberIds || []).map(Number));
                 const membershipMismatch = members.length !== persistedMemberIds.size
                     || members.some((member) => !persistedMemberIds.has(Number(member.characterId)));
-                if (members.length >= Config.partyMaxSize) {
+                if (members.length >= partyLimits.maxSize) {
                     if (!membershipMismatch) return null;
                     const electedLeaderId = leaderIdForMembers(party, members);
                     const reconciledParty = {
@@ -2194,13 +2259,17 @@ const PopulationService = {
                 const nearby = candidates.filter((state) => (
                     !claimed.has(Number(state.characterId))
                     && (partyObjective
-                        ? (partyObjectiveKeyForState(state) === partyObjective.objectiveKey
+                        ? (partyObjectiveKeyForState(state) === partyObjectiveGroupingKey(partyObjective)
                             || partyObjectivesShareRoute(partyObjective, partyObjectiveForState(state))
-                            || (state.stats?.partyRequest?.priority !== 'required'
+                            || (!partyObjective.clanGoalKey
+                                && state.stats?.partyRequest?.priority !== 'required'
                                 && partyObjectiveSpotForState(state) === partyObjective.spotId))
                         : state.spotId === party.spotId)
                 ));
-                const recruits = PartyComposition.selectRecruits(members, nearby, { maxSize: Config.partyMaxSize });
+                const recruits = PartyComposition.selectRecruits(members, nearby, {
+                    maxSize: partyLimits.maxSize,
+                    levelRange: partyLimits.levelRange
+                });
                 if (!recruits.length) return null;
 
                 return hydratePartyCandidates(recruits).then((hydratedRecruits) => {
@@ -3304,5 +3373,8 @@ PopulationService.beginPartySpotTravel = beginPartySpotTravel;
 PopulationService.finishPartySpotTravel = finishPartySpotTravel;
 PopulationService.finishPartyTravelRecord = finishPartyTravelRecord;
 PopulationService.marketListingIntent = marketListingIntent;
+PopulationService.partyLimitsForObjective = partyLimitsForObjective;
+PopulationService.requiresClanEquipmentParty = requiresClanEquipmentParty;
+PopulationService.partyObjectivesShareRoute = partyObjectivesShareRoute;
 
 module.exports = PopulationService;

--- a/src/GameServer/Bot/Population/SpotRiskPolicy.js
+++ b/src/GameServer/Bot/Population/SpotRiskPolicy.js
@@ -1,6 +1,7 @@
 const MIN_DEATHS_AT_SPOT = 2;
 const MIN_DEATH_RATE = 0.2;
 const BACKOFF_MS = 60 * 60 * 1000;
+const MAX_BACKOFF_MS = 6 * 60 * 60 * 1000;
 const MAX_BACKOFFS = 8;
 
 function normalizedSpotId(value) {
@@ -67,14 +68,25 @@ function withBackoff(state = {}, backoff = null, timestamp = Date.now()) {
     const spotId = normalizedSpotId(backoff?.spotId);
     if (!spotId) return state;
 
+    const prior = (Array.isArray(state.stats?.spotBackoffs) ? state.stats.spotBackoffs : [])
+        .filter((entry) => normalizedSpotId(entry?.spotId) === spotId)
+        .sort((left, right) => Number(right.startedAt || 0) - Number(left.startedAt || 0))[0];
+    const continuing = prior
+        && Number(prior.until || 0) > timestamp
+        && Number(prior.startedAt || 0) === Number(backoff.startedAt || 0);
+    const attempts = continuing
+        ? Math.max(1, Number(prior.attempts || 1))
+        : Math.max(1, Number(prior?.attempts || 0) + 1);
+    const escalationMs = Math.min(MAX_BACKOFF_MS, BACKOFF_MS * (2 ** Math.min(3, attempts - 1)));
     const retained = activeBackoffs(state, timestamp)
         .filter((entry) => entry.spotId !== spotId);
     const next = {
         ...backoff,
         spotId,
         reason: backoff.reason || 'death_pressure',
+        attempts,
         startedAt: Number(backoff.startedAt || timestamp),
-        until: Math.max(timestamp + 1000, Number(backoff.until || timestamp + BACKOFF_MS))
+        until: Math.max(timestamp + escalationMs, Number(backoff.until || 0))
     };
     const spotBackoffs = [...retained, next]
         .sort((left, right) => Number(right.until) - Number(left.until))
@@ -92,6 +104,7 @@ module.exports = {
     MIN_DEATHS_AT_SPOT,
     MIN_DEATH_RATE,
     BACKOFF_MS,
+    MAX_BACKOFF_MS,
     MAX_BACKOFFS,
     deathPressure,
     activeBackoffs,

--- a/src/GameServer/Bot/Population/SpotRiskPolicy.js
+++ b/src/GameServer/Bot/Population/SpotRiskPolicy.js
@@ -74,9 +74,10 @@ function withBackoff(state = {}, backoff = null, timestamp = Date.now()) {
     const continuing = prior
         && Number(prior.until || 0) > timestamp
         && Number(prior.startedAt || 0) === Number(backoff.startedAt || 0);
+    const priorAttempts = prior ? Math.max(1, Number(prior.attempts || 1)) : 0;
     const attempts = continuing
-        ? Math.max(1, Number(prior.attempts || 1))
-        : Math.max(1, Number(prior?.attempts || 0) + 1);
+        ? priorAttempts
+        : Math.max(1, priorAttempts + 1);
     const escalationMs = Math.min(MAX_BACKOFF_MS, BACKOFF_MS * (2 ** Math.min(3, attempts - 1)));
     const retained = activeBackoffs(state, timestamp)
         .filter((entry) => entry.spotId !== spotId);

--- a/src/GameServer/Bot/Population/SpotRiskPolicy.js
+++ b/src/GameServer/Bot/Population/SpotRiskPolicy.js
@@ -87,7 +87,10 @@ function withBackoff(state = {}, backoff = null, timestamp = Date.now()) {
         reason: backoff.reason || 'death_pressure',
         attempts,
         startedAt: Number(backoff.startedAt || timestamp),
-        until: Math.max(timestamp + escalationMs, Number(backoff.until || 0))
+        until: Math.min(
+            timestamp + MAX_BACKOFF_MS,
+            Math.max(timestamp + escalationMs, Number(backoff.until || 0))
+        )
     };
     const spotBackoffs = [...retained, next]
         .sort((left, right) => Number(right.until) - Number(left.until))

--- a/src/GameServer/Clan/ClanActionService.js
+++ b/src/GameServer/Clan/ClanActionService.js
@@ -17,7 +17,7 @@ const ACTION_TYPES = Object.freeze({
 });
 // Bump when a deploy adds a recovery behavior that must revisit durable goals
 // whose previous bootstrap action already succeeded under older code.
-const BOOTSTRAP_RECOVERY_VERSION = 3;
+const BOOTSTRAP_RECOVERY_VERSION = 4;
 
 const metrics = {
     bootstraps: 0,
@@ -107,10 +107,11 @@ async function refreshQueueStats() {
 
 function actionTypeFor(clan, goal) {
     if (!clan || !goal || goal.status === 'completed') return null;
-    // L3 equipment goals are consumed by the beneficiary's normal gear and
-    // party lifecycle. Keeping them out of this queue avoids turning a durable
-    // objective into a per-tick clan scheduler job.
-    if (goal.type === 'equipment') return null;
+    // The bots execute an equipment route through their normal lifecycle, but
+    // the clan re-evaluates the weakest/highest-priority beneficiary on the
+    // bounded retry cadence. This also repairs a lost durable plan binding
+    // without turning equipment into a per-combat-tick scheduler job.
+    if (goal.type === 'equipment') return ACTION_TYPES.PLAN;
     if (number(clan.level) <= 1) return ACTION_TYPES.CONTRIBUTION;
     switch (String(goal.plan?.kind || '')) {
         case 'warehouse': return ACTION_TYPES.WAREHOUSE;

--- a/src/GameServer/Clan/ClanActionService.js
+++ b/src/GameServer/Clan/ClanActionService.js
@@ -15,6 +15,9 @@ const ACTION_TYPES = Object.freeze({
     MARKET: 'market',
     PARTY: 'party'
 });
+// Bump when a deploy adds a recovery behavior that must revisit durable goals
+// whose previous bootstrap action already succeeded under older code.
+const BOOTSTRAP_RECOVERY_VERSION = 3;
 
 const metrics = {
     bootstraps: 0,
@@ -149,7 +152,7 @@ async function bootstrap() {
     for (const clan of clans) {
         const result = await Database.enqueueClanAction({
             clanId: clan.clanId,
-            actionKey: `clan:${Number(clan.clanId)}:recovery:${Number(clan.updatedAt) || 0}`,
+            actionKey: `clan:${Number(clan.clanId)}:recovery:v${BOOTSTRAP_RECOVERY_VERSION}:${Number(clan.updatedAt) || 0}`,
             actionType: ACTION_TYPES.PLAN,
             priority: 75,
             payload: { reason: 'runtime_bootstrap', clanId: Number(clan.clanId) }

--- a/src/GameServer/Clan/ClanEquipmentPolicy.js
+++ b/src/GameServer/Clan/ClanEquipmentPolicy.js
@@ -65,6 +65,7 @@ function selectTargetMember(members = [], plans = new Map(), previousGoal = null
     // This prevents a replan from jumping to another member while the current
     // member is still waiting for a drop, craft, or market purchase.
     if (previousMember && isAcquisitionPlan(previousPlan)
+        && previousPlan.status !== 'blocked'
         && previousGoal?.status !== 'completed'
         && !options.previousFulfilled) {
         return { member: previousMember, plan: previousPlan, preserved: true };

--- a/src/GameServer/Clan/ClanEquipmentPolicy.js
+++ b/src/GameServer/Clan/ClanEquipmentPolicy.js
@@ -4,6 +4,16 @@ function number(value, fallback = 0) {
 }
 
 const PLAN_STATUSES = new Set(['active', 'blocked', 'component_ready', 'ready_to_craft']);
+const GRADE_RANK = Object.freeze({ none: 0, d: 1, c: 2, b: 3, a: 4, s: 5 });
+const ROLE_PRIORITY = Object.freeze({
+    tank: 45,
+    healer: 40,
+    buffer: 20,
+    dps: 8,
+    mage: 8,
+    crafter: 4,
+    spoiler: 4
+});
 
 function memberId(member) {
     return number(member?.characterId ?? member?.id);
@@ -35,6 +45,64 @@ function planPriority(plan) {
         + Math.min(100, Math.max(0, number(plan?.expectedKills) / 10));
 }
 
+function rankFor(value) {
+    return GRADE_RANK[String(value || 'none').toLowerCase()] || 0;
+}
+
+function memberRole(member, options = {}) {
+    if (typeof options.roleFor === 'function') return String(options.roleFor(member) || 'dps');
+    return String(member?.stats?.role || member?.party?.role || 'dps');
+}
+
+function equippedItems(member) {
+    const summarized = Array.isArray(member?.stats?.equipment) ? member.stats.equipment : [];
+    if (summarized.length) return summarized;
+    return Object.values(member?.inventory || {}).filter((item) => item?.equipped);
+}
+
+function itemSlots(item) {
+    if (Array.isArray(item?.equippedSlots) && item.equippedSlots.length) return item.equippedSlots.map(Number);
+    const slot = number(item?.slot ?? item?.etc?.slot);
+    return slot > 0 ? [slot] : [];
+}
+
+function itemRank(item) {
+    return rankFor(item?.rank ?? item?.etc?.rank ?? item?.template?.rank);
+}
+
+function slotMatches(left, right) {
+    return left === right || [7, 14].includes(left) && [7, 14].includes(right);
+}
+
+function equipmentPriority(member, plan, options = {}) {
+    const items = equippedItems(member);
+    const targetSlot = number(plan?.target?.slot);
+    const targetRank = rankFor(plan?.grade);
+    const currentTargetRank = items.reduce((best, item) => (
+        itemSlots(item).some((slot) => slotMatches(slot, targetSlot))
+            ? Math.max(best, itemRank(item))
+            : best
+    ), 0);
+    const representedSlots = new Set(items.flatMap(itemSlots).filter((slot) => slot > 0));
+    const overallStrength = items.reduce((sum, item) => sum + itemRank(item), 0);
+    const expectedStrength = Math.max(1, targetRank) * 8;
+    const overallDebt = Math.max(0, expectedStrength - overallStrength);
+    const targetDebt = Math.max(1, targetRank - currentTargetRank);
+    const missingTargetSlot = ![...representedSlots].some((slot) => slotMatches(slot, targetSlot));
+    const readiness = {
+        ready_to_craft: 24,
+        component_ready: 14,
+        active: 8,
+        blocked: -100
+    }[String(plan?.status || '')] || 0;
+    const role = memberRole(member, options);
+    return targetDebt * 100
+        + overallDebt * 5
+        + (missingTargetSlot ? 20 : 0)
+        + (ROLE_PRIORITY[role] || 0)
+        + readiness;
+}
+
 function goalKey(clanId, member, plan) {
     return [
         'clan-equipment',
@@ -61,28 +129,44 @@ function selectTargetMember(members = [], plans = new Map(), previousGoal = null
     const previousMember = members.find((member) => memberId(member) === previousMemberId);
     const previousPlan = plans.get(previousMemberId);
 
-    // One clan goal owns one beneficiary until the item is actually equipped.
-    // This prevents a replan from jumping to another member while the current
-    // member is still waiting for a drop, craft, or market purchase.
+    const ranked = members
+        .filter((member) => member?.phase === 'cold'
+            && (!member?.partyId || memberId(member) === previousMemberId))
+        .map((member) => {
+            const plan = plans.get(memberId(member));
+            return { member, plan, priority: equipmentPriority(member, plan, options) };
+        })
+        .filter((entry) => isAcquisitionPlan(entry.plan))
+        .sort((left, right) => (
+            right.priority - left.priority
+            || planPriority(right.plan) - planPriority(left.plan)
+            || number(left.member.level) - number(right.member.level)
+            || memberId(left.member) - memberId(right.member)
+        ));
+    const selected = ranked[0] || null;
+    if (!selected) return null;
+
+    // Keep a current beneficiary only while its equipment debt is at least as
+    // important as the best alternative. This gives a nearly-finished craft a
+    // small stability bonus, but lets a weaker tank/healer or a materially
+    // worse-equipped member take over at the next clan review.
     if (previousMember && isAcquisitionPlan(previousPlan)
         && previousPlan.status !== 'blocked'
         && previousGoal?.status !== 'completed'
         && !options.previousFulfilled) {
-        return { member: previousMember, plan: previousPlan, preserved: true };
+        const previousPriority = equipmentPriority(previousMember, previousPlan, options);
+        if (memberId(selected.member) === previousMemberId || previousPriority >= selected.priority) {
+            return { member: previousMember, plan: previousPlan, priority: previousPriority, preserved: true };
+        }
     }
-
-    return members
-        .filter((member) => member?.phase === 'cold' && !member?.partyId)
-        .map((member) => ({ member, plan: plans.get(memberId(member)) }))
-        .filter((entry) => isAcquisitionPlan(entry.plan))
-        .sort((left, right) => (
-            planPriority(right.plan) - planPriority(left.plan)
-            || number(left.member.level) - number(right.member.level)
-            || memberId(left.member) - memberId(right.member)
-        ))[0] || null;
+    return {
+        ...selected,
+        rotated: previousMemberId > 0 && previousMemberId !== memberId(selected.member),
+        previousMemberId: previousMemberId || null
+    };
 }
 
-function buildGoal(clan, selection, previousGoal = null, timestamp = Date.now()) {
+function buildGoal(clan, selection, previousGoal = null, timestamp = Date.now(), options = {}) {
     if (!selection?.member || !selection?.plan) return null;
     const member = selection.member;
     const plan = selection.plan;
@@ -120,12 +204,16 @@ function buildGoal(clan, selection, previousGoal = null, timestamp = Date.now())
             selectedAt: timestamp,
             reasonCode: `clan_equipment_${route}`
         },
-        assignedMemberIds: [memberIdValue],
+        assignedMemberIds: Array.isArray(options.assignedMemberIds) && options.assignedMemberIds.length
+            ? [...new Set(options.assignedMemberIds.map(number).filter(Boolean))]
+            : [memberIdValue],
         partyId: null,
         catastrophicFailures: sameTarget ? number(previousGoal.catastrophicFailures) : 0,
         status,
         reasonCodes: [`clan_equipment_${route}`],
         goalKey: goalKey(clan.id, member, plan),
+        priorityScore: number(selection.priority),
+        beneficiaryRole: String(options.roleFor?.(member) || member?.stats?.role || 'dps'),
         createdAt: sameTarget ? number(previousGoal.createdAt, timestamp) : timestamp,
         updatedAt: timestamp
     };
@@ -137,6 +225,7 @@ module.exports = {
     goalKey,
     hasTarget,
     isAcquisitionPlan,
+    equipmentPriority,
     planPriority,
     routeFor,
     selectTargetMember,

--- a/src/GameServer/Clan/ClanEquipmentService.js
+++ b/src/GameServer/Clan/ClanEquipmentService.js
@@ -3,6 +3,10 @@ const GearAcquisitionPlanner = invoke('GameServer/Bot/AI/GearAcquisitionPlanner'
 const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
 const SpotProfiles = invoke('GameServer/Bot/Population/SpotProfiles');
 const Policy = invoke('GameServer/Clan/ClanEquipmentPolicy');
+const Config = invoke('GameServer/Clan/ClanSimulationConfig');
+const GoalPolicy = invoke('GameServer/Clan/ClanGoalPolicy');
+const ClanPolicy = invoke('GameServer/Clan/ClanSimulationPolicy');
+const BackgroundPartyState = invoke('GameServer/Bot/Population/BackgroundPartyState');
 
 const metrics = {
     resolves: 0,
@@ -141,6 +145,27 @@ function samePlanTarget(left, right) {
         && number(left?.target?.slot) === number(right?.target?.slot);
 }
 
+function memberId(member) {
+    return number(member?.characterId ?? member?.id);
+}
+
+function equipmentRoster(clan, beneficiary, previousGoal = null) {
+    const beneficiaryId = memberId(beneficiary);
+    const memberIds = new Set((clan?.members || []).map(memberId).filter(Boolean));
+    const previousBeneficiaryId = number(previousGoal?.target?.memberId);
+    const retained = (previousGoal?.assignedMemberIds || []).map(number)
+        .filter((id) => memberIds.has(id));
+    if (beneficiaryId && beneficiaryId === previousBeneficiaryId
+        && retained.length >= Math.max(2, number(Config.operationMinMembers, 5))) return retained;
+    const maxMembers = Math.max(2, Math.min(9, number(Config.operationMaxMembers, 9)));
+    const selected = GoalPolicy.operationMembers(clan?.members || [], maxMembers);
+    if (beneficiaryId && !selected.includes(beneficiaryId)) {
+        if (selected.length >= maxMembers) selected.pop();
+        selected.unshift(beneficiaryId);
+    }
+    return [...new Set(selected.map(number).filter(Boolean))];
+}
+
 function clanPartyObjective(plan, goal, priority = 'preferred', clanId = 0) {
     // A craft plan with missing components still has a farming route in
     // `next`; a ready-to-craft plan has no route and therefore needs no party.
@@ -151,6 +176,9 @@ function clanPartyObjective(plan, goal, priority = 'preferred', clanId = 0) {
     const objectiveKey = npcId > 0
         ? [strategy, plan.next.spotId, npcId].join(':')
         : [strategy, plan.next.spotId, npcId, targetItemId].join(':');
+    const rosterSize = Math.max(1, (goal?.assignedMemberIds || []).length);
+    const maxPartySize = Math.max(2, Math.min(9, rosterSize));
+    const minPartySize = Math.max(2, Math.min(maxPartySize, number(Config.operationMinMembers, 5)));
     return {
         status: 'open',
         priority,
@@ -165,6 +193,10 @@ function clanPartyObjective(plan, goal, priority = 'preferred', clanId = 0) {
         clanId: number(clanId) || null,
         clanGoalKey: goal.goalKey || null,
         partyPreference: 'clan_first',
+        clanOperation: 'equipment',
+        maxPartySize,
+        minPartySize,
+        levelRange: 99,
         requestedAt: Date.now(),
         reviewAt: Date.now() + 300000,
         attempts: 0,
@@ -175,7 +207,65 @@ function clanPartyObjective(plan, goal, priority = 'preferred', clanId = 0) {
 function stateHasSameClanObjective(state, objective) {
     return String(state?.stats?.clanPartyObjective?.clanGoalKey || '') === String(objective?.clanGoalKey || '')
         && String(state?.stats?.clanPartyObjective?.objectiveKey || '') === String(objective?.objectiveKey || '')
-        && state?.stats?.partyRequest?.status === 'open';
+        && number(state?.stats?.clanPartyObjective?.maxPartySize) === number(objective?.maxPartySize)
+        && state?.stats?.partyRequest?.status === 'open'
+        && state.stats.partyRequest.priority === objective.priority;
+}
+
+async function releasePreviousBeneficiary(clan, previousGoal, nextGoal) {
+    const previousMemberId = number(previousGoal?.target?.memberId);
+    if (!previousMemberId || previousMemberId === number(nextGoal?.target?.memberId)) {
+        return { changed: false, releasedMembers: 0 };
+    }
+    const previousGoalKey = String(previousGoal?.goalKey || '');
+    const parties = BackgroundPartyState.active().filter((party) => (
+        String(party?.stats?.objective?.clanGoalKey || '') === previousGoalKey
+    ));
+    let releasedMembers = 0;
+    for (const party of parties) {
+        const dissolved = await BackgroundPartyState.setStatus(party.partyId, 'dissolved');
+        if (dissolved) {
+            releasedMembers += number(await LifeState.releaseDissolvedPartyMembers(
+                party.partyId,
+                'clan_equipment_goal_rotated'
+            ));
+        }
+    }
+
+    const current = await LifeState.findByCharacterId(previousMemberId);
+    const currentPlan = current?.stats?.equipmentPlan;
+    if (!current || String(currentPlan?.clanGoal?.goalKey || '') !== previousGoalKey) {
+        return { changed: parties.length > 0, releasedMembers };
+    }
+    const stats = { ...(current.stats || {}) };
+    stats.equipmentPlan = { ...currentPlan };
+    delete stats.equipmentPlan.clanGoal;
+    if (String(stats.clanPartyObjective?.clanGoalKey || '') === previousGoalKey) delete stats.clanPartyObjective;
+    if (String(stats.partyRequest?.clanGoalKey || '') === previousGoalKey) delete stats.partyRequest;
+    const saved = await LifeState.upsertState({ ...current, stats }, 'clan_equipment_beneficiary_rotated');
+    return { changed: !!saved || parties.length > 0, releasedMembers };
+}
+
+async function releaseConflictingRosterParties(assignedMemberIds, goal) {
+    const roster = new Set((assignedMemberIds || []).map(number).filter(Boolean));
+    if (!roster.size) return { parties: 0, releasedMembers: 0 };
+    const goalKey = String(goal?.goalKey || '');
+    const parties = BackgroundPartyState.active().filter((party) => {
+        const memberIds = (party.memberIds || []).map(number).filter(Boolean);
+        if (!memberIds.some((id) => roster.has(id))) return false;
+        const partyGoalKey = String(party?.stats?.objective?.clanGoalKey || '');
+        return partyGoalKey !== goalKey || memberIds.some((id) => !roster.has(id));
+    });
+    let releasedMembers = 0;
+    for (const party of parties) {
+        const dissolved = await BackgroundPartyState.setStatus(party.partyId, 'dissolved');
+        if (!dissolved) continue;
+        releasedMembers += number(await LifeState.releaseDissolvedPartyMembers(
+            party.partyId,
+            'clan_equipment_party_reformed'
+        ));
+    }
+    return { parties: parties.length, releasedMembers };
 }
 
 async function handoffWarehouseMaterials(current, plan, clan, goal) {
@@ -214,12 +304,17 @@ async function handoffWarehouseMaterials(current, plan, clan, goal) {
     return { state, results };
 }
 
-async function assignPartyObjective(member, clan, goal, plan) {
+async function assignPartyObjective(member, clan, goal, plan, priority = 'preferred') {
     const id = number(member.characterId ?? member.id);
-    const objective = clanPartyObjective(plan, goal, 'preferred', clan.id);
+    const objective = clanPartyObjective(plan, goal, priority, clan.id);
     await LifeState.init();
     const current = await LifeState.findByCharacterId(id);
     if (!current) return { ok: false, code: 'member_state_missing', memberId: id };
+    const currentPartyId = current.partyId || current.party?.partyId || null;
+    if (objective && currentPartyId) {
+        const sameGoal = String(current.stats?.clanPartyObjective?.clanGoalKey || '') === String(goal?.goalKey || '');
+        return { ok: sameGoal, changed: false, memberId: id, code: sameGoal ? null : 'member_party_conflict' };
+    }
     if (!objective) {
         const old = current.stats?.clanPartyObjective;
         if (!old || number(old.clanId) !== number(clan.id)) return { ok: true, changed: false, memberId: id };
@@ -312,24 +407,36 @@ async function resolveClan(clan, previousGoal = null, options = {}) {
     const previousFulfilled = previousMember
         ? Policy.targetFulfilled(previousMember, previousGoal, GearAcquisitionPlanner.equippedSlotsFor)
         : false;
-    const selection = Policy.selectTargetMember(clan.members, plans, previousGoal, { previousFulfilled });
+    const selection = Policy.selectTargetMember(clan.members, plans, previousGoal, {
+        previousFulfilled,
+        roleFor: ClanPolicy.rosterRole
+    });
     if (!selection) {
         metrics.noDebt += 1;
         recordReason('no_equipment_debt');
         return { ok: true, skipped: true, reason: 'no_equipment_debt', plans };
     }
 
-    const goal = Policy.buildGoal(clan, selection, previousGoal, Date.now());
+    const assignedMemberIds = equipmentRoster(clan, selection.member, previousGoal);
+    const goal = Policy.buildGoal(clan, selection, previousGoal, Date.now(), {
+        assignedMemberIds,
+        roleFor: ClanPolicy.rosterRole
+    });
+    const rotation = await releasePreviousBeneficiary(clan, previousGoal, goal);
+    const partyReform = await releaseConflictingRosterParties(assignedMemberIds, goal);
     const assignment = await assignPlan(selection.member, selection.plan, clan, goal);
     if (!assignment.ok) {
         metrics.assignmentFailures += 1;
         recordReason(assignment.code);
         return { ...assignment, goal, plans, selection };
     }
+    const roster = new Set(assignedMemberIds);
     const partyAssignments = await (clan.members || [])
-        .filter((member) => member?.phase === 'cold' && !member?.partyId)
+        .filter((member) => member?.phase === 'cold')
         .reduce((chain, member) => chain.then(async (results) => {
-            const result = await assignPartyObjective(member, clan, goal, selection.plan);
+            const result = roster.has(memberId(member))
+                ? await assignPartyObjective(member, clan, goal, selection.plan, 'required')
+                : await assignPartyObjective(member, clan, goal, null);
             if (!result.ok) recordReason(result.code);
             results.push(result);
             return results;
@@ -347,6 +454,8 @@ async function resolveClan(clan, previousGoal = null, options = {}) {
         plans,
         selection,
         assignment,
+        rotation,
+        partyReform,
         partyAssignments,
         previousFulfilled,
         expectedUpdatedAt: number(latestState.updatedAt) || null
@@ -356,6 +465,7 @@ async function resolveClan(clan, previousGoal = null, options = {}) {
 const ClanEquipmentService = {
     resolveClan,
     planForMember,
+    releaseConflictingRosterParties,
     metrics() {
         return {
             resolves: metrics.resolves,

--- a/src/GameServer/Clan/ClanEquipmentService.js
+++ b/src/GameServer/Clan/ClanEquipmentService.js
@@ -85,6 +85,13 @@ function overlayWarehouseMaterials(state, plan, warehouseRows = []) {
 
 function planForMember(member, spots = [], warehouseRows = []) {
     const existing = existingPlanFor(member);
+    if (existing?.status === 'blocked') {
+        const targetId = number(existing.target?.selfId);
+        return GearAcquisitionPlanner.planFor(plannerState(member), {
+            spots,
+            ...(targetId ? { excludedTargetIds: [targetId] } : {})
+        });
+    }
     if (existing && GearAcquisitionPlanner.clanGoalPlanLocked(member, existing)) {
         if (existing.strategy !== 'craft') return existing;
         const overlay = overlayWarehouseMaterials(plannerState(member), existing, warehouseRows);

--- a/src/GameServer/Clan/ClanGoalPolicy.js
+++ b/src/GameServer/Clan/ClanGoalPolicy.js
@@ -1,6 +1,6 @@
-const ClanRules = invoke('GameServer/Clan/ClanRules');
 const ClanPolicy = invoke('GameServer/Clan/ClanSimulationPolicy');
 const Contracts = invoke('GameServer/Clan/ClanSimulationContracts');
+const Config = invoke('GameServer/Clan/ClanSimulationConfig');
 
 function number(value, fallback = 0) {
     const parsed = Number(value);
@@ -15,9 +15,15 @@ function roleRank(role) {
     return { tank: 0, healer: 1, buffer: 2, dps: 3, mage: 4, crafter: 5, spoiler: 6 }[role] ?? 9;
 }
 
-function operationMembers(members = [], limit = 5) {
-    return members
-        .filter((member) => member?.phase === 'cold' && !member?.partyId)
+function operationAvailable(member) {
+    return member?.phase === 'cold'
+        && !member?.partyId
+        && String(member?.simulationOwner || 'legacy_main') === 'legacy_main';
+}
+
+function operationMembers(members = [], limit = Config.operationMaxMembers) {
+    const ranked = members
+        .filter(operationAvailable)
         .map((member) => ({
             member,
             role: ClanPolicy.rosterRole(member),
@@ -26,15 +32,29 @@ function operationMembers(members = [], limit = 5) {
         }))
         .sort((left, right) => roleRank(left.role) - roleRank(right.role)
             || right.level - left.level
-            || left.id - right.id)
-        .slice(0, Math.max(1, Math.min(5, number(limit, 5))))
-        .map((entry) => entry.id);
+            || left.id - right.id);
+    const maxMembers = Math.max(1, Math.min(9, number(limit, Config.operationMaxMembers)));
+    const selected = [];
+    const selectedIds = new Set();
+    ['tank', 'healer', 'buffer'].forEach((role) => {
+        const entry = ranked.find((candidate) => candidate.role === role && !selectedIds.has(candidate.id));
+        if (!entry || selected.length >= maxMembers) return;
+        selected.push(entry);
+        selectedIds.add(entry.id);
+    });
+    ranked.forEach((entry) => {
+        if (selected.length >= maxMembers || selectedIds.has(entry.id)) return;
+        selected.push(entry);
+        selectedIds.add(entry.id);
+    });
+    return selected.map((entry) => entry.id);
 }
 
 function hasReadyRoles(members = []) {
-    const available = members.filter((member) => member?.phase === 'cold' && !member?.partyId);
+    const available = members.filter(operationAvailable);
     const roles = new Set(available.map((member) => ClanPolicy.rosterRole(member)));
-    return available.length >= 5 && roles.has('tank') && roles.has('healer') && roles.has('buffer');
+    return available.length >= Config.operationMinMembers
+        && roles.has('tank') && roles.has('healer') && roles.has('buffer');
 }
 
 function planReason(plan, context = {}) {
@@ -126,7 +146,7 @@ function buildGoal(clan = {}, context = {}, previousGoal = null, options = {}) {
         progress: shape.progress,
         plan,
         assignedMemberIds: shape.type === 'item' && plan.kind !== 'prepare'
-            ? operationMembers(shape.members, 5)
+            ? operationMembers(shape.members, Config.operationMaxMembers)
             : [],
         partyId: null,
         catastrophicFailures,
@@ -172,6 +192,7 @@ module.exports = {
     buildGoal,
     goalEquivalent,
     hasReadyRoles,
+    operationAvailable,
     operationMembers,
     planCandidates,
     replanGoal,

--- a/src/GameServer/Clan/ClanGoalService.js
+++ b/src/GameServer/Clan/ClanGoalService.js
@@ -6,6 +6,8 @@ const GoalPolicy = invoke('GameServer/Clan/ClanGoalPolicy');
 const ClanSimulationPolicy = invoke('GameServer/Clan/ClanSimulationPolicy');
 const MarketOpportunity = invoke('GameServer/Bot/Economy/MarketOpportunity');
 const ClanEquipmentService = invoke('GameServer/Clan/ClanEquipmentService');
+const ClanCrestService = invoke('GameServer/Clan/ClanCrestService');
+const ClanService = invoke('GameServer/Clan/ClanService');
 
 const metrics = {
     resolves: 0,
@@ -18,6 +20,7 @@ const metrics = {
     preparationCycles: 0,
     replans: 0,
     catastrophicFailures: 0,
+    levelUps: 0,
     budgetStops: 0,
     planCounts: new Map(),
     reasonCounts: new Map()
@@ -60,7 +63,7 @@ async function clanProjection(clanId = null) {
                members.classId, members.level AS memberLevel, members.clanId AS memberClanId,
                life.accountName, life.activity, life.phase, life.adena, life.currentRegion,
                life.partyId,
-               life.simulationRevision, life.inventorySummary, life.statsJson
+               life.simulationOwner, life.simulationRevision, life.inventorySummary, life.statsJson
         FROM clan_simulation_clans simulated
         JOIN clans ON clans.id = simulated.clanId
         JOIN characters members ON members.clanId = simulated.clanId
@@ -93,6 +96,7 @@ async function clanProjection(clanId = null) {
             phase: String(row.phase || ''),
             currentRegion: String(row.currentRegion || ''),
             partyId: row.partyId || null,
+            simulationOwner: String(row.simulationOwner || 'legacy_main'),
             adena: number(row.adena),
             simulationRevision: number(row.simulationRevision),
             inventory: parseJson(row.inventorySummary, {}),
@@ -252,6 +256,36 @@ async function resolveClan(clan, options = {}) {
     }
     const context = await contextFor(clan);
     const previous = clan.state?.goal || null;
+    if (number(clan.level) === 2 && number(context.progress) >= number(context.required)) {
+        const advanced = await Database.advanceAutonomousClanLevel({
+            clanId: clan.id,
+            fromLevel: 2,
+            toLevel: 3,
+            requiredAmount: 1,
+            requiredItemId: Config.bloodMarkItemId,
+            requiredItemAmount: 1
+        });
+        if (advanced.ok) {
+            metrics.levelUps += 1;
+            metrics.goalsCompleted += previous?.status === 'completed' ? 0 : 1;
+            record(metrics.reasonCounts, Contracts.REASON_CODES.CONTRIBUTION_LEVEL_UP);
+            await ClanCrestService.ensureAutonomousCrest(clan.id);
+            if (typeof ClanService.reload === 'function') await ClanService.reload();
+            return {
+                ok: true,
+                clanId: clan.id,
+                level: 3,
+                changed: true,
+                goal: null,
+                advanced,
+                context,
+                reason: advanced.code || null
+            };
+        }
+        if (advanced.code !== 'level_already_advanced') {
+            return { ok: false, clanId: clan.id, level: 2, changed: false, goal: previous, advanced, context, reason: advanced.code };
+        }
+    }
     let goal = GoalPolicy.buildGoal(clan, context, previous, {
         timestamp: Date.now(),
         failureThreshold: Config.catastrophicFailureThreshold
@@ -369,6 +403,7 @@ const ClanGoalService = {
             preparationCycles: metrics.preparationCycles,
             replans: metrics.replans,
             catastrophicFailures: metrics.catastrophicFailures,
+            levelUps: metrics.levelUps,
             budgetStops: metrics.budgetStops,
             planCounts: Object.fromEntries(metrics.planCounts.entries()),
             reasonCounts: Object.fromEntries(metrics.reasonCounts.entries()),

--- a/src/GameServer/Clan/ClanGoalService.js
+++ b/src/GameServer/Clan/ClanGoalService.js
@@ -285,6 +285,17 @@ async function resolveClan(clan, options = {}) {
         if (advanced.code !== 'level_already_advanced') {
             return { ok: false, clanId: clan.id, level: 2, changed: false, goal: previous, advanced, context, reason: advanced.code };
         }
+        return {
+            ok: true,
+            clanId: clan.id,
+            level: number(advanced.level, 3),
+            changed: false,
+            skipped: true,
+            goal: previous,
+            advanced,
+            context,
+            reason: advanced.code
+        };
     }
     let goal = GoalPolicy.buildGoal(clan, context, previous, {
         timestamp: Date.now(),

--- a/src/GameServer/Clan/ClanPartyService.js
+++ b/src/GameServer/Clan/ClanPartyService.js
@@ -3,8 +3,11 @@ const Config = invoke('GameServer/Clan/ClanSimulationConfig');
 const Contracts = invoke('GameServer/Clan/ClanSimulationContracts');
 const GoalService = invoke('GameServer/Clan/ClanGoalService');
 const GoalPolicy = invoke('GameServer/Clan/ClanGoalPolicy');
+const ClanPolicy = invoke('GameServer/Clan/ClanSimulationPolicy');
 const ClanService = invoke('GameServer/Clan/ClanService');
 const BackgroundDropResolver = invoke('GameServer/Bot/Population/BackgroundDropResolver');
+const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
+const BackgroundPartyState = invoke('GameServer/Bot/Population/BackgroundPartyState');
 const ClanCrestService = invoke('GameServer/Clan/ClanCrestService');
 
 const metrics = {
@@ -17,6 +20,8 @@ const metrics = {
     levelUps: 0,
     catastrophicFailures: 0,
     memberReservationConflicts: 0,
+    supportPartiesReclaimed: 0,
+    supportMembersReleased: 0,
     budgetStops: 0,
     reasonCounts: new Map()
 };
@@ -54,13 +59,91 @@ function operationKey(clan, goal) {
 }
 
 function operationRoster(clan, goal) {
-    const members = parseIds(goal.assignedMemberIds);
-    const selected = members.length ? members : GoalPolicy.operationMembers(clan.members, 5);
+    const assigned = parseIds(goal.assignedMemberIds);
+    const candidates = assigned.length
+        ? assigned.map((id) => memberById(clan, id)).filter(Boolean)
+        : clan.members;
+    const selected = GoalPolicy.operationMembers(candidates, Config.operationMaxMembers);
     const selectedMembers = selected.map((id) => memberById(clan, id)).filter(Boolean);
     return {
         selected,
-        ready: selected.length >= 5 && GoalPolicy.hasReadyRoles(selectedMembers)
+        ready: selected.length >= Config.operationMinMembers && GoalPolicy.hasReadyRoles(selectedMembers)
     };
+}
+
+function sameIds(left = [], right = []) {
+    return left.length === right.length && left.every((id, index) => Number(id) === Number(right[index]));
+}
+
+function protectedClanParty(party) {
+    return Number(party?.stats?.objective?.clanId || party?.stats?.acquisitionGoal?.clanGoal?.clanId || 0) > 0;
+}
+
+function requiredRoleParties(clan) {
+    const readyRoles = new Set((clan?.members || [])
+        .filter(GoalPolicy.operationAvailable)
+        .map((member) => ClanPolicy.rosterRole(member)));
+    const missingRoles = ['tank', 'healer', 'buffer'].filter((role) => !readyRoles.has(role));
+    const selectedPartyIds = [];
+    const selected = new Set();
+    missingRoles.forEach((role) => {
+        const candidate = (clan?.members || [])
+            .filter((member) => member?.phase === 'cold'
+                && String(member?.partyId || '')
+                && ClanPolicy.rosterRole(member) === role)
+            .sort((left, right) => number(right.level) - number(left.level)
+                || number(left.characterId ?? left.id) - number(right.characterId ?? right.id))
+            .find((member) => {
+                const partyId = String(member.partyId || '');
+                const party = BackgroundPartyState.find(partyId);
+                return party?.status === 'active' && !protectedClanParty(party) && !selected.has(partyId);
+            });
+        if (!candidate) return;
+        const partyId = String(candidate.partyId);
+        selected.add(partyId);
+        selectedPartyIds.push(partyId);
+    });
+    return selectedPartyIds;
+}
+
+async function reclaimRequiredRoleParties(clan) {
+    const partyIds = requiredRoleParties(clan);
+    let releasedMembers = 0;
+    const reclaimedPartyIds = [];
+    for (const partyId of partyIds) {
+        const dissolved = await BackgroundPartyState.setStatus(partyId, 'dissolved');
+        if (!dissolved) continue;
+        const released = await LifeState.releaseDissolvedPartyMembers(partyId, 'clan_operation_reclaimed');
+        releasedMembers += number(released);
+        reclaimedPartyIds.push(partyId);
+    }
+    metrics.supportPartiesReclaimed += reclaimedPartyIds.length;
+    metrics.supportMembersReleased += releasedMembers;
+    return { reclaimedPartyIds, releasedMembers };
+}
+
+async function refreshOperationRoster(clan, goal) {
+    const assigned = parseIds(goal.assignedMemberIds).sort((left, right) => left - right);
+    const clanMemberIds = new Set((clan.members || []).map((member) => number(member.characterId ?? member.id)).filter(Boolean));
+    const retained = assigned.filter((id) => clanMemberIds.has(Number(id)));
+    const available = GoalPolicy.operationMembers(clan.members, Config.operationMaxMembers);
+    const projected = [...available, ...retained.filter((id) => !available.includes(Number(id)))]
+        .slice(0, Config.operationMaxMembers)
+        .sort((left, right) => left - right);
+    if (sameIds(assigned, projected)) return { changed: false, goal };
+    const nextGoal = {
+        ...goal,
+        assignedMemberIds: projected,
+        updatedAt: Date.now()
+    };
+    const persisted = await Database.updateAutonomousClanGoal({
+        clanId: clan.id,
+        goal: nextGoal,
+        expectedUpdatedAt: number(clan.state?.updatedAt) || null,
+        eventType: 'party_roster_refreshed',
+        reasonCode: Contracts.REASON_CODES.PARTY_NOT_READY
+    });
+    return { ...persisted, changed: !!persisted.ok, goal: persisted.goal || nextGoal };
 }
 
 async function startOperation(clan, goal) {
@@ -175,26 +258,58 @@ async function resolveActiveOperation(clan, goal, operation, options = {}) {
 
 async function resolveClan(clan, options = {}) {
     if (!clan || number(clan.level) !== 2) return { ok: true, skipped: true, reason: 'level_not_farmable' };
-    const goal = clan.state?.goal;
+    let currentClan = clan;
+    let goal = clan.state?.goal;
     if (!goal || goal.type !== 'item' || goal.plan?.kind !== 'farm' || number(goal.progress) >= number(goal.required)) {
         return { ok: true, skipped: true, reason: 'farm_goal_missing' };
+    }
+
+    let reclaimed = { reclaimedPartyIds: [], releasedMembers: 0 };
+    if (!String(goal.partyId || '')) {
+        reclaimed = await reclaimRequiredRoleParties(currentClan);
+        if (reclaimed.reclaimedPartyIds.length) {
+            const projected = await GoalService.clanProjectionById(currentClan.id);
+            if (projected?.state?.goal) {
+                currentClan = projected;
+                goal = projected.state.goal;
+            }
+        }
+        const refreshed = await refreshOperationRoster(currentClan, goal);
+        if (!refreshed.ok && refreshed.code) return refreshed;
+        if (refreshed.changed) {
+            goal = refreshed.goal;
+            currentClan = {
+                ...currentClan,
+                state: {
+                    ...(currentClan.state || {}),
+                    goal,
+                    updatedAt: number(refreshed.updatedAt, number(currentClan.state?.updatedAt))
+                }
+            };
+        }
     }
 
     // Starting an operation atomically writes goal.partyId together with the
     // active operation row. If there is no party id yet and the projected
     // roster is unavailable, no active operation can require resolution. Skip
     // the database lookup and retain the durable action for a later retry.
-    if (!String(goal.partyId || '') && !operationRoster(clan, goal).ready) {
+    if (!String(goal.partyId || '') && !operationRoster(currentClan, goal).ready) {
         recordReason(Contracts.REASON_CODES.PARTY_NOT_READY);
         return { ok: false, code: Contracts.REASON_CODES.PARTY_NOT_READY, skipped: true };
     }
 
-    const active = await Database.fetchActiveAutonomousClanOperation(clan.id);
+    const active = await Database.fetchActiveAutonomousClanOperation(currentClan.id);
     if (!active) {
-        const started = await startOperation(clan, goal);
-        return { ...started, started: !!started.ok && !started.idempotent };
+        const started = await startOperation(currentClan, goal);
+        return {
+            ...started,
+            rosterRefreshed: currentClan !== clan,
+            reclaimedPartyIds: reclaimed.reclaimedPartyIds,
+            releasedMembers: reclaimed.releasedMembers,
+            started: !!started.ok && !started.idempotent
+        };
     }
-    return resolveActiveOperation(clan, goal, active, options);
+    return resolveActiveOperation(currentClan, goal, active, options);
 }
 
 const ClanPartyService = {
@@ -252,6 +367,8 @@ const ClanPartyService = {
             levelUps: metrics.levelUps,
             catastrophicFailures: metrics.catastrophicFailures,
             memberReservationConflicts: metrics.memberReservationConflicts,
+            supportPartiesReclaimed: metrics.supportPartiesReclaimed,
+            supportMembersReleased: metrics.supportMembersReleased,
             budgetStops: metrics.budgetStops,
             reasonCounts: Object.fromEntries(metrics.reasonCounts.entries())
         };

--- a/src/GameServer/Clan/ClanSimulationConfig.js
+++ b/src/GameServer/Clan/ClanSimulationConfig.js
@@ -22,6 +22,8 @@ const DEFAULTS = {
     marketDemandTimeoutMs: 300000,
     bloodMarkItemId: 1419,
     bloodMarkSourceNpcId: 12079,
+    operationMinMembers: 5,
+    operationMaxMembers: 9,
     catastrophicFailureThreshold: 5,
     resolveIntervalMs: 60000,
     resolveBatchSize: 16,
@@ -58,6 +60,8 @@ const ENV_KEYS = {
     marketDemandTimeoutMs: 'CLAN_SIMULATION_MARKET_DEMAND_TIMEOUT_MS',
     bloodMarkItemId: 'CLAN_SIMULATION_BLOOD_MARK_ITEM_ID',
     bloodMarkSourceNpcId: 'CLAN_SIMULATION_BLOOD_MARK_SOURCE_NPC_ID',
+    operationMinMembers: 'CLAN_SIMULATION_OPERATION_MIN_MEMBERS',
+    operationMaxMembers: 'CLAN_SIMULATION_OPERATION_MAX_MEMBERS',
     catastrophicFailureThreshold: 'CLAN_SIMULATION_CATASTROPHIC_FAILURE_THRESHOLD',
     resolveIntervalMs: 'CLAN_SIMULATION_RESOLVE_INTERVAL_MS',
     resolveBatchSize: 'CLAN_SIMULATION_RESOLVE_BATCH_SIZE',
@@ -119,6 +123,11 @@ config.contributionBatchSize = Math.max(1, Math.floor(config.contributionBatchSi
 config.warehouseDepositBatchSize = Math.max(1, Math.floor(config.warehouseDepositBatchSize));
 config.bloodMarkMaxPrice = Math.max(1, Math.floor(config.bloodMarkMaxPrice));
 config.marketDemandTimeoutMs = Math.max(1000, Math.floor(config.marketDemandTimeoutMs));
+config.operationMinMembers = Math.max(2, Math.min(9, Math.floor(config.operationMinMembers)));
+config.operationMaxMembers = Math.max(
+    config.operationMinMembers,
+    Math.min(9, Math.floor(config.operationMaxMembers))
+);
 config.catastrophicFailureThreshold = Math.max(1, Math.floor(config.catastrophicFailureThreshold));
 config.resolveIntervalMs = Math.max(1000, Math.floor(config.resolveIntervalMs));
 config.resolveBatchSize = Math.max(1, Math.floor(config.resolveBatchSize));

--- a/tests/test_bot_background_party_recruitment.js
+++ b/tests/test_bot_background_party_recruitment.js
@@ -7,6 +7,7 @@ const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
 const LifeEvents = invoke('GameServer/Bot/Population/BotLifeEvents');
 const PartyState = invoke('GameServer/Bot/Population/BackgroundPartyState');
 const PopulationService = invoke('GameServer/Bot/Population/PopulationService');
+const PartyRequestPlanner = invoke('GameServer/Bot/Population/PartyRequestPlanner');
 const HotActivation = invoke('GameServer/Bot/Population/HotActivation');
 const ColdSimulationOwner = invoke('GameServer/Bot/Population/ColdSimulationOwner');
 const BotManager = invoke('GameServer/Bot/BotManager');
@@ -178,6 +179,61 @@ async function run() {
     ], { prioritizePartyWait: true });
     assert.strictEqual(objectiveGroups.length, 2, 'party formation must keep different acquisition objectives separate even on one spot');
     assert.strictEqual(objectiveGroups[0].length, 2, 'compatible requesters must share an objective group');
+    const clanObjectiveGroups = PopulationService.groupPartyCandidatesByObjective([
+        { characterId: 114, level: 25, stats: { partyRequest: { status: 'open', priority: 'required', objectiveKey: 'direct_drop:cruma:701', clanGoalKey: 'clan-equipment:77:114:88:7' } } },
+        { characterId: 115, level: 25, stats: { partyRequest: { status: 'open', priority: 'required', objectiveKey: 'direct_drop:cruma:701', clanGoalKey: 'clan-equipment:78:115:88:7' } } }
+    ]);
+    assert.strictEqual(clanObjectiveGroups.length, 2,
+        'different clan equipment goals must never merge merely because they hunt the same NPC');
+    const prioritizedClanGroups = PopulationService.groupPartyCandidatesByObjective([
+        { characterId: 116, level: 25, stats: { partyRequest: { status: 'open', priority: 'required', objectiveKey: 'large-normal' } } },
+        { characterId: 117, level: 25, stats: { partyRequest: { status: 'open', priority: 'required', objectiveKey: 'large-normal' } } },
+        { characterId: 118, level: 25, stats: { clanPartyObjective: { status: 'open', priority: 'required', objectiveKey: 'clan-route', clanId: 77, clanGoalKey: 'clan-equipment:77:118:88:7', clanOperation: 'equipment' } } }
+    ], { prioritizePartyWait: true });
+    assert.strictEqual(prioritizedClanGroups[0][0].characterId, 118,
+        'clan equipment groups must be admitted before larger ordinary required queues');
+    assert.strictEqual(PopulationService.partyObjectivesShareRoute(
+        { spotId: 'cruma', npcId: 701, clanGoalKey: 'clan-equipment:77:114:88:7' },
+        { spotId: 'cruma', npcId: 701, clanGoalKey: 'clan-equipment:78:115:88:7' }
+    ), false, 'route compatibility must preserve clan ownership');
+    assert.deepStrictEqual(
+        PopulationService.partyLimitsForObjective({
+            clanId: 77,
+            clanOperation: 'equipment',
+            minPartySize: 5,
+            maxPartySize: 9,
+            levelRange: 99
+        }),
+        { minSize: 5, maxSize: 9, levelRange: 99 },
+        'a clan equipment objective may form one native nine-member party'
+    );
+    assert.strictEqual(
+        PopulationService.requiresClanEquipmentParty({
+            stats: {
+                partyRequest: {
+                    status: 'open',
+                    priority: 'required',
+                    clanId: 77,
+                    clanOperation: 'equipment'
+                }
+            }
+        }),
+        true,
+        'a required clan equipment roster must override elective persona party preferences'
+    );
+    assert.strictEqual(
+        PartyRequestPlanner.partyObjectiveForState({
+            stats: {
+                partyRequest: { status: 'open', priority: 'required', objectiveKey: 'personal-route' },
+                clanPartyObjective: {
+                    status: 'open', priority: 'required', objectiveKey: 'clan-route', clanId: 77,
+                    clanGoalKey: 'clan-equipment:77:114:88:7', clanOperation: 'equipment'
+                }
+            }
+        }).objectiveKey,
+        'clan-route',
+        'a stale personal request must not hide the durable clan party objective'
+    );
     assert.strictEqual(
         PopulationService.partyTargetNpcId({ stats: { objective: { strategy: 'craft', npcId: 701 } } }, { stats: {} }),
         701,
@@ -211,6 +267,28 @@ async function run() {
     assert.deepStrictEqual(released.map((party) => party.partyId), ['bgp_elective']);
     assert.deepStrictEqual(reclaimed, [{ partyId: 'bgp_elective', status: 'dissolved' }]);
     assert.deepStrictEqual(dissolvedReleases, [{ partyId: 'bgp_elective', reason: 'party_capacity_reclaimed' }]);
+
+    reclaimed.length = 0;
+    dissolvedReleases.length = 0;
+    const ordinaryRequiredA = { ...requiredParty, partyId: 'bgp_required_a', startedAt: 1, stats: { objective: { priority: 'required' } } };
+    const ordinaryRequiredB = { ...requiredParty, partyId: 'bgp_required_b', startedAt: 2, stats: { objective: { priority: 'required' } } };
+    PartyState.active = () => [ordinaryRequiredA, ordinaryRequiredB];
+    LifeState.partyRequirementCounts = () => Promise.resolve([
+        { partyId: 'bgp_required_a', requiredMembers: 2 },
+        { partyId: 'bgp_required_b', requiredMembers: 2 }
+    ]);
+    const clanWaiters = Array.from({ length: 5 }, (_, index) => ({
+        characterId: 40 + index,
+        stats: {
+            clanPartyObjective: {
+                status: 'open', priority: 'required', clanId: 77, clanOperation: 'equipment',
+                clanGoalKey: 'clan-equipment:77:40:88:7', objectiveKey: 'clan-route'
+            }
+        }
+    }));
+    const clanReleased = await PopulationService.reclaimBackgroundPartyCapacity(clanWaiters);
+    assert.deepStrictEqual(clanReleased.map((party) => party.partyId), ['bgp_required_a'],
+        'a saturated queue must yield one ordinary required party slot to a missing clan equipment group');
 
     const activationOrder = [];
     ColdSimulationOwner.handoffToMain = async (state) => {

--- a/tests/test_bot_gear_acquisition.js
+++ b/tests/test_bot_gear_acquisition.js
@@ -23,6 +23,38 @@ const ironSources = GearAcquisitionPlanner.sourceForItem(1869, [stoneGolemSpot])
 assert(ironSources.length > 0, 'known material drops must resolve to their real NPC source');
 assert.strictEqual(ironSources[0].spotId, stoneGolemSpot.id, 'source lookup must retain the matching farming spot');
 assert(ironSources[0].chance > 0, 'source lookup must retain an expected drop chance');
+const antharasSpot = {
+    id: 'antharas-nest',
+    avgLevel: 70,
+    npcEntries: [{ selfId: 12211, name: 'Antharas', count: 1 }]
+};
+assert.strictEqual(GearAcquisitionPlanner.isBotEligibleSourceNpcId(12211), false,
+    'legacy kind=Boss grandboss rows must never become bot equipment sources');
+assert.deepStrictEqual(GearAcquisitionPlanner.sourceForItem(91, [antharasSpot], { level: 60 }), [],
+    'grandboss-only drops must be absent from the bot source index');
+const protectedClanPlan = {
+    status: 'active',
+    grade: 'b',
+    strategy: 'direct_drop',
+    plannedForLevel: 60,
+    rateModelVersion: GearAcquisitionPlanner.RATE_MODEL_VERSION - 1,
+    target: { selfId: 91, name: 'Heavy War Axe', slot: 7 },
+    next: { npcId: 12211, spotId: antharasSpot.id, itemId: 91 },
+    clanGoal: { clanId: 1, goalKey: 'raid-source-regression' }
+};
+const protectedContext = GearAcquisitionPlanner.replanContextFor({
+    level: 60,
+    stats: { classId: 0, role: 'dps', equipmentPlan: protectedClanPlan },
+    inventory: {}
+}, protectedClanPlan, Date.now());
+assert.strictEqual(protectedContext.routeCurrent, false,
+    'persisted raid-source routes must be forced through the new source model');
+assert.strictEqual(protectedContext.invalidSource?.npcId, 12211);
+assert.strictEqual(GearAcquisitionPlanner.clanGoalPlanLocked({
+    level: 60,
+    stats: { equipmentPlan: protectedClanPlan },
+    inventory: {}
+}, protectedClanPlan), false, 'a clan goal lock must not preserve an illegal raid source');
 const handAxe = DataCache.items.find((item) => item.template?.name === 'Hand Axe');
 const boneStaff = DataCache.items.find((item) => item.template?.name === 'Bone Staff');
 const scallopJamadhr = DataCache.items.find((item) => item.template?.name === 'Scallop Jamadhr');

--- a/tests/test_bot_population_state.js
+++ b/tests/test_bot_population_state.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { DatabaseSync } = require('node:sqlite');
 
 require('../src/Global');
 
@@ -96,6 +97,49 @@ try {
         const invalidPlanMigration = statements.find((entry) => entry.sql.includes("json_remove(COALESCE(statsJson, '{}'), '$.equipmentPlan'"));
         assert(invalidPlanMigration, 'startup must discard malformed persisted equipment plans that passive bots would not otherwise replan');
         assert(invalidPlanMigration.sql.includes("'$.equipmentPlan.target.selfId'"), 'the invalid-plan migration must validate the persisted target identity');
+        assert(invalidPlanMigration.sql.includes("'$.equipmentPlan.rateModelVersion'"),
+            'startup must immediately discard routes from a superseded source model');
+        assert(invalidPlanMigration.sql.includes("activity = 'hunting'"),
+            'startup model invalidation must not reset passive market, craft, or blocked workflows');
+        assert(invalidPlanMigration.sql.includes("'$.equipmentPlan.status') = 'active'"),
+            'startup model invalidation must preserve inactive acquisition plans');
+        assert(invalidPlanMigration.sql.includes("'$.equipmentPlan.expectedKills') IS NOT NULL"),
+            'startup model invalidation must only reset combat-rate routes');
+        assert.strictEqual(invalidPlanMigration.params[1], GearPlanner.RATE_MODEL_VERSION,
+            'startup invalidation must track the current planner model instead of a stale literal');
+        const migrationProbe = new DatabaseSync(':memory:');
+        try {
+            migrationProbe.exec(`CREATE TABLE bot_life_state (
+                characterId INTEGER PRIMARY KEY,
+                activity TEXT NOT NULL,
+                statsJson TEXT NOT NULL,
+                updatedAt INTEGER NOT NULL
+            )`);
+            const insertProbe = migrationProbe.prepare(`INSERT INTO bot_life_state
+                (characterId, activity, statsJson, updatedAt) VALUES (?, ?, ?, 0)`);
+            const staleVersion = GearPlanner.RATE_MODEL_VERSION - 1;
+            const validTarget = { selfId: 100, name: 'Valid Target' };
+            [
+                [1, 'hunting', { status: 'active', strategy: 'direct_drop', expectedKills: 10, rateModelVersion: staleVersion, target: validTarget }],
+                [2, 'hunting', { status: 'blocked', strategy: 'blocked', rateModelVersion: staleVersion, target: validTarget }],
+                [3, 'shopping', { status: 'active', strategy: 'market', rateModelVersion: staleVersion, target: validTarget }],
+                [4, 'crafting', { status: 'ready_to_craft', strategy: 'craft', rateModelVersion: staleVersion, target: validTarget }],
+                [5, 'crafting', { status: 'component_ready', strategy: 'craft', rateModelVersion: staleVersion, target: validTarget }],
+                [6, 'merchant', { status: 'blocked', strategy: 'blocked', rateModelVersion: GearPlanner.RATE_MODEL_VERSION, target: { selfId: 0, name: '' } }]
+            ].forEach(([characterId, activity, equipmentPlan]) => insertProbe.run(
+                characterId,
+                activity,
+                JSON.stringify({ equipmentPlan, partyRequest: { status: 'open' }, clanPartyObjective: { clanId: 1 } })
+            ));
+            migrationProbe.prepare(invalidPlanMigration.sql).run(...invalidPlanMigration.params);
+            const retainedPlanIds = migrationProbe.prepare(`SELECT characterId FROM bot_life_state
+                WHERE json_extract(statsJson, '$.equipmentPlan.target') IS NOT NULL ORDER BY characterId`).all()
+                .map((row) => Number(row.characterId));
+            assert.deepStrictEqual(retainedPlanIds, [2, 3, 4, 5],
+                'startup model invalidation must remove only stale combat routes and malformed plans');
+        } finally {
+            migrationProbe.close();
+        }
         const fulfilledPlanMigration = statements.find((entry) => entry.sql.includes('fulfilled_equipment_plans'));
         assert(fulfilledPlanMigration, 'startup must discard equipment plans whose exact target slot is already equipped');
         assert(fulfilledPlanMigration.sql.includes('json_each'), 'fulfilled paired-slot plans must inspect their persisted equipped slots');

--- a/tests/test_bot_raid_safety.js
+++ b/tests/test_bot_raid_safety.js
@@ -98,6 +98,8 @@ assert.strictEqual(BotRaidSafety.isProtectedRaidEntity(boss), true, 'a live raid
 assert.strictEqual(BotRaidSafety.isProtectedRaidEntity(minion), true, 'a live linked raid minion must be protected');
 assert.strictEqual(BotRaidSafety.isProtectedRaidEntity({ selfId: 10002 }), true,
     'a cold raid minion template must be protected without a live boss object');
+assert.strictEqual(BotRaidSafety.isProtectedRaidEntity({ template: { kind: 'Boss' } }), true,
+    'legacy grandboss templates must be protected even without a raidBoss flag');
 assert.strictEqual(BotRaidSafety.isProtectedRaidEntity(regular), false, 'ordinary monsters must remain eligible');
 assert.strictEqual(BotHuntingTargetPolicy.isSiegeGuard(siegeGuard), true,
     'runtime castle defenders must retain their sourced siege identity');
@@ -105,6 +107,8 @@ assert.strictEqual(BotHuntingTargetPolicy.isSiegeGuard({ clan: { clanName: 'Door
     'cold castle-defender records must retain their sourced siege identity');
 assert.strictEqual(BotHuntingTargetPolicy.canHunt({ template: { name: 'Oren Royal Gatekeeper' } }), false,
     'misclassified castle teleporters must not keep castle sectors in the hunting atlas');
+assert.strictEqual(BotHuntingTargetPolicy.canHunt({ template: { kind: 'Boss', name: 'Antharas' } }), false,
+    'boss templates without a raidBoss flag must still be absent from bot hunting logic');
 assert.strictEqual(BotHuntingTargetPolicy.canHunt({ clan: { clanName: 'ant_clan' } }), true,
     'ordinary monster clans must remain eligible even when the NPC name contains Guard');
 
@@ -152,6 +156,7 @@ assert(!indexedIds.includes(boss.fetchSelfId()), 'raid bosses must not create bo
 assert(!indexedIds.includes(minion.fetchSelfId()), 'raid minions must not create bot hunting grounds');
 assert(!indexedIds.includes(siegeGuard.fetchSelfId()), 'castle guards must not create bot hunting grounds');
 
+if (BotRaidSafety.BOT_RAID_PARTICIPATION_ENABLED) {
 const tank = actor(5100, { classId: 5, hp: 500, maxHp: 1000, pDef: 500, heavyArmor: true });
 const heavyFighter = actor(5101, { classId: 1, hp: 1000, maxHp: 1000, pDef: 600, heavyArmor: true });
 const mage = actor(5102, { classId: 10, hp: 700, maxHp: 700, mp: 900, maxMp: 1000, pDef: 200 });
@@ -291,6 +296,18 @@ delete leaderSession.partyRaidEngagement;
 World.user.sessions = [leaderSession, mageSession];
 engagement = BotRaidSafety.syncPlayerPartyRaid(leaderSession, 1200);
 assert.strictEqual(engagement.openerId, mage.fetchId(), 'any remaining companion must be able to open when no tank or heavy armor exists');
+} else {
+    leader.fetchDestId = () => boss.fetchId();
+    leaderSession.partyRaidEngagement = { bossId: boss.fetchId(), phase: 'combat' };
+    assert.strictEqual(BotRaidSafety.syncPlayerPartyRaid(leaderSession), null,
+        'bot raid participation must stay disabled even when a real player selects the boss');
+    assert.strictEqual(leaderSession.partyRaidEngagement, undefined,
+        'disabled raid participation must clear stale companion engagement state');
+    assert.strictEqual(BotRaidSafety.canEngagePlayerPartyRaid(companionSession, boss, leaderSession), false,
+        'no companion may receive a raid combat exception');
+    assert.strictEqual(PartyAwareness.leaderCombatTargetId(leaderSession, { allowPlayerRaid: true }), null,
+        'raid targets must remain hidden even from the former explicit assist path');
+}
 
 const safeCompanion = actor(5003, { locX: 2500 });
 const holdingCompanion = {

--- a/tests/test_bot_spot_risk_baseline.js
+++ b/tests/test_bot_spot_risk_baseline.js
@@ -102,6 +102,16 @@ async function run() {
     assert(legacyRepeatedBackoff.stats.spotBackoffs[0].until
         >= legacyUntil + 1 + SpotRiskPolicy.BACKOFF_MS * 2,
     'returning after a legacy backoff must use the second-attempt duration');
+    const overCapTimestamp = legacyRepeatedBackoff.stats.spotBackoffs[0].until + 1;
+    const cappedBackoff = SpotRiskPolicy.withBackoff(legacyRepeatedBackoff, {
+        spotId: 'over_cap_spot',
+        reason: 'death_pressure',
+        startedAt: overCapTimestamp,
+        until: overCapTimestamp + SpotRiskPolicy.MAX_BACKOFF_MS * 2
+    }, overCapTimestamp);
+    assert.strictEqual(cappedBackoff.stats.spotBackoffs[0].until,
+        overCapTimestamp + SpotRiskPolicy.MAX_BACKOFF_MS,
+        'a persisted deadline must not extend a spot backoff beyond the maximum duration');
     console.log('Bot spot risk baseline checks passed');
 }
 

--- a/tests/test_bot_spot_risk_baseline.js
+++ b/tests/test_bot_spot_risk_baseline.js
@@ -80,6 +80,28 @@ async function run() {
     assert(repeatedBackoff.stats.spotBackoffs[0].until
         >= firstBackoff.stats.spotBackoffs[0].until + 1 + SpotRiskPolicy.BACKOFF_MS * 2,
     'a repeated death loop must stay excluded longer than the first occurrence');
+    const legacyUntil = 2000 + SpotRiskPolicy.BACKOFF_MS;
+    const legacyRepeatedBackoff = SpotRiskPolicy.withBackoff({
+        ...state,
+        stats: {
+            ...state.stats,
+            spotBackoffs: [{
+                spotId: 'legacy_spot',
+                reason: 'death_pressure',
+                startedAt: 2000,
+                until: legacyUntil
+            }]
+        }
+    }, {
+        spotId: 'legacy_spot',
+        reason: 'death_pressure',
+        startedAt: legacyUntil + 1
+    }, legacyUntil + 1);
+    assert.strictEqual(legacyRepeatedBackoff.stats.spotBackoffs[0].attempts, 2,
+        'a persisted pre-attempts backoff must count as the first failed visit');
+    assert(legacyRepeatedBackoff.stats.spotBackoffs[0].until
+        >= legacyUntil + 1 + SpotRiskPolicy.BACKOFF_MS * 2,
+    'returning after a legacy backoff must use the second-attempt duration');
     console.log('Bot spot risk baseline checks passed');
 }
 

--- a/tests/test_bot_spot_risk_baseline.js
+++ b/tests/test_bot_spot_risk_baseline.js
@@ -5,6 +5,7 @@ require('../src/Global');
 const DataCache = invoke('GameServer/DataCache');
 const Database = invoke('Database');
 const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
+const SpotRiskPolicy = invoke('GameServer/Bot/Population/SpotRiskPolicy');
 
 DataCache.init();
 
@@ -63,6 +64,22 @@ async function run() {
     assert.strictEqual(saved.stats.spotRisk.spotId, 'new_spot');
     assert.strictEqual(saved.stats.spotRisk.deathsAtEntry, 4);
     assert.strictEqual(saved.stats.spotRisk.fightsAtEntry, 20);
+    const firstBackoff = SpotRiskPolicy.withBackoff(state, {
+        spotId: 'old_spot',
+        reason: 'death_pressure',
+        startedAt: 1000,
+        until: 1000 + SpotRiskPolicy.BACKOFF_MS
+    }, 1000);
+    const repeatedBackoff = SpotRiskPolicy.withBackoff(firstBackoff, {
+        spotId: 'old_spot',
+        reason: 'death_pressure',
+        startedAt: firstBackoff.stats.spotBackoffs[0].until + 1
+    }, firstBackoff.stats.spotBackoffs[0].until + 1);
+    assert.strictEqual(repeatedBackoff.stats.spotBackoffs[0].attempts, 2,
+        'returning to the same lethal spot must escalate its persistent backoff');
+    assert(repeatedBackoff.stats.spotBackoffs[0].until
+        >= firstBackoff.stats.spotBackoffs[0].until + 1 + SpotRiskPolicy.BACKOFF_MS * 2,
+    'a repeated death loop must stay excluded longer than the first occurrence');
     console.log('Bot spot risk baseline checks passed');
 }
 

--- a/tests/test_clan_action_queue.js
+++ b/tests/test_clan_action_queue.js
@@ -308,6 +308,20 @@ async function main() {
         assert.strictEqual(ClanGoalPolicy.hasReadyRoles(readyRoster.map((member) => (
             member.classId === 21 ? { ...member, partyId: 'background-party' } : member
         ))), false, 'a background-party member must not count as an available role');
+        const expandedRoster = [4, 4, 4, 4, 15, 21, 11].map((classId, index) => ({
+            characterId: 8000 + index,
+            classId,
+            level: 60 - index,
+            phase: 'cold'
+        }));
+        const expandedIds = ClanGoalPolicy.operationMembers(expandedRoster, 9);
+        assert.strictEqual(expandedIds.length, 7, 'a clan operation may use more than five available members');
+        assert(expandedIds.includes(8005), 'role-first selection must retain the buffer behind several stronger tanks');
+        assert.strictEqual(ClanGoalPolicy.hasReadyRoles(expandedRoster), true,
+            'a larger role-balanced clan roster must be ready');
+        assert.strictEqual(ClanGoalPolicy.hasReadyRoles(expandedRoster.map((member) => (
+            member.characterId === 8005 ? { ...member, simulationOwner: 'cold_simulation_owner' } : member
+        ))), false, 'a worker-owned support must not be reserved by the main-owned clan operation');
         console.log('Clan action queue checks passed');
     } finally {
         await Database.close();

--- a/tests/test_clan_action_queue.js
+++ b/tests/test_clan_action_queue.js
@@ -316,7 +316,9 @@ async function main() {
         }));
         const expandedIds = ClanGoalPolicy.operationMembers(expandedRoster, 9);
         assert.strictEqual(expandedIds.length, 7, 'a clan operation may use more than five available members');
-        assert(expandedIds.includes(8005), 'role-first selection must retain the buffer behind several stronger tanks');
+        const cappedIds = ClanGoalPolicy.operationMembers(expandedRoster, 3).sort((a, b) => a - b);
+        assert.deepStrictEqual(cappedIds, [8000, 8004, 8005],
+            'role-first selection must retain one tank, healer, and buffer when the roster is capped');
         assert.strictEqual(ClanGoalPolicy.hasReadyRoles(expandedRoster), true,
             'a larger role-balanced clan roster must be ready');
         assert.strictEqual(ClanGoalPolicy.hasReadyRoles(expandedRoster.map((member) => (

--- a/tests/test_clan_equipment_goal.js
+++ b/tests/test_clan_equipment_goal.js
@@ -105,6 +105,9 @@ async function main() {
         assert.strictEqual(Number(firstGoal.target.memberId), 4700001);
         assert.strictEqual(firstGoal.plan.kind, 'farm');
         assert.strictEqual(firstGoal.target.itemId, 4709101);
+        assert.deepStrictEqual(firstGoal.assignedMemberIds.sort((a, b) => a - b),
+            [4700001, 4700002, 4700003, 4700004, 4700005],
+            'an L3 equipment goal must reserve one cohesive clan roster');
 
         const [targetState] = await Database.execute([
             'SELECT statsJson FROM bot_life_state WHERE characterId = ?',
@@ -119,6 +122,10 @@ async function main() {
         ]);
         const helperStats = JSON.parse(helperState.statsJson);
         assert.strictEqual(Number(helperStats.clanPartyObjective.clanId), Number(created.clanId));
+        assert.strictEqual(helperStats.clanPartyObjective.priority, 'required');
+        assert.strictEqual(helperStats.clanPartyObjective.clanOperation, 'equipment');
+        assert.strictEqual(helperStats.clanPartyObjective.maxPartySize, 5);
+        assert.strictEqual(helperStats.clanPartyObjective.minPartySize, 5);
         assert.strictEqual(
             PartyRequestPlanner.partyObjectiveForState({ stats: helperStats }).clanGoalKey,
             firstGoal.goalKey,
@@ -168,6 +175,11 @@ async function main() {
         const thirdGoal = JSON.parse(thirdRow.stateJson).goal;
         assert.strictEqual(thirdGoal.type, 'equipment');
         assert.notStrictEqual(Number(thirdGoal.target.memberId), Number(firstGoal.target.memberId));
+        const [followUp] = await Database.execute([`SELECT status, availableAt
+            FROM clan_actions WHERE clanId = ? AND actionType = 'goal_plan' AND status = 'pending'
+            ORDER BY id DESC LIMIT 1`, [created.clanId]]);
+        assert(followUp, 'an L3 equipment goal must keep a bounded periodic priority review queued');
+        assert(Number(followUp.availableAt) >= Date.now(), 'an unchanged equipment review must use the retry cadence');
 
         console.log('Clan equipment goal checks passed');
     } finally {

--- a/tests/test_clan_equipment_goal.js
+++ b/tests/test_clan_equipment_goal.js
@@ -15,6 +15,7 @@ const SpotProfiles = invoke('GameServer/Bot/Population/SpotProfiles');
 const ClanGoalService = invoke('GameServer/Clan/ClanGoalService');
 const ClanActionService = invoke('GameServer/Clan/ClanActionService');
 const PartyRequestPlanner = invoke('GameServer/Bot/Population/PartyRequestPlanner');
+const ColdSimulationCoordinator = invoke('GameServer/Bot/Population/ColdSimulationCoordinator');
 
 DataCache.init();
 
@@ -136,12 +137,27 @@ async function main() {
         });
         const targetBeforeCompletion = await LifeState.findByCharacterId(firstGoal.target.memberId);
         const targetEquipped = await LifeState.refreshInventory(targetBeforeCompletion, { equip: true });
-        await LifeState.upsertState(targetEquipped, 'test_equipment_complete');
+        const originalCachedState = LifeState.cachedState;
+        try {
+            LifeState.cachedState = (characterId) => Number(characterId) === Number(targetEquipped.characterId)
+                ? targetEquipped
+                : originalCachedState.call(LifeState, characterId);
+            await ColdSimulationCoordinator.afterCommit({
+                nextState: targetEquipped,
+                proposal: { result: { events: [], debug: {} }, enqueuedAt: Date.now() }
+            });
+        } finally {
+            LifeState.cachedState = originalCachedState;
+        }
         const [advanceAction] = await Database.execute([`SELECT actionType, payloadJson
             FROM clan_actions WHERE clanId = ? AND actionType = 'goal_plan'
             ORDER BY id DESC LIMIT 1`, [created.clanId]]);
-        assert.strictEqual(advanceAction.actionType, 'goal_plan', 'equipment completion must wake the clan goal resolver once');
+        assert.strictEqual(advanceAction.actionType, 'goal_plan', 'cold equipment completion must wake the clan goal resolver once');
         assert.strictEqual(JSON.parse(advanceAction.payloadJson).reason, 'equipment_goal_completed');
+        // The real cold-owner commit has already persisted this snapshot
+        // before afterCommit runs. Mirror that durable state here only after
+        // proving that afterCommit itself emitted the wakeup action.
+        await LifeState.upsertState(targetEquipped, 'test_cold_equipment_commit');
 
         const third = await ClanActionService.resolveBatch({ limit: 4, budgetMs: 1000 });
         assert(third.succeeded >= 1, 'the completion signal must run a goal resolver action');

--- a/tests/test_clan_equipment_plan_lock.js
+++ b/tests/test_clan_equipment_plan_lock.js
@@ -30,6 +30,9 @@ const clanPlan = {
 async function main() {
     const originalPlanFor = GearAcquisitionPlanner.planFor;
     const originalStatesForParties = LifeState.statesForParties;
+    const originalReleaseDissolvedPartyMembers = LifeState.releaseDissolvedPartyMembers;
+    const originalActiveParties = PartyState.active;
+    const originalSetPartyStatus = PartyState.setStatus;
     const originalCreateOrUpdate = PartyState.createOrUpdate;
     const originalSpotEnsure = SpotProfiles.ensure;
 
@@ -164,10 +167,90 @@ async function main() {
         assert.strictEqual(selected.member.characterId, 1002,
             'a blocked previous beneficiary must yield to another member with an actionable plan');
 
+        const currentPlan = {
+            ...clanPlan,
+            grade: 'c',
+            target: { selfId: 9301, name: 'Current Upgrade', slot: 7 },
+            clanGoal: { ...clanPlan.clanGoal, beneficiaryId: 1003, goalKey: 'clan-equipment:77:1003:9301:7' }
+        };
+        const weakHealerPlan = {
+            ...clanPlan,
+            grade: 'b',
+            target: { selfId: 9302, name: 'Healer Upgrade', slot: 10 },
+            clanGoal: undefined
+        };
+        const prioritySelection = ClanEquipmentPolicy.selectTargetMember([
+            {
+                characterId: 1003,
+                level: 45,
+                phase: 'cold',
+                stats: { role: 'dps', equipment: [{ selfId: 1, slot: 7, rank: 'd' }] },
+                inventory: {}
+            },
+            {
+                characterId: 1004,
+                level: 45,
+                phase: 'cold',
+                stats: { role: 'healer', equipment: [] },
+                inventory: {}
+            }
+        ], new Map([
+            [1003, currentPlan],
+            [1004, weakHealerPlan]
+        ]), {
+            status: 'executing',
+            target: { memberId: 1003, itemId: 9301, slot: 7 }
+        });
+        assert.strictEqual(prioritySelection.member.characterId, 1004,
+            'a materially weaker healer must take over from a lower-priority beneficiary before full dressing');
+        assert.strictEqual(prioritySelection.rotated, true);
+
+        const staleLifecycleState = {
+            characterId: 1001,
+            phase: 'cold',
+            inventory: {},
+            stats: {
+                equipmentPlan: {
+                    ...clanPlan,
+                    target: { selfId: 9202, name: 'Stale Personal Target', slot: 7 },
+                    clanGoal: undefined
+                }
+            }
+        };
+        const protectedState = LifeState.preserveClanOwnedEquipmentState(staleLifecycleState, 'market_visit_complete', {
+            ...staleLifecycleState,
+            stats: { equipmentPlan: clanPlan, clanPartyObjective: { clanGoalKey: clanPlan.clanGoal.goalKey } }
+        });
+        assert.strictEqual(protectedState.stats.equipmentPlan.target.selfId, clanPlan.target.selfId,
+            'a late lifecycle callback must not overwrite a clan-owned equipment plan');
+        assert.strictEqual(protectedState.stats.equipmentPlan.clanGoal.goalKey, clanPlan.clanGoal.goalKey);
+
+        const dissolved = [];
+        PartyState.active = () => [
+            { partyId: 'same-clean', memberIds: [1001, 1002], stats: { objective: { clanGoalKey: clanPlan.clanGoal.goalKey } } },
+            { partyId: 'same-mixed', memberIds: [1001, 9999], stats: { objective: { clanGoalKey: clanPlan.clanGoal.goalKey } } },
+            { partyId: 'wrong-goal', memberIds: [1002, 1003], stats: { objective: { clanGoalKey: 'clan-equipment:78:1002:9202:7' } } }
+        ];
+        PartyState.setStatus = async (partyId, status) => {
+            dissolved.push({ partyId, status });
+            return { partyId, status };
+        };
+        LifeState.releaseDissolvedPartyMembers = async () => 2;
+        const reformed = await ClanEquipmentService.releaseConflictingRosterParties(
+            [1001, 1002, 1003],
+            { goalKey: clanPlan.clanGoal.goalKey }
+        );
+        assert.deepStrictEqual(dissolved.map((entry) => entry.partyId), ['same-mixed', 'wrong-goal']);
+        assert.deepStrictEqual(reformed, { parties: 2, releasedMembers: 4 },
+            'a clan equipment review must dissolve mixed or foreign parties before rebuilding its roster');
+
         console.log('Clan equipment plan lock checks passed');
     } finally {
         GearAcquisitionPlanner.planFor = originalPlanFor;
         LifeState.statesForParties = originalStatesForParties;
+        LifeState.releaseDissolvedPartyMembers = originalReleaseDissolvedPartyMembers;
+        PartyState.active = originalActiveParties;
+        PartyState.setStatus = originalSetPartyStatus;
         PartyState.createOrUpdate = originalCreateOrUpdate;
         SpotProfiles.ensure = originalSpotEnsure;
     }

--- a/tests/test_clan_equipment_plan_lock.js
+++ b/tests/test_clan_equipment_plan_lock.js
@@ -3,6 +3,8 @@ const assert = require('assert');
 require('../src/Global');
 
 const GearAcquisitionPlanner = invoke('GameServer/Bot/AI/GearAcquisitionPlanner');
+const ClanEquipmentPolicy = invoke('GameServer/Clan/ClanEquipmentPolicy');
+const ClanEquipmentService = invoke('GameServer/Clan/ClanEquipmentService');
 const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
 const PartyState = invoke('GameServer/Bot/Population/BackgroundPartyState');
 const PopulationService = invoke('GameServer/Bot/Population/PopulationService');
@@ -15,7 +17,7 @@ const clanPlan = {
     partyNeedReason: 'underleveled',
     requiresParty: true,
     target: { selfId: 9101, name: 'Clan Blade', slot: 7 },
-    next: { spotId: 'clan-spot', npcId: 1234, itemId: 9101 },
+    next: { spotId: 'clan-spot', npcId: 0, itemId: 9101 },
     clanGoal: {
         clanId: 77,
         goalKey: 'clan-equipment:77:1001:9101:7',
@@ -117,6 +119,50 @@ async function main() {
             false,
             'an equipped clan target must be allowed to advance'
         );
+
+        const blockedPlan = {
+            ...clanPlan,
+            status: 'blocked',
+            strategy: 'blocked',
+            next: null
+        };
+        assert.strictEqual(
+            GearAcquisitionPlanner.clanGoalPlanLocked({ inventory: {} }, blockedPlan),
+            false,
+            'an unobtainable clan target must not remain locked forever'
+        );
+        const replannedBlocked = ClanEquipmentService.planForMember({
+            characterId: 1001,
+            name: 'ClanMember',
+            level: 35,
+            phase: 'cold',
+            inventory: {},
+            stats: { equipmentPlan: blockedPlan }
+        });
+        assert.strictEqual(plannerCalls, 1, 'a blocked clan plan must return to the acquisition planner');
+        assert.strictEqual(replannedBlocked.target.selfId, 9202,
+            'blocked-plan replanning must exclude the unobtainable target and accept a replacement');
+
+        const replacementMember = {
+            characterId: 1002,
+            name: 'ReplacementMember',
+            level: 35,
+            phase: 'cold',
+            inventory: {}
+        };
+        const selected = ClanEquipmentPolicy.selectTargetMember(
+            [{ characterId: 1001, phase: 'cold' }, replacementMember],
+            new Map([
+                [1001, blockedPlan],
+                [1002, clanPlan]
+            ]),
+            {
+                status: 'blocked',
+                target: { memberId: 1001, itemId: blockedPlan.target.selfId, slot: blockedPlan.target.slot }
+            }
+        );
+        assert.strictEqual(selected.member.characterId, 1002,
+            'a blocked previous beneficiary must yield to another member with an actionable plan');
 
         console.log('Clan equipment plan lock checks passed');
     } finally {

--- a/tests/test_clan_simulation_slice4.js
+++ b/tests/test_clan_simulation_slice4.js
@@ -99,6 +99,21 @@ async function main() {
         const events = await Database.fetchClanGoalEvents(created.clanId, 20);
         assert(events.filter((event) => event.eventType === 'goal_replanned').length >= Config.catastrophicFailureThreshold);
 
+        const timestamp = Date.now();
+        await Database.execute([`INSERT INTO clan_warehouse_items(
+            clanId, selfId, name, kind, amount, reservedAmount, createdAt, updatedAt
+        ) VALUES (?, ?, 'Blood Mark', 'quest', 1, 0, ?, ?)`, [created.clanId, Config.bloodMarkItemId, timestamp, timestamp]]);
+        const completed = await ClanGoalService.resolveBatch(4, { budgetMs: 1000 });
+        assert.strictEqual(completed.changed, 1, 'fulfilled L2 conditions must be consumed by the goal resolver');
+        const [advancedClan] = await Database.execute(['SELECT level FROM clans WHERE id = ?', [created.clanId]]);
+        assert.strictEqual(Number(advancedClan.level), 3,
+            'an already warehoused Blood Mark must advance L2 without a market or party completion callback');
+        const [remainingMark] = await Database.execute([
+            'SELECT amount FROM clan_warehouse_items WHERE clanId = ? AND selfId = ?',
+            [created.clanId, Config.bloodMarkItemId]
+        ]);
+        assert.strictEqual(Number(remainingMark?.amount || 0), 0, 'the direct level-up must consume its Blood Mark');
+
         console.log('Clan simulation Slice 4 checks passed');
     } finally {
         await Database.close();

--- a/tests/test_clan_simulation_slice5.js
+++ b/tests/test_clan_simulation_slice5.js
@@ -231,6 +231,33 @@ async function main() {
         assert.strictEqual(terminal.started, 0);
         assert.strictEqual(terminal.resolved, 0);
 
+        const timestamp = Date.now();
+        await Database.execute([`INSERT INTO clan_warehouse_items
+            (clanId, selfId, name, amount, createdAt, updatedAt)
+            VALUES (?, ?, 'Blood Mark', 1, ?, ?)`, [created.clanId, Config.bloodMarkItemId, timestamp, timestamp]]);
+        const currentProjection = await ClanGoalService.clanProjectionById(created.clanId);
+        const staleProjection = {
+            ...currentProjection,
+            level: 2,
+            state: { ...currentProjection.state, level: 2, goal: null }
+        };
+        const goalEventsBefore = await Database.fetchClanGoalEvents(created.clanId, 200);
+        const staleResolve = await ClanGoalService.resolveClan(staleProjection);
+        assert.strictEqual(staleResolve.ok, true);
+        assert.strictEqual(staleResolve.skipped, true,
+            'an already-advanced clan must skip planning from its stale level-2 projection');
+        assert.strictEqual(staleResolve.reason, 'level_already_advanced');
+        assert.strictEqual(Number(staleResolve.level), 3);
+        const [stateAfterStaleResolve] = await Database.execute([
+            'SELECT stateJson FROM clan_simulation_clans WHERE clanId = ?',
+            [created.clanId]
+        ]);
+        assert.strictEqual(JSON.parse(stateAfterStaleResolve.stateJson).goal, null,
+            'a stale level-2 projection must not persist a Blood Mark goal onto a level-3 clan');
+        const goalEventsAfter = await Database.fetchClanGoalEvents(created.clanId, 200);
+        assert.strictEqual(goalEventsAfter.length, goalEventsBefore.length,
+            'skipping an already-advanced clan must not emit a misleading goal event');
+
         console.log('Clan simulation Slice 5 checks passed');
     } finally {
         await Database.close();

--- a/tests/test_clan_simulation_slice5.js
+++ b/tests/test_clan_simulation_slice5.js
@@ -12,6 +12,8 @@ const databasePath = path.join(rootDir, 'tmp', 'test-clan-simulation-slice5.sqli
 const Database = invoke('Database');
 const ClanGoalService = invoke('GameServer/Clan/ClanGoalService');
 const ClanPartyService = invoke('GameServer/Clan/ClanPartyService');
+const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
+const BackgroundPartyState = invoke('GameServer/Bot/Population/BackgroundPartyState');
 const Config = invoke('GameServer/Clan/ClanSimulationConfig');
 
 function removeDatabaseFiles() {
@@ -48,6 +50,8 @@ async function main() {
     seedDatabase();
     options.default.Database.path = path.relative(rootDir, databasePath);
     Database.init();
+    await LifeState.init();
+    await BackgroundPartyState.init();
 
     try {
         const created = await Database.createAutonomousClan({
@@ -101,10 +105,49 @@ async function main() {
         }
         assert.strictEqual(notReady.started, 0, 'an unavailable required role must keep the clan party pending');
         assert.strictEqual(activeOperationLookups, 0, 'a not-ready roster without goal.partyId must not query for an impossible active operation');
-        await Database.execute(['UPDATE bot_life_state SET partyId = NULL WHERE characterId = ?', [4500002]]);
+        const [beforeRefreshStart] = await Database.execute([
+            'SELECT stateJson FROM clan_simulation_clans WHERE clanId = ?',
+            [created.clanId]
+        ]);
+        const staleRosterState = JSON.parse(beforeRefreshStart.stateJson);
+        const staleRosterGoal = {
+            ...staleRosterState.goal,
+            assignedMemberIds: [4500001, 4500003, 4500004, 4500005]
+        };
+        const staleRosterUpdate = await Database.updateAutonomousClanGoal({
+            clanId: created.clanId,
+            goal: staleRosterGoal,
+            expectedUpdatedAt: staleRosterState.updatedAt,
+            eventType: 'test_stale_roster_setup',
+            reasonCode: 'party_not_ready'
+        });
+        assert.strictEqual(staleRosterUpdate.ok, true);
+
+        const busyParty = await BackgroundPartyState.createOrUpdate({
+            partyId: 'busy-party',
+            leaderId: 4500001,
+            memberIds: [4500001, 4500002, 4500003, 4500004, 4500005],
+            spotId: 'test-spot',
+            startedAt: Date.now(),
+            nextResolveAt: Date.now() + 30000,
+            status: 'active',
+            stats: { objective: { clanId: null } }
+        });
+        assert(busyParty);
+        await Database.execute([
+            'UPDATE bot_life_state SET partyId = ? WHERE characterId BETWEEN ? AND ?',
+            ['busy-party', 4500001, 4500005]
+        ]);
 
         const started = await ClanPartyService.resolveBatch(4, { budgetMs: 1000, rng: () => 0 });
-        assert.strictEqual(started.started, 1, 'first party pass must persist the operation');
+        assert.strictEqual(started.started, 1,
+            'a required support must be reclaimed and a refreshed roster started in the same pass');
+        assert.strictEqual(BackgroundPartyState.find('busy-party').status, 'dissolved');
+        const lingeringBusyMembers = await Database.execute([
+            'SELECT characterId FROM bot_life_state WHERE partyId = ?',
+            ['busy-party']
+        ]);
+        assert.deepStrictEqual(lingeringBusyMembers, [], 'reclaimed party members must be durably detached');
         const [activeOperation] = await Database.execute([
             "SELECT * FROM clan_operations WHERE clanId = ? AND status = 'active'",
             [created.clanId]
@@ -115,6 +158,36 @@ async function main() {
             [activeOperation.id]
         ]);
         assert.strictEqual(activeMembers.length, 5);
+        const activeMemberIds = activeMembers.map((member) => Number(member.characterId));
+        const activeStates = await LifeState.statesByIds(activeMemberIds, { ownerId: 'legacy_main' });
+        const competingParty = BackgroundPartyState.prepareCommit({
+            partyId: 'competing-party',
+            leaderId: activeMemberIds[0],
+            memberIds: activeMemberIds,
+            spotId: 'test-spot',
+            startedAt: Date.now(),
+            nextResolveAt: Date.now() + 30000,
+            status: 'active'
+        });
+        const competingMembers = activeStates.map((member) => LifeState.preparePartyAssignment(
+            member,
+            competingParty.snapshot.partyId,
+            member.stats?.role || 'dps',
+            competingParty.snapshot.leaderId,
+            competingParty.snapshot.nextResolveAt
+        ));
+        const competingCommit = await Database.commitBackgroundPartyMembership({
+            party: competingParty.row,
+            members: competingMembers
+        });
+        assert.strictEqual(competingCommit.ok, false);
+        assert.strictEqual(competingCommit.reason, 'clan_operation_reserved',
+            'atomic ordinary-party commit must respect the clan operation reservation');
+        const reservedCandidates = await LifeState.statesByIds(
+            activeMemberIds,
+            { ownerId: 'legacy_main', unassigned: true }
+        );
+        assert.deepStrictEqual(reservedCandidates, [], 'active clan operation members must be excluded from ordinary party hydration');
 
         const resolved = await ClanPartyService.resolveBatch(4, { budgetMs: 1000, rng: () => 0 });
         assert.strictEqual(resolved.succeeded, 1, 'second pass must resolve the persistent operation');

--- a/tests/test_cold_orphan_party_reconcile.js
+++ b/tests/test_cold_orphan_party_reconcile.js
@@ -18,12 +18,17 @@ const originalPurgeHistory = BackgroundPartyState.purgeHistory;
 (async () => {
     const orphan = { partyId: 'bgp_orphan', leaderId: 9001, memberIds: [9001, 9002], status: 'active' };
     const attached = { partyId: 'bgp_attached', leaderId: 9010, memberIds: [9010, 9011], status: 'active' };
+    const detachedLeader = { partyId: 'bgp_detached_leader', leaderId: 9020, memberIds: [9020, 9021], status: 'active' };
     const statuses = [];
     const releases = [];
-    BackgroundPartyState.active = () => [orphan, attached];
-    LifeState.cachedState = (characterId) => [9010, 9011].includes(Number(characterId))
-        ? { characterId: Number(characterId) }
-        : null;
+    BackgroundPartyState.active = () => [orphan, attached, detachedLeader];
+    LifeState.cachedState = (characterId) => {
+        const id = Number(characterId);
+        if ([9010, 9011].includes(id)) return { characterId: id };
+        if (id === 9020) return { characterId: id, party: { partyId: null } };
+        if (id === 9021) return { characterId: id, party: { partyId: 'bgp_detached_leader' } };
+        return null;
+    };
     BackgroundPartyState.setStatus = async (partyId, status) => {
         statuses.push({ partyId, status });
         return { partyId, status };
@@ -34,9 +39,15 @@ const originalPurgeHistory = BackgroundPartyState.purgeHistory;
     };
 
     const orphaned = await ColdSimulationCoordinator.reconcileOrphanedBackgroundParties();
-    assert.deepStrictEqual(orphaned.map((party) => party.partyId), ['bgp_orphan']);
-    assert.deepStrictEqual(statuses, [{ partyId: 'bgp_orphan', status: 'dissolved' }]);
-    assert.deepStrictEqual(releases, [{ partyId: 'bgp_orphan', reason: 'orphaned_dissolved_party' }]);
+    assert.deepStrictEqual(orphaned.map((party) => party.partyId), ['bgp_orphan', 'bgp_detached_leader']);
+    assert.deepStrictEqual(statuses, [
+        { partyId: 'bgp_orphan', status: 'dissolved' },
+        { partyId: 'bgp_detached_leader', status: 'dissolved' }
+    ]);
+    assert.deepStrictEqual(releases, [
+        { partyId: 'bgp_orphan', reason: 'orphaned_dissolved_party' },
+        { partyId: 'bgp_detached_leader', reason: 'party_membership_mismatch' }
+    ]);
 
     let purges = 0;
     let workersStarted = 0;

--- a/tests/test_cold_orphan_party_reconcile.js
+++ b/tests/test_cold_orphan_party_reconcile.js
@@ -24,8 +24,8 @@ const originalPurgeHistory = BackgroundPartyState.purgeHistory;
     BackgroundPartyState.active = () => [orphan, attached, detachedLeader];
     LifeState.cachedState = (characterId) => {
         const id = Number(characterId);
-        if ([9010, 9011].includes(id)) return { characterId: id };
-        if (id === 9020) return { characterId: id, party: { partyId: null } };
+        if ([9010, 9011].includes(id)) return { characterId: id, party: { partyId: 'bgp_attached' } };
+        if (id === 9020) return { characterId: id };
         if (id === 9021) return { characterId: id, party: { partyId: 'bgp_detached_leader' } };
         return null;
     };

--- a/tests/test_cold_worker_party_coordinator.js
+++ b/tests/test_cold_worker_party_coordinator.js
@@ -13,6 +13,7 @@ const Owner = invoke('GameServer/Bot/Population/ColdSimulationOwner');
 const Metrics = invoke('GameServer/Bot/Population/PopulationMetrics');
 const { ColdSimulationCoordinator } = require('../src/GameServer/Bot/Population/ColdSimulationCoordinator');
 const databasePath = path.join(process.cwd(), 'tmp', 'test-cold-worker-party-coordinator.sqlite');
+const originalEnqueueEquipmentGoalAdvanceForState = LifeState.enqueueEquipmentGoalAdvanceForState;
 
 fs.rmSync(databasePath, { force: true });
 options.default.Database.path = path.relative(process.cwd(), databasePath);
@@ -77,6 +78,9 @@ let coordinator = null;
     let mainCommands = 0;
     let partyGoalReconciles = 0;
     const partyResolvesBefore = Number(Metrics.counters.partyResolves || 0);
+    LifeState.enqueueEquipmentGoalAdvanceForState = async () => {
+        throw new Error('synthetic equipment goal wakeup failure');
+    };
     await coordinator.start({
         executeWorkerLifecycleCommand() { mainCommands += 1; },
         reconcileWorkerPartyGoals(party) {
@@ -124,6 +128,7 @@ let coordinator = null;
     console.error(error);
     process.exitCode = 1;
 }).finally(async () => {
+    LifeState.enqueueEquipmentGoalAdvanceForState = originalEnqueueEquipmentGoalAdvanceForState;
     if (coordinator?.started) await coordinator.stop().catch(() => null);
     Database.close();
 });

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -298,6 +298,7 @@ try {
     assert.strictEqual(bot.moves.length, 1, 'companion should run after the leader at 1200 range');
     assert.strictEqual(bot.fetchLocX(), 1200, 'companion should not teleport at 1200 range');
 
+    if (BotRaidSafety.BOT_RAID_PARTICIPATION_ENABLED) {
     const raidBoss = {
         model: { raidBoss: true, raidAttackers: new Set() },
         destId: undefined,
@@ -477,6 +478,40 @@ try {
     raidBoss.destId = undefined;
     World.npc = { spawns: [] };
     World.fetchNpcsInRadius = () => [];
+    } else {
+        const disabledRaidBoss = {
+            model: { raidBoss: true },
+            fetchId: () => 9100001,
+            fetchSelfId: () => 25325,
+            fetchName: () => 'disabled party raid target',
+            fetchLocX: () => 400,
+            fetchLocY: () => 0,
+            fetchLocZ: () => 0,
+            fetchLevel: () => 40,
+            fetchAttackable: () => true,
+            fetchIsRaidBoss: () => true,
+            fetchDestId: () => undefined,
+            isDead: () => false,
+            state: { fetchDead: () => false }
+        };
+        leader.destId = disabledRaidBoss.fetchId();
+        World.user = { sessions: [leaderSession, botSession] };
+        World.npc = { spawns: [disabledRaidBoss] };
+        World.fetchNpcsInRadius = () => [disabledRaidBoss];
+        let raidAssists = 0;
+        FollowingState.tick(botSession, bot, {}, {
+            say() {},
+            executePvPCombat() {},
+            executeCombat() { raidAssists += 1; }
+        });
+        assert.strictEqual(raidAssists, 0,
+            'a companion must not assist a player-selected raid boss while bot raid participation is disabled');
+        assert.strictEqual(BotRaidSafety.syncPlayerPartyRaid(leaderSession), null,
+            'disabled raid participation must not create a companion raid context');
+        leader.destId = undefined;
+        World.npc = { spawns: [] };
+        World.fetchNpcsInRadius = () => [];
+    }
 
     const selectedTargetRefreshBot = fakeActor(2000042, { locX: 0, locY: 0, level: 1 });
     selectedTargetRefreshBot.activeBuffs = {};

--- a/tests/test_raid_entity_index.js
+++ b/tests/test_raid_entity_index.js
@@ -69,12 +69,24 @@ try {
     });
     for (let index = 0; index < companions.length; index++) {
         const raid = BotRaidSafety.syncPlayerPartyRaid(leaderSession, 1000 + index);
-        assert.strictEqual(raid?.bossId, boss.fetchId(), 'every companion tick must resolve the same authoritative raid');
+        if (BotRaidSafety.BOT_RAID_PARTICIPATION_ENABLED) {
+            assert.strictEqual(raid?.bossId, boss.fetchId(), 'every companion tick must resolve the same authoritative raid');
+        } else {
+            assert.strictEqual(raid, null, 'companion ticks must not create raid engagement while participation is disabled');
+        }
     }
 } finally {
     Object.entries(spawnScanMethods).forEach(([method, implementation]) => {
         World.npc.spawns[method] = implementation;
     });
+}
+if (!BotRaidSafety.BOT_RAID_PARTICIPATION_ENABLED) {
+    // The world index remains authoritative for spawning, observer telemetry,
+    // and bot avoidance even though companions cannot engage it.
+    leaderSession.partyRaidEngagement = {
+        bossId: boss.fetchId(),
+        bossTemplateId: boss.fetchSelfId()
+    };
 }
 
 let indexStats = RaidEntityIndex.stats(World);


### PR DESCRIPTION
## Summary
- harden autonomous clan and bot progression, including reliable clan-level advancement, safer spot recovery, and explicit raid-boss exclusion from autonomous bot logic
- make level 3 clans continuously select equipment beneficiaries by gear debt, with extra priority for tanks and healers and periodic rotation when the target is fulfilled or a higher-priority member appears
- coordinate clan-pure five-to-nine-member parties for farmable equipment goals while preserving clan-owned plans across cold simulation, stale writes, mixed parties, and saturated admission queues

## Player impact
After reaching level 3, autonomous clans keep strengthening their roster instead of stalling. Clan members group up to obtain an upgrade for the current beneficiary, then rebalance toward the next weak or role-critical member. Market purchases and ready-to-craft goals remain solo activities, and raid bosses remain outside autonomous bot and clan planning.

## Validation
- `npm test`
- `npm run check` (1059 JavaScript files)
- `git diff --check origin/main...HEAD`
- focused clan equipment, plan-lock, party recruitment, atomic membership, population-state, and candidate-projection tests
- live restart and telemetry verification on the main server and a simulation instance: beneficiary selection matched recomputed priorities, equipment parties stayed clan-pure at five to nine members, and a live goal advanced after its previous target item was equipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clan equipment operations support configurable rosters of up to nine members, role-based prioritization, and improved party formation.
  * Clan progression can advance from level 2 to level 3 when requirements are met.
  * Equipment goals now use prioritized targets and retry processing.
  * Bot raid participation can be disabled, preventing raid targeting and engagement.

* **Bug Fixes**
  * Reserved clan-operation members are excluded from competing parties.
  * Protected or invalid raid and equipment targets are no longer selected.
  * Stale or conflicting parties and outdated plans are cleaned up more reliably.
  * Repeated risky-location backoffs increase correctly, up to six hours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->