### PR TITLE
Improve autonomous bot combat, progression, and simulation

### DIFF
--- a/data/Items/Others/others.json
+++ b/data/Items/Others/others.json
@@ -3177,7 +3177,7 @@
 },{
     "selfId": 1666,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Wooden Arrow", "class1": 4, "class2": 5, "mass": 30, "price": 600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1667,
     "template": { "kind": "Other.Spellbook", "name": "Spellbook: Summon Shadow", "class1": 4, "class2": 5, "mass": 120, "price": 800 },
@@ -3657,175 +3657,175 @@
 },{
     "selfId": 1786,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Broad Sword", "class1": 4, "class2": 5, "mass": 30, "price": 250 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1787,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Willow Staff", "class1": 4, "class2": 5, "mass": 30, "price": 250 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1788,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Bow", "class1": 4, "class2": 5, "mass": 30, "price": 250 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1789,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Cedar Staff", "class1": 4, "class2": 5, "mass": 30, "price": 1082 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1790,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Dirk", "class1": 4, "class2": 5, "mass": 30, "price": 1082 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1791,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Brandish", "class1": 4, "class2": 5, "mass": 30, "price": 1082 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1792,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Short Spear", "class1": 4, "class2": 5, "mass": 30, "price": 2720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1793,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sword of Reflection", "class1": 4, "class2": 5, "mass": 30, "price": 2720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1794,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Forest Bow", "class1": 4, "class2": 5, "mass": 30, "price": 2720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1795,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Leather Shoes", "class1": 4, "class2": 5, "mass": 30, "price": 53 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1796,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Leather Tunic", "class1": 4, "class2": 5, "mass": 30, "price": 159 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1797,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Leather Stockings", "class1": 4, "class2": 5, "mass": 30, "price": 99 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1798,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Leather Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 204 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1799,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Leather Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 135 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1800,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Piece Bone Breastplate", "class1": 4, "class2": 5, "mass": 30, "price": 636 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1801,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Piece Bone Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 397 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1802,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Necklace of Anguish", "class1": 4, "class2": 5, "mass": 30, "price": 93 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1803,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Necklace of Wisdom", "class1": 4, "class2": 5, "mass": 30, "price": 238 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1804,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Soulshot: D-Grade", "class1": 4, "class2": 5, "mass": 30, "price": 5000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1805,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Soulshot: C-Grade", "class1": 4, "class2": 5, "mass": 30, "price": 60000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1806,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Soulshot: B-Grade", "class1": 4, "class2": 5, "mass": 30, "price": 100000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1807,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Soulshot: A-Grade", "class1": 4, "class2": 5, "mass": 30, "price": 150000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1808,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Soulshot: S Grade", "class1": 4, "class2": 5, "mass": 30, "price": 450000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1809,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Durable Stem", "class1": 4, "class2": 5, "mass": 30, "price": 100 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1810,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Wooden Frame", "class1": 4, "class2": 5, "mass": 30, "price": 100 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1811,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Bark of Treant", "class1": 4, "class2": 5, "mass": 30, "price": 100 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1812,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Coarse Bone Powder", "class1": 4, "class2": 5, "mass": 30, "price": 100 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1813,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Refined Steel", "class1": 4, "class2": 5, "mass": 30, "price": 100 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1814,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Leather", "class1": 4, "class2": 5, "mass": 30, "price": 380 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1815,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Bowstring", "class1": 4, "class2": 5, "mass": 30, "price": 100 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1816,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Steel Frame", "class1": 4, "class2": 5, "mass": 30, "price": 500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1817,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Cord", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1818,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Refined Bronze", "class1": 4, "class2": 5, "mass": 30, "price": 500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1819,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Treant Potion", "class1": 4, "class2": 5, "mass": 30, "price": 500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1820,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Spell Paper", "class1": 4, "class2": 5, "mass": 30, "price": 500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1821,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Flaming Oil", "class1": 4, "class2": 5, "mass": 30, "price": 500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1822,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Magic Powder", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1823,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Refined Mythril", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1824,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Fortified Steel", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1825,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Oriharukon", "class1": 4, "class2": 5, "mass": 30, "price": 2800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1826,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Spell Solution", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1827,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Metal Frame", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1828,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Steel of Highest Grade", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 1829,
     "template": { "kind": "Other.Scroll", "name": "Scroll of Escape: Clan Hall", "class1": 4, "class2": 5, "mass": 120, "price": 500 },
@@ -5053,935 +5053,935 @@
 },{
     "selfId": 2135,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Braided Hemp", "class1": 4, "class2": 5, "mass": 30, "price": 680 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2136,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Cokes", "class1": 4, "class2": 5, "mass": 30, "price": 680 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2137,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Steel", "class1": 4, "class2": 5, "mass": 30, "price": 680 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2138,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Coarse Bone Powder (100%)", "class1": 4, "class2": 5, "mass": 30, "price": 680 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2139,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Steel Mold", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2140,
     "template": { "kind": "Other.Recipe", "name": "Recipe: High Grade Suede", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2141,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Silver Mold", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2142,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Varnish of Purity", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2143,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Synthetic Cokes", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2144,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Compound Braid", "class1": 4, "class2": 5, "mass": 30, "price": 1000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2145,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Alloy", "class1": 4, "class2": 5, "mass": 30, "price": 2800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2146,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Artisan's frame", "class1": 4, "class2": 5, "mass": 30, "price": 2800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2147,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blacksmith's frame", "class1": 4, "class2": 5, "mass": 30, "price": 2800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2148,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Crafted Leather", "class1": 4, "class2": 5, "mass": 30, "price": 2800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2149,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Metallic Fiber", "class1": 4, "class2": 5, "mass": 30, "price": 2800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2150,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blue Diamond Necklace", "class1": 4, "class2": 5, "mass": 30, "price": 426 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2151,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Necklace of Devotion", "class1": 4, "class2": 5, "mass": 30, "price": 718 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2152,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Enchanted Necklace", "class1": 4, "class2": 5, "mass": 30, "price": 1136 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2153,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Tiger's Eye Earring", "class1": 4, "class2": 5, "mass": 30, "price": 1286 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2154,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elven Earring", "class1": 4, "class2": 5, "mass": 30, "price": 1868 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2155,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elven Ring", "class1": 4, "class2": 5, "mass": 30, "price": 1246 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2156,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elven Necklace", "class1": 4, "class2": 5, "mass": 30, "price": 2500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2157,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Omen Beast's Eye Earring", "class1": 4, "class2": 5, "mass": 30, "price": 2420 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2158,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Ring", "class1": 4, "class2": 5, "mass": 30, "price": 1616 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2159,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Necklace of Darkness", "class1": 4, "class2": 5, "mass": 30, "price": 3240 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2160,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Moonstone Earring", "class1": 4, "class2": 5, "mass": 30, "price": 3100 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2161,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Aquastone Ring", "class1": 4, "class2": 5, "mass": 30, "price": 2060 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2162,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Aquastone Necklace", "class1": 4, "class2": 5, "mass": 30, "price": 4140 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2163,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Earring of Protection", "class1": 4, "class2": 5, "mass": 30, "price": 3920 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2164,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Ring of Protection", "class1": 4, "class2": 5, "mass": 30, "price": 2600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2165,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Necklace of Protection", "class1": 4, "class2": 5, "mass": 30, "price": 5220 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2166,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Earrings of Binding (100%)", "class1": 4, "class2": 5, "mass": 30, "price": 5900 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2167,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Ring of Ages", "class1": 4, "class2": 5, "mass": 30, "price": 3920 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2168,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Necklace of Mermaid", "class1": 4, "class2": 5, "mass": 30, "price": 7860 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2169,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Necklace of Binding", "class1": 4, "class2": 5, "mass": 30, "price": 11300 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2170,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Nassen's Earring", "class1": 4, "class2": 5, "mass": 30, "price": 8480 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2171,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sage's Ring", "class1": 4, "class2": 5, "mass": 30, "price": 5640 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2172,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sage's Necklace", "class1": 4, "class2": 5, "mass": 30, "price": 11300 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2173,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Hard Leather Shirt", "class1": 4, "class2": 5, "mass": 30, "price": 738 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2174,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Hard Leather Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 460 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2175,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Boots", "class1": 4, "class2": 5, "mass": 30, "price": 246 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2176,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Leather Boots", "class1": 4, "class2": 5, "mass": 30, "price": 418 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2177,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Bone Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 626 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2178,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Dark Stockings", "class1": 4, "class2": 5, "mass": 30, "price": 1250 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2179,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Crafted Leather Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 418 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2180,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Scale Mail", "class1": 4, "class2": 5, "mass": 30, "price": 2660 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2181,
     "template": { "kind": "Other.Recipe", "name": "Recipe: White Tunic", "class1": 4, "class2": 5, "mass": 30, "price": 1998 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2182,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Scale Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 1666 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2183,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Banded Mail", "class1": 4, "class2": 5, "mass": 30, "price": 3040 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2184,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Banded Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 1904 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2185,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Iron Boots", "class1": 4, "class2": 5, "mass": 30, "price": 1016 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2186,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Brigandine Tunic", "class1": 4, "class2": 5, "mass": 30, "price": 5980 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2187,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Manticore Skin Shirt", "class1": 4, "class2": 5, "mass": 30, "price": 4480 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2188,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Manticore Skin Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 2800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2189,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Tunic", "class1": 4, "class2": 5, "mass": 30, "price": 4480 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2190,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Stockings", "class1": 4, "class2": 5, "mass": 30, "price": 2800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2191,
     "template": { "kind": "Other.Recipe", "name": "Recipe: RIP Gauntlets", "class1": 4, "class2": 5, "mass": 30, "price": 1494 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2192,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Kite Shield", "class1": 4, "class2": 5, "mass": 30, "price": 1568 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2193,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Boots of Power", "class1": 4, "class2": 5, "mass": 30, "price": 1494 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2194,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 1956 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2195,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Half Plate Armor", "class1": 4, "class2": 5, "mass": 30, "price": 7820 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2196,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Plate Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 4880 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2197,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Salamander Skin Mail", "class1": 4, "class2": 5, "mass": 30, "price": 9540 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2198,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sage's Rag", "class1": 4, "class2": 5, "mass": 30, "price": 9540 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2199,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Karmian Stockings", "class1": 4, "class2": 5, "mass": 30, "price": 4740 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2200,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Chain Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 2940 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2201,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Square Shield", "class1": 4, "class2": 5, "mass": 30, "price": 2060 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2202,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Assault Boots", "class1": 4, "class2": 5, "mass": 30, "price": 1956 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2203,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Boots", "class1": 4, "class2": 5, "mass": 30, "price": 918 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2204,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Chain Mail Shirt", "class1": 4, "class2": 5, "mass": 30, "price": 10100 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2205,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Chain Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 6320 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2206,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Shirt", "class1": 4, "class2": 5, "mass": 30, "price": 7580 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2207,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Karmian Tunic", "class1": 4, "class2": 5, "mass": 30, "price": 7580 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2208,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Ogre Power Gauntlets", "class1": 4, "class2": 5, "mass": 30, "price": 1956 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2209,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Eldarake", "class1": 4, "class2": 5, "mass": 30, "price": 2660 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2210,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Steel Plate Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 4120 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2211,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Plated Leather Armor", "class1": 4, "class2": 5, "mass": 30, "price": 8920 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2212,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Plated Leather Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 5580 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2213,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Dwarven Chain Mail Shirt", "class1": 4, "class2": 5, "mass": 30, "price": 12880 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2214,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Dwarven Chain Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 8060 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2215,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Robe of Seal", "class1": 4, "class2": 5, "mass": 30, "price": 15700 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2216,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Great Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 4840 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2217,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Knight's Shield", "class1": 4, "class2": 5, "mass": 30, "price": 3380 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2218,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Pa'agrian Hand", "class1": 4, "class2": 5, "mass": 30, "price": 3220 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2219,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Crimson Boots", "class1": 4, "class2": 5, "mass": 30, "price": 3220 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2220,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Rind Leather Armor", "class1": 4, "class2": 5, "mass": 30, "price": 9660 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2221,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Rind Leather Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 6040 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2222,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Composite Armor", "class1": 4, "class2": 5, "mass": 30, "price": 32000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2223,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Tower Shield", "class1": 4, "class2": 5, "mass": 30, "price": 5160 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2224,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Demon's Tunic", "class1": 4, "class2": 5, "mass": 30, "price": 14720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2225,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Demon's Stockings", "class1": 4, "class2": 5, "mass": 30, "price": 9200 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2226,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Gauntlets", "class1": 4, "class2": 5, "mass": 30, "price": 4900 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2227,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Forgotten Boots", "class1": 4, "class2": 5, "mass": 30, "price": 4900 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2228,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Shining Circlet", "class1": 4, "class2": 5, "mass": 30, "price": 7360 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2229,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Theca Leather Armor", "class1": 4, "class2": 5, "mass": 30, "price": 16500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2230,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Theca Leather Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 10320 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2231,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Full Plate Armor", "class1": 4, "class2": 5, "mass": 30, "price": 46400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2232,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Drake Leather Armor", "class1": 4, "class2": 5, "mass": 30, "price": 34800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2233,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Divine Tunic", "class1": 4, "class2": 5, "mass": 30, "price": 21400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2234,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Divine Stockings", "class1": 4, "class2": 5, "mass": 30, "price": 13420 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2235,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2236,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Cap of Mana", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2237,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Paradia Hood", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2238,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Hood of Solar Eclipse", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2239,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Hood of Summoning", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2240,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elemental Hood", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2241,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Hood of Grace", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2242,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Phoenix Hood", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2243,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Hood of Aid", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2244,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Flame Helm", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2245,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Tallum Helm", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2246,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Helm of Avadon", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2247,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Helmet of Pledge", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2248,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Gauntlets of Ghost", "class1": 4, "class2": 5, "mass": 30, "price": 7160 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2249,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Adamantite Boots", "class1": 4, "class2": 5, "mass": 30, "price": 7160 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2250,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Bone Arrow", "class1": 4, "class2": 5, "mass": 30, "price": 800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2251,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Steel Arrow", "class1": 4, "class2": 5, "mass": 30, "price": 1200 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2252,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Iron Hammer", "class1": 4, "class2": 5, "mass": 30, "price": 4880 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2253,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sword Breaker", "class1": 4, "class2": 5, "mass": 30, "price": 4880 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2254,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Composition Bow", "class1": 4, "class2": 5, "mass": 30, "price": 4880 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2255,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Saber", "class1": 4, "class2": 5, "mass": 30, "price": 8180 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2256,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Assassin Knife", "class1": 4, "class2": 5, "mass": 30, "price": 8180 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2257,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Trident", "class1": 4, "class2": 5, "mass": 30, "price": 8180 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2258,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Temptation of Abyss", "class1": 4, "class2": 5, "mass": 30, "price": 8180 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2259,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Spinebone Sword", "class1": 4, "class2": 5, "mass": 30, "price": 12880 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2260,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mace of Judgment", "class1": 4, "class2": 5, "mass": 30, "price": 12880 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2261,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Conjuror's Staff", "class1": 4, "class2": 5, "mass": 30, "price": 12880 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2262,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elven Bow", "class1": 4, "class2": 5, "mass": 30, "price": 12880 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2263,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Dwarven Trident", "class1": 4, "class2": 5, "mass": 30, "price": 12880 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2264,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Two-handed Sword", "class1": 4, "class2": 5, "mass": 30, "price": 19340 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2265,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Spiked Club", "class1": 4, "class2": 5, "mass": 30, "price": 19340 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2266,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Shilen Knife", "class1": 4, "class2": 5, "mass": 30, "price": 19340 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2267,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Gastraphetes", "class1": 4, "class2": 5, "mass": 30, "price": 19340 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2268,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Tome of Blood", "class1": 4, "class2": 5, "mass": 30, "price": 19340 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2269,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Morning Star", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2270,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Goat Head Staff", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2271,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Winged Spear", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2272,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sword of Revolution", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2273,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Tarbar", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2274,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Skull Breaker", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2275,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Heavy Bone Club", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2276,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Maingauche", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2277,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Bich'hwa", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2278,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Strengthened Long Bow", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2279,
     "template": { "kind": "Other.Recipe", "name": "Recipe: War Pick", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2280,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Crucifix of Blood", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2281,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Eye of Infinity", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2282,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Cursed Maingauche", "class1": 4, "class2": 5, "mass": 30, "price": 28000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2283,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blue Crystal Skull", "class1": 4, "class2": 5, "mass": 30, "price": 30400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2284,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Demon Fangs", "class1": 4, "class2": 5, "mass": 30, "price": 30400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2285,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Claymore", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2286,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Bonebreaker", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2287,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Atuba Hammer", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2288,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Ghost Staff", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2289,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Staff of Life", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2290,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Dagger", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2291,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Scallop Jamadhr", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2292,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Light Crossbow", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2293,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Glaive", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2294,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Vajra Wands", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2295,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Ancient Reagent", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2296,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Atuba Mace", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2297,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Flamberge", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2298,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Stormbringer", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2299,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Big Hammer", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2300,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Scythe", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2301,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Battle Axe", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2302,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Silver Axe", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2303,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Skull Graver", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2304,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Heavy Doom Hammer", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2305,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Crystal Staff", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2306,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Stick of Faith", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2307,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Heavy Doom Axe", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2308,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Cursed Dagger", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2309,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Wolverine Needle", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2310,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Dark Elven Dagger", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2311,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Chakram", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2312,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Crystallized Ice Bow", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2313,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Orcish Glaive", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2314,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Body Slasher", "class1": 4, "class2": 5, "mass": 30, "price": 45800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2315,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Shamshir", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2316,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Katana", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2317,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Bec de Corbin", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2318,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Spirit Sword", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2319,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Raid Sword", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2320,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Cursed Staff", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2321,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Stiletto", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2322,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Soulfire Dirk", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2323,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elemental Bow", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2324,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elven Bow of Nobility", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2325,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Tears of Fairy", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2326,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Horn of Glory", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2327,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Caliburs", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2328,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sword of Delusion", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2329,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Tsurugi", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2330,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Homunkulus's Sword", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2331,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Poleaxe", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2332,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sword of Limit", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2333,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sword of Nightmare", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2334,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sword of Whispering Death", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2335,
     "template": { "kind": "Other.Recipe", "name": "Recipe: War Axe", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2336,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Nirvana Axe", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2337,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Stick of Eternity", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2338,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Paradia Staff", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2339,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Inferno Staff", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2340,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Pa'agrian Hammer", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2341,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sage's Staff", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2342,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Club of Nature", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2343,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mace of the Underworld", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2344,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Grace Dagger", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2345,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Dark Screamer", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2346,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Fisted Blade", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2347,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Akat Long Bow", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2348,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Heathen's Book", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2349,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Hex Doll", "class1": 4, "class2": 5, "mass": 30, "price": 86000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2350,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Pa'agrian Axe", "class1": 4, "class2": 5, "mass": 30, "price": 95600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2351,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Scorpion", "class1": 4, "class2": 5, "mass": 30, "price": 95600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2352,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Widow Maker", "class1": 4, "class2": 5, "mass": 30, "price": 95600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2353,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Samurai Longsword", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2354,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Deadman's Staff", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2355,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Ghoul's Staff", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2356,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Demon's Staff", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2357,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Crystal Dagger", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2358,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Great Pata", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2359,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Eminence Bow", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2360,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Orcish Poleaxe", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2361,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Candle of Wisdom", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2362,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blessed Branch", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2363,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Phoenix Feather", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2364,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Cerberus Eye", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2365,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Scroll of Destruction", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2366,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Claws of Black Dragon", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2367,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Three Eyed Crow's Feather", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2375,
     "template": { "kind": "Other.PetCollar", "name": "Wolf Collar", "class1": 4, "class2": 5, "mass": 10, "price": 0 },
@@ -7389,227 +7389,227 @@
 },{
     "selfId": 2970,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Ring of Binding", "class1": 4, "class2": 5, "mass": 30, "price": 5640 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2971,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Mithril Scale Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 3740 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2972,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Brigandine Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 3740 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2973,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elven Mithril Tunic", "class1": 4, "class2": 5, "mass": 30, "price": 4480 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2974,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elven Mithril Stockings", "class1": 4, "class2": 5, "mass": 30, "price": 2800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2975,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Brigandine Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 2240 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2976,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Manticore Skin Boots", "class1": 4, "class2": 5, "mass": 30, "price": 1494 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2977,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Brigandine Boots", "class1": 4, "class2": 5, "mass": 30, "price": 1494 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2978,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elven Mithril Boots", "class1": 4, "class2": 5, "mass": 30, "price": 1494 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2979,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Manticore Skin Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 1494 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2980,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Brigandine Gauntlets", "class1": 4, "class2": 5, "mass": 30, "price": 1494 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2981,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elven Mithril Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 1494 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2982,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Brigandine Shield", "class1": 4, "class2": 5, "mass": 30, "price": 1568 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2983,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Plate Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 2940 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2984,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Salamander Skin Boots", "class1": 4, "class2": 5, "mass": 30, "price": 1956 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2985,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Plate Boots", "class1": 4, "class2": 5, "mass": 30, "price": 1956 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2986,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sage's Worn Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 1956 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2987,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Plate Shield", "class1": 4, "class2": 5, "mass": 30, "price": 2060 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2988,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Tempered Mithril Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 4740 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2989,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Chain Hood", "class1": 4, "class2": 5, "mass": 30, "price": 3780 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2990,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Chain Boots", "class1": 4, "class2": 5, "mass": 30, "price": 2520 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2991,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Karmian Boots", "class1": 4, "class2": 5, "mass": 30, "price": 2520 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2992,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Plated Leather Boots", "class1": 4, "class2": 5, "mass": 30, "price": 2520 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2993,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Dwarven Chain Boots", "class1": 4, "class2": 5, "mass": 30, "price": 2520 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2994,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Boots of Seal", "class1": 4, "class2": 5, "mass": 30, "price": 2520 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2995,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Reinforced Mithril Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 2520 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2996,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Chain Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 2520 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2997,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Karmian Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 2520 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2998,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Chain Shield", "class1": 4, "class2": 5, "mass": 30, "price": 2660 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 2999,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Plated Leather Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 2980 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3000,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Dwarven Chain Shield", "class1": 4, "class2": 5, "mass": 30, "price": 3120 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3001,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Rind Leather Boots", "class1": 4, "class2": 5, "mass": 30, "price": 3220 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3002,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Dwarven Chain Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 3220 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3003,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Gloves of Seal", "class1": 4, "class2": 5, "mass": 30, "price": 3220 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3004,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Rind Leather Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 3220 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3005,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Demon's Boots", "class1": 4, "class2": 5, "mass": 30, "price": 4900 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3006,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Demon's Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 4900 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3007,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Theca Leather Boots", "class1": 4, "class2": 5, "mass": 30, "price": 5500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3008,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Theca Leather Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 5500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3009,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Composite Boots", "class1": 4, "class2": 5, "mass": 30, "price": 4900 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3010,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Composite Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 7360 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3011,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Divine Boots", "class1": 4, "class2": 5, "mass": 30, "price": 7160 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3012,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Full Plate Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 10720 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3013,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Drake Leather Boots", "class1": 4, "class2": 5, "mass": 30, "price": 7160 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3014,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Full Plate Boots", "class1": 4, "class2": 5, "mass": 30, "price": 7160 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3015,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Drake Leather Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 7160 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3016,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Full Plate Gauntlets", "class1": 4, "class2": 5, "mass": 30, "price": 7160 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3017,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Divine Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 7160 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3018,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blessed Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 7160 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3019,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Full Plate Shield", "class1": 4, "class2": 5, "mass": 30, "price": 7500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3020,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elven Long Sword", "class1": 4, "class2": 5, "mass": 30, "price": 36000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3021,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Dwarven War Hammer", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3022,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Yaksa Mace", "class1": 4, "class2": 5, "mass": 30, "price": 122600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3023,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Titan Key", "class1": 4, "class2": 5, "mass": 30, "price": 0 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3024,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Journeyman Ring", "class1": 4, "class2": 5, "mass": 30, "price": 0 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3025,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Amber Bead", "class1": 4, "class2": 5, "mass": 30, "price": 0 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3030,
     "template": { "kind": "Other.None", "name": "Key of Titan", "class1": 4, "class2": 5, "mass": 10, "price": 0 },
@@ -7621,23 +7621,23 @@
 },{
     "selfId": 3032,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Spiritshot D", "class1": 4, "class2": 5, "mass": 30, "price": 5000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3033,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Spiritshot C", "class1": 4, "class2": 5, "mass": 30, "price": 60000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3034,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Spiritshot B", "class1": 4, "class2": 5, "mass": 30, "price": 100000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3035,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Spiritshot A", "class1": 4, "class2": 5, "mass": 30, "price": 150000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3036,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Spiritshot S", "class1": 4, "class2": 5, "mass": 30, "price": 450000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3037,
     "template": { "kind": "Other.Quest", "name": "Kakan's Letter", "class1": 4, "class2": 3, "mass": 0, "price": 0 },
@@ -10837,7 +10837,7 @@
 },{
     "selfId": 3838,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Titan's Powerstone", "class1": 4, "class2": 5, "mass": 30, "price": 0 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3839,
     "template": { "kind": "Other.None", "name": "Mist Drake Egg", "class1": 4, "class2": 5, "mass": 0, "price": 0 },
@@ -11145,23 +11145,23 @@
 },{
     "selfId": 3953,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blessed Spiritshot D", "class1": 4, "class2": 5, "mass": 30, "price": 5000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3954,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blessed Spiritshot C", "class1": 4, "class2": 5, "mass": 30, "price": 60000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3955,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blessed Spiritshot B", "class1": 4, "class2": 5, "mass": 30, "price": 100000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3956,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blessed Spiritshot A", "class1": 4, "class2": 5, "mass": 30, "price": 150000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3957,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blessed Spiritshot S", "class1": 4, "class2": 5, "mass": 30, "price": 450000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 3958,
     "template": { "kind": "Other.Scroll", "name": "L2Day - Blessed Escape Effect", "class1": 4, "class2": 5, "mass": 120, "price": 0 },
@@ -11813,315 +11813,315 @@
 },{
     "selfId": 4122,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Maestro Holder", "class1": 4, "class2": 5, "mass": 30, "price": 4500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4123,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Maestro Anvil Lock", "class1": 4, "class2": 5, "mass": 30, "price": 4500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4124,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Craftsman Mold", "class1": 4, "class2": 5, "mass": 30, "price": 4500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4125,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Maestro Mold", "class1": 4, "class2": 5, "mass": 30, "price": 4500 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4126,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Adamantite Earrings", "class1": 4, "class2": 5, "mass": 30, "price": 12120 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4127,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Adamantite Ring", "class1": 4, "class2": 5, "mass": 30, "price": 8080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4128,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Adamantite Necklace", "class1": 4, "class2": 5, "mass": 30, "price": 16160 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4129,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Earrings of Black Ore", "class1": 4, "class2": 5, "mass": 30, "price": 18480 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4130,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Ring of Black Ore", "class1": 4, "class2": 5, "mass": 30, "price": 12320 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4131,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Necklace of Black Ore", "class1": 4, "class2": 5, "mass": 30, "price": 24600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4132,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Composite Shield", "class1": 4, "class2": 5, "mass": 30, "price": 5160 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4133,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Zubei's Breastplate", "class1": 4, "class2": 5, "mass": 30, "price": 41600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4134,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Zubei's Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 26000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4135,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Implosion Boots", "class1": 4, "class2": 5, "mass": 30, "price": 16080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4136,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Boots of Silence", "class1": 4, "class2": 5, "mass": 30, "price": 10380 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4137,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Guardian's Boots", "class1": 4, "class2": 5, "mass": 30, "price": 10380 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4138,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Paradia Boots", "class1": 4, "class2": 5, "mass": 30, "price": 16080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4139,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elemental Boots", "class1": 4, "class2": 5, "mass": 30, "price": 16080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4140,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Boots of Grace", "class1": 4, "class2": 5, "mass": 30, "price": 16080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4141,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Avadon Breastplate", "class1": 4, "class2": 5, "mass": 30, "price": 41600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4142,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Avadon Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 26000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4143,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Zubei's Leather Shirt", "class1": 4, "class2": 5, "mass": 30, "price": 31200 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4144,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Zubei's Leather Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 19460 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4145,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Avadon Leather Armor", "class1": 4, "class2": 5, "mass": 30, "price": 45600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4146,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Tunic of Zubei", "class1": 4, "class2": 5, "mass": 30, "price": 31200 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4147,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Stockings of Zubei", "class1": 4, "class2": 5, "mass": 30, "price": 19460 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4148,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Avadon Robe", "class1": 4, "class2": 5, "mass": 30, "price": 45600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4149,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Avadon Circlet", "class1": 4, "class2": 5, "mass": 30, "price": 15560 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4150,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Avadon Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 10380 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4151,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Chain Gloves of Silence", "class1": 4, "class2": 5, "mass": 30, "price": 10380 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4152,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Guardian's Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 10380 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4153,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Gloves of Blessing", "class1": 4, "class2": 5, "mass": 30, "price": 10380 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4154,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Doom Shield", "class1": 4, "class2": 5, "mass": 30, "price": 16900 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4155,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blue Wolf Breastplate", "class1": 4, "class2": 5, "mass": 30, "price": 64400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4156,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Boots of Blessing", "class1": 4, "class2": 5, "mass": 30, "price": 10380 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4157,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blue Wolf Gaiters", "class1": 4, "class2": 5, "mass": 30, "price": 40200 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4158,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Doom Plate Armor", "class1": 4, "class2": 5, "mass": 30, "price": 94200 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4159,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blue Wolf Leather Armor", "class1": 4, "class2": 5, "mass": 30, "price": 70600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4160,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Leather Armor of Doom", "class1": 4, "class2": 5, "mass": 30, "price": 70600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4161,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blue Wolf Tunic", "class1": 4, "class2": 5, "mass": 30, "price": 48200 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4162,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Tunic of Doom", "class1": 4, "class2": 5, "mass": 30, "price": 48200 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4163,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blue Wolf Stockings", "class1": 4, "class2": 5, "mass": 30, "price": 30200 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4164,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Stockings of Doom", "class1": 4, "class2": 5, "mass": 30, "price": 30200 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4165,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blue Wolf Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 24200 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4166,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Doom Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 24200 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4167,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blue Wolf Boots", "class1": 4, "class2": 5, "mass": 30, "price": 16080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4168,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Doom Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 16080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4169,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Elemental Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 16080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4170,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Gloves of Grace", "class1": 4, "class2": 5, "mass": 30, "price": 16080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4171,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Implosion Gauntlets", "class1": 4, "class2": 5, "mass": 30, "price": 16080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4172,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Paradia Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 16080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4173,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Blue Wolf Gloves", "class1": 4, "class2": 5, "mass": 30, "price": 16080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4174,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Zubei's Boots", "class1": 4, "class2": 5, "mass": 30, "price": 10380 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4175,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Avadon Boots", "class1": 4, "class2": 5, "mass": 30, "price": 10380 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4176,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Doom Boots", "class1": 4, "class2": 5, "mass": 30, "price": 16080 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4177,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Zubei's Gauntlets", "class1": 4, "class2": 5, "mass": 30, "price": 10380 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4178,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Zubei's Shield (100%)", "class1": 4, "class2": 5, "mass": 30, "price": 10900 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4179,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Zubei's Helmet", "class1": 4, "class2": 5, "mass": 30, "price": 15560 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4180,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Silver Arrow", "class1": 4, "class2": 5, "mass": 30, "price": 1800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4181,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Pata", "class1": 4, "class2": 5, "mass": 30, "price": 156600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4182,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Great Sword", "class1": 4, "class2": 5, "mass": 30, "price": 173600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4183,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Heavy War Axe", "class1": 4, "class2": 5, "mass": 30, "price": 173600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4184,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sprite's Staff", "class1": 4, "class2": 5, "mass": 30, "price": 173600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4185,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Keshanberk", "class1": 4, "class2": 5, "mass": 30, "price": 173600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4186,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sword of Valhalla", "class1": 4, "class2": 5, "mass": 30, "price": 173600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4187,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Kris", "class1": 4, "class2": 5, "mass": 30, "price": 173600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4188,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Hell Knife", "class1": 4, "class2": 5, "mass": 30, "price": 173600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4189,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Arthro Nail", "class1": 4, "class2": 5, "mass": 30, "price": 173600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4190,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Dark Elven Long Bow", "class1": 4, "class2": 5, "mass": 30, "price": 173600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4191,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Great Axe", "class1": 4, "class2": 5, "mass": 30, "price": 173600 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4192,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Sword of Damascus", "class1": 4, "class2": 5, "mass": 30, "price": 262000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4193,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Lance", "class1": 4, "class2": 5, "mass": 30, "price": 262000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4194,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Deadman's Glory", "class1": 4, "class2": 5, "mass": 30, "price": 262000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4195,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Art of Battle Axe", "class1": 4, "class2": 5, "mass": 30, "price": 262000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4196,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Staff of Evil Spirits", "class1": 4, "class2": 5, "mass": 30, "price": 262000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4197,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Demon Dagger", "class1": 4, "class2": 5, "mass": 30, "price": 262000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4198,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Bellion Cestus", "class1": 4, "class2": 5, "mass": 30, "price": 262000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4199,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Bow of Peril", "class1": 4, "class2": 5, "mass": 30, "price": 262000 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4200,
     "template": { "kind": "Other.Spellbook", "name": "Spellbook: Restore Life", "class1": 4, "class2": 5, "mass": 120, "price": 3850 },
@@ -13005,11 +13005,11 @@
 },{
     "selfId": 4440,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Knuckle Duster", "class1": 4, "class2": 5, "mass": 30, "price": 57400 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4441,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Avadon Shield", "class1": 4, "class2": 5, "mass": 30, "price": 10900 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 4442,
     "template": { "kind": "Other.Lotto", "name": "Lottery Ticket", "class1": 4, "class2": 5, "mass": 20, "price": 0 },
@@ -14009,31 +14009,31 @@
 },{
     "selfId": 5231,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Metal Hardener (100%)", "class1": 4, "class2": 5, "mass": 30, "price": 2800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 5472,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Metallic Thread (100%)", "class1": 4, "class2": 5, "mass": 30, "price": 2800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 5473,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Durable Metal Plate (100%)", "class1": 4, "class2": 5, "mass": 30, "price": 2800 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 5474,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Leolin's Mold (100%)", "class1": 4, "class2": 5, "mass": 30, "price": 0 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 5475,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Warsmith's Mold (100%)", "class1": 4, "class2": 5, "mass": 30, "price": 0 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 5476,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Arcsmith's Anvil (100%)", "class1": 4, "class2": 5, "mass": 30, "price": 0 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 5477,
     "template": { "kind": "Other.Recipe", "name": "Recipe: Warsmith's Holder (100%)", "class1": 4, "class2": 5, "mass": 30, "price": 0 },
-    "etc": { "stackable": false, "consumable": false }
+    "etc": { "stackable": true, "consumable": false }
 },{
     "selfId": 5549,
     "template": { "kind": "Other.Material", "name": "Metallic Thread", "class1": 4, "class2": 5, "mass": 2, "price": 2000 },

--- a/data/Items/Weapons/c4_s_grade.json
+++ b/data/Items/Weapons/c4_s_grade.json
@@ -189,6 +189,33 @@
         }
     },
     {
+        "selfId": 6580,
+        "template": {
+            "name": "Tallum Blade*Dark Legion's Edge",
+            "class1": 0,
+            "class2": 0,
+            "mass": 2080,
+            "price": 48800000,
+            "kind": "Weapon.Dual"
+        },
+        "stats": {
+            "pAtk": 342,
+            "pAtkRnd": 10,
+            "mAtk": 132,
+            "atkSpd": 325,
+            "crit": 80,
+            "accur": 0
+        },
+        "etc": {
+            "slot": 14,
+            "mp": 0,
+            "soulshot": 1,
+            "spiritshot": 1,
+            "rank": "s",
+            "cristals": 2440
+        }
+    },
+    {
         "selfId": 7575,
         "template": {
             "name": "Draconic Bow",

--- a/data/Items/Weapons/c4_special_ability_weapons.json
+++ b/data/Items/Weapons/c4_special_ability_weapons.json
@@ -70,5 +70,29 @@
         "template": { "kind": "Weapon.Pole", "name": "Halberd - Wide Blow", "class1": 0, "class2": 0, "mass": 1900, "price": 18300000 },
         "stats": { "pAtk": 213, "pAtkRnd": 10, "mAtk": 107, "atkSpd": 325, "crit": 8, "accur": -3, "attackRange": 66 },
         "etc": { "slot": 14, "mp": 0, "soulshot": 1, "spiritshot": 1, "rank": "a", "cristals": 1464 }
+    },
+    {
+        "selfId": 5233,
+        "template": { "kind": "Weapon.Dual", "name": "Keshanberk*Keshanberk", "class1": 0, "class2": 0, "mass": 2080, "price": 18300000 },
+        "stats": { "pAtk": 259, "pAtkRnd": 10, "mAtk": 107, "atkSpd": 325, "crit": 80, "accur": 0 },
+        "etc": { "slot": 14, "mp": 0, "soulshot": 1, "spiritshot": 1, "rank": "a", "cristals": 1464 }
+    },
+    {
+        "selfId": 5704,
+        "template": { "kind": "Weapon.Dual", "name": "Keshanberk*Keshanberk", "class1": 0, "class2": 0, "mass": 2080, "price": 18300000 },
+        "stats": { "pAtk": 259, "pAtkRnd": 10, "mAtk": 107, "atkSpd": 325, "crit": 80, "accur": 0 },
+        "etc": { "slot": 14, "mp": 0, "soulshot": 1, "spiritshot": 1, "rank": "a", "cristals": 1464 }
+    },
+    {
+        "selfId": 5705,
+        "template": { "kind": "Weapon.Dual", "name": "Keshanberk*Damascus", "class1": 0, "class2": 0, "mass": 2080, "price": 24100000 },
+        "stats": { "pAtk": 275, "pAtkRnd": 10, "mAtk": 112, "atkSpd": 325, "crit": 80, "accur": 0 },
+        "etc": { "slot": 14, "mp": 0, "soulshot": 1, "spiritshot": 1, "rank": "a", "cristals": 1928 }
+    },
+    {
+        "selfId": 5706,
+        "template": { "kind": "Weapon.Dual", "name": "Damascus*Damascus", "class1": 0, "class2": 0, "mass": 2080, "price": 27000000 },
+        "stats": { "pAtk": 282, "pAtkRnd": 10, "mAtk": 114, "atkSpd": 325, "crit": 80, "accur": 0 },
+        "etc": { "slot": 14, "mp": 0, "soulshot": 1, "spiritshot": 1, "rank": "a", "cristals": 2160 }
     }
 ]

--- a/data/KnowledgeBase/items.json
+++ b/data/KnowledgeBase/items.json
@@ -489434,6 +489434,43 @@
     }
   },
   {
+    "grade": "a",
+    "id": 5233,
+    "kind": "Weapon.Dual",
+    "name": "Keshanberk*Keshanberk",
+    "sources": {
+      "drops": [],
+      "spoils": []
+    },
+    "template": {
+      "etc": {
+        "cristals": 1464,
+        "mp": 0,
+        "rank": "a",
+        "slot": 14,
+        "soulshot": 1,
+        "spiritshot": 1
+      },
+      "selfId": 5233,
+      "stats": {
+        "accur": 0,
+        "atkSpd": 325,
+        "crit": 80,
+        "mAtk": 107,
+        "pAtk": 259,
+        "pAtkRnd": 10
+      },
+      "template": {
+        "class1": 0,
+        "class2": 0,
+        "kind": "Weapon.Dual",
+        "mass": 2080,
+        "name": "Keshanberk*Keshanberk",
+        "price": 18300000
+      }
+    }
+  },
+  {
     "grade": "none",
     "id": 5250,
     "kind": "Other.Shot",
@@ -531802,6 +531839,117 @@
     }
   },
   {
+    "grade": "a",
+    "id": 5704,
+    "kind": "Weapon.Dual",
+    "name": "Keshanberk*Keshanberk",
+    "sources": {
+      "drops": [],
+      "spoils": []
+    },
+    "template": {
+      "etc": {
+        "cristals": 1464,
+        "mp": 0,
+        "rank": "a",
+        "slot": 14,
+        "soulshot": 1,
+        "spiritshot": 1
+      },
+      "selfId": 5704,
+      "stats": {
+        "accur": 0,
+        "atkSpd": 325,
+        "crit": 80,
+        "mAtk": 107,
+        "pAtk": 259,
+        "pAtkRnd": 10
+      },
+      "template": {
+        "class1": 0,
+        "class2": 0,
+        "kind": "Weapon.Dual",
+        "mass": 2080,
+        "name": "Keshanberk*Keshanberk",
+        "price": 18300000
+      }
+    }
+  },
+  {
+    "grade": "a",
+    "id": 5705,
+    "kind": "Weapon.Dual",
+    "name": "Keshanberk*Damascus",
+    "sources": {
+      "drops": [],
+      "spoils": []
+    },
+    "template": {
+      "etc": {
+        "cristals": 1928,
+        "mp": 0,
+        "rank": "a",
+        "slot": 14,
+        "soulshot": 1,
+        "spiritshot": 1
+      },
+      "selfId": 5705,
+      "stats": {
+        "accur": 0,
+        "atkSpd": 325,
+        "crit": 80,
+        "mAtk": 112,
+        "pAtk": 275,
+        "pAtkRnd": 10
+      },
+      "template": {
+        "class1": 0,
+        "class2": 0,
+        "kind": "Weapon.Dual",
+        "mass": 2080,
+        "name": "Keshanberk*Damascus",
+        "price": 24100000
+      }
+    }
+  },
+  {
+    "grade": "a",
+    "id": 5706,
+    "kind": "Weapon.Dual",
+    "name": "Damascus*Damascus",
+    "sources": {
+      "drops": [],
+      "spoils": []
+    },
+    "template": {
+      "etc": {
+        "cristals": 2160,
+        "mp": 0,
+        "rank": "a",
+        "slot": 14,
+        "soulshot": 1,
+        "spiritshot": 1
+      },
+      "selfId": 5706,
+      "stats": {
+        "accur": 0,
+        "atkSpd": 325,
+        "crit": 80,
+        "mAtk": 114,
+        "pAtk": 282,
+        "pAtkRnd": 10
+      },
+      "template": {
+        "class1": 0,
+        "class2": 0,
+        "kind": "Weapon.Dual",
+        "mass": 2080,
+        "name": "Damascus*Damascus",
+        "price": 27000000
+      }
+    }
+  },
+  {
     "grade": "none",
     "id": 5789,
     "kind": "Other.Shot",
@@ -547742,6 +547890,43 @@
         "kind": "Weapon.Blunt",
         "mass": 1300,
         "name": "Arcana Mace",
+        "price": 48800000
+      }
+    }
+  },
+  {
+    "grade": "s",
+    "id": 6580,
+    "kind": "Weapon.Dual",
+    "name": "Tallum Blade*Dark Legion's Edge",
+    "sources": {
+      "drops": [],
+      "spoils": []
+    },
+    "template": {
+      "etc": {
+        "cristals": 2440,
+        "mp": 0,
+        "rank": "s",
+        "slot": 14,
+        "soulshot": 1,
+        "spiritshot": 1
+      },
+      "selfId": 6580,
+      "stats": {
+        "accur": 0,
+        "atkSpd": 325,
+        "crit": 80,
+        "mAtk": 132,
+        "pAtk": 342,
+        "pAtkRnd": 10
+      },
+      "template": {
+        "class1": 0,
+        "class2": 0,
+        "kind": "Weapon.Dual",
+        "mass": 2080,
+        "name": "Tallum Blade*Dark Legion's Edge",
         "price": 48800000
       }
     }

--- a/data/KnowledgeBase/items.json
+++ b/data/KnowledgeBase/items.json
@@ -171370,7 +171370,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1666,
       "template": {
@@ -174534,7 +174534,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1786,
       "template": {
@@ -174750,7 +174750,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1787,
       "template": {
@@ -175020,7 +175020,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1788,
       "template": {
@@ -175182,7 +175182,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1789,
       "template": {
@@ -175317,7 +175317,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1790,
       "template": {
@@ -175452,7 +175452,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1791,
       "template": {
@@ -175776,7 +175776,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1792,
       "template": {
@@ -176046,7 +176046,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1793,
       "template": {
@@ -176370,7 +176370,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1794,
       "template": {
@@ -176532,7 +176532,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1795,
       "template": {
@@ -176721,7 +176721,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1796,
       "template": {
@@ -176856,7 +176856,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1797,
       "template": {
@@ -177180,7 +177180,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1798,
       "template": {
@@ -177423,7 +177423,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1799,
       "template": {
@@ -177693,7 +177693,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1800,
       "template": {
@@ -177963,7 +177963,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1801,
       "template": {
@@ -178071,7 +178071,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1802,
       "template": {
@@ -178368,7 +178368,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1803,
       "template": {
@@ -178665,7 +178665,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1804,
       "template": {
@@ -178935,7 +178935,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1805,
       "template": {
@@ -179286,7 +179286,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1806,
       "template": {
@@ -179637,7 +179637,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1807,
       "template": {
@@ -180177,7 +180177,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1808,
       "template": {
@@ -180202,7 +180202,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1809,
       "template": {
@@ -180227,7 +180227,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1810,
       "template": {
@@ -180252,7 +180252,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1811,
       "template": {
@@ -180277,7 +180277,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1812,
       "template": {
@@ -180302,7 +180302,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1813,
       "template": {
@@ -180464,7 +180464,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1814,
       "template": {
@@ -180489,7 +180489,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1815,
       "template": {
@@ -180514,7 +180514,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1816,
       "template": {
@@ -180649,7 +180649,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1817,
       "template": {
@@ -180674,7 +180674,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1818,
       "template": {
@@ -180699,7 +180699,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1819,
       "template": {
@@ -180724,7 +180724,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1820,
       "template": {
@@ -180749,7 +180749,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1821,
       "template": {
@@ -180774,7 +180774,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1822,
       "template": {
@@ -180799,7 +180799,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1823,
       "template": {
@@ -180824,7 +180824,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1824,
       "template": {
@@ -181148,7 +181148,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1825,
       "template": {
@@ -181173,7 +181173,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1826,
       "template": {
@@ -181198,7 +181198,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1827,
       "template": {
@@ -181223,7 +181223,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 1828,
       "template": {
@@ -327408,7 +327408,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2135,
       "template": {
@@ -327570,7 +327570,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2136,
       "template": {
@@ -327732,7 +327732,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2137,
       "template": {
@@ -327867,7 +327867,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2138,
       "template": {
@@ -328056,7 +328056,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2139,
       "template": {
@@ -328218,7 +328218,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2140,
       "template": {
@@ -328380,7 +328380,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2141,
       "template": {
@@ -328542,7 +328542,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2142,
       "template": {
@@ -328758,7 +328758,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2143,
       "template": {
@@ -328920,7 +328920,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2144,
       "template": {
@@ -329217,7 +329217,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2145,
       "template": {
@@ -329406,7 +329406,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2146,
       "template": {
@@ -329568,7 +329568,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2147,
       "template": {
@@ -329648,7 +329648,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2148,
       "template": {
@@ -329729,7 +329729,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2149,
       "template": {
@@ -329945,7 +329945,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2150,
       "template": {
@@ -330242,7 +330242,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2151,
       "template": {
@@ -330485,7 +330485,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2152,
       "template": {
@@ -330944,7 +330944,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2153,
       "template": {
@@ -331187,7 +331187,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2154,
       "template": {
@@ -331349,7 +331349,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2155,
       "template": {
@@ -331402,7 +331402,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2156,
       "template": {
@@ -331483,7 +331483,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2157,
       "template": {
@@ -331564,7 +331564,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2158,
       "template": {
@@ -331645,7 +331645,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2159,
       "template": {
@@ -331726,7 +331726,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2160,
       "template": {
@@ -331807,7 +331807,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2161,
       "template": {
@@ -331942,7 +331942,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2162,
       "template": {
@@ -332185,7 +332185,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2163,
       "template": {
@@ -332320,7 +332320,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2164,
       "template": {
@@ -332373,7 +332373,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2165,
       "template": {
@@ -332670,7 +332670,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2166,
       "template": {
@@ -332859,7 +332859,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2167,
       "template": {
@@ -332967,7 +332967,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2168,
       "template": {
@@ -333102,7 +333102,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2169,
       "template": {
@@ -333210,7 +333210,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2170,
       "template": {
@@ -333235,7 +333235,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2171,
       "template": {
@@ -333260,7 +333260,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2172,
       "template": {
@@ -333449,7 +333449,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2173,
       "template": {
@@ -333584,7 +333584,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2174,
       "template": {
@@ -333773,7 +333773,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2175,
       "template": {
@@ -334070,7 +334070,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2176,
       "template": {
@@ -334232,7 +334232,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2177,
       "template": {
@@ -334448,7 +334448,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2178,
       "template": {
@@ -334583,7 +334583,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2179,
       "template": {
@@ -334745,7 +334745,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2180,
       "template": {
@@ -334907,7 +334907,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2181,
       "template": {
@@ -335096,7 +335096,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2182,
       "template": {
@@ -335285,7 +335285,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2183,
       "template": {
@@ -335447,7 +335447,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2184,
       "template": {
@@ -335555,7 +335555,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2185,
       "template": {
@@ -335636,7 +335636,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2186,
       "template": {
@@ -335716,7 +335716,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2187,
       "template": {
@@ -335851,7 +335851,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2188,
       "template": {
@@ -335958,7 +335958,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2189,
       "template": {
@@ -336119,7 +336119,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2190,
       "template": {
@@ -336227,7 +336227,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2191,
       "template": {
@@ -336280,7 +336280,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2192,
       "template": {
@@ -336333,7 +336333,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2193,
       "template": {
@@ -336414,7 +336414,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2194,
       "template": {
@@ -336495,7 +336495,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2195,
       "template": {
@@ -336576,7 +336576,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2196,
       "template": {
@@ -336629,7 +336629,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2197,
       "template": {
@@ -336710,7 +336710,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2198,
       "template": {
@@ -336790,7 +336790,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2199,
       "template": {
@@ -336815,7 +336815,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2200,
       "template": {
@@ -336895,7 +336895,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2201,
       "template": {
@@ -336975,7 +336975,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2202,
       "template": {
@@ -337164,7 +337164,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2203,
       "template": {
@@ -337244,7 +337244,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2204,
       "template": {
@@ -337378,7 +337378,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2205,
       "template": {
@@ -337459,7 +337459,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2206,
       "template": {
@@ -337540,7 +337540,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2207,
       "template": {
@@ -337621,7 +337621,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2208,
       "template": {
@@ -337701,7 +337701,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2209,
       "template": {
@@ -337726,7 +337726,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2210,
       "template": {
@@ -337779,7 +337779,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2211,
       "template": {
@@ -337832,7 +337832,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2212,
       "template": {
@@ -337913,7 +337913,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2213,
       "template": {
@@ -337994,7 +337994,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2214,
       "template": {
@@ -338129,7 +338129,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2215,
       "template": {
@@ -338182,7 +338182,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2216,
       "template": {
@@ -338235,7 +338235,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2217,
       "template": {
@@ -338260,7 +338260,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2218,
       "template": {
@@ -338341,7 +338341,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2219,
       "template": {
@@ -338449,7 +338449,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2220,
       "template": {
@@ -338556,7 +338556,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2221,
       "template": {
@@ -338636,7 +338636,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2222,
       "template": {
@@ -338689,7 +338689,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2223,
       "template": {
@@ -338714,7 +338714,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2224,
       "template": {
@@ -338767,7 +338767,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2225,
       "template": {
@@ -338847,7 +338847,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2226,
       "template": {
@@ -338872,7 +338872,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2227,
       "template": {
@@ -338952,7 +338952,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2228,
       "template": {
@@ -339032,7 +339032,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2229,
       "template": {
@@ -339113,7 +339113,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2230,
       "template": {
@@ -339194,7 +339194,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2231,
       "template": {
@@ -339301,7 +339301,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2232,
       "template": {
@@ -339354,7 +339354,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2233,
       "template": {
@@ -339462,7 +339462,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2234,
       "template": {
@@ -339487,7 +339487,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2235,
       "template": {
@@ -339512,7 +339512,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2236,
       "template": {
@@ -339537,7 +339537,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2237,
       "template": {
@@ -339562,7 +339562,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2238,
       "template": {
@@ -339587,7 +339587,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2239,
       "template": {
@@ -339612,7 +339612,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2240,
       "template": {
@@ -339637,7 +339637,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2241,
       "template": {
@@ -339662,7 +339662,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2242,
       "template": {
@@ -339687,7 +339687,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2243,
       "template": {
@@ -339712,7 +339712,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2244,
       "template": {
@@ -339737,7 +339737,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2245,
       "template": {
@@ -339762,7 +339762,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2246,
       "template": {
@@ -339787,7 +339787,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2247,
       "template": {
@@ -339812,7 +339812,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2248,
       "template": {
@@ -339837,7 +339837,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2249,
       "template": {
@@ -340107,7 +340107,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2250,
       "template": {
@@ -340241,7 +340241,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2251,
       "template": {
@@ -340403,7 +340403,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2252,
       "template": {
@@ -340619,7 +340619,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2253,
       "template": {
@@ -340808,7 +340808,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2254,
       "template": {
@@ -340970,7 +340970,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2255,
       "template": {
@@ -341186,7 +341186,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2256,
       "template": {
@@ -341348,7 +341348,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2257,
       "template": {
@@ -341483,7 +341483,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2258,
       "template": {
@@ -341672,7 +341672,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2259,
       "template": {
@@ -341834,7 +341834,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2260,
       "template": {
@@ -341969,7 +341969,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2261,
       "template": {
@@ -342185,7 +342185,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2262,
       "template": {
@@ -342320,7 +342320,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2263,
       "template": {
@@ -342428,7 +342428,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2264,
       "template": {
@@ -342590,7 +342590,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2265,
       "template": {
@@ -342671,7 +342671,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2266,
       "template": {
@@ -342806,7 +342806,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2267,
       "template": {
@@ -342914,7 +342914,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2268,
       "template": {
@@ -342967,7 +342967,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2269,
       "template": {
@@ -343020,7 +343020,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2270,
       "template": {
@@ -343073,7 +343073,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2271,
       "template": {
@@ -343126,7 +343126,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2272,
       "template": {
@@ -343179,7 +343179,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2273,
       "template": {
@@ -343232,7 +343232,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2274,
       "template": {
@@ -343340,7 +343340,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2275,
       "template": {
@@ -343393,7 +343393,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2276,
       "template": {
@@ -343446,7 +343446,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2277,
       "template": {
@@ -343554,7 +343554,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2278,
       "template": {
@@ -343662,7 +343662,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2279,
       "template": {
@@ -343715,7 +343715,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2280,
       "template": {
@@ -343740,7 +343740,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2281,
       "template": {
@@ -343793,7 +343793,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2282,
       "template": {
@@ -343818,7 +343818,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2283,
       "template": {
@@ -343843,7 +343843,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2284,
       "template": {
@@ -343951,7 +343951,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2285,
       "template": {
@@ -344085,7 +344085,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2286,
       "template": {
@@ -344138,7 +344138,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2287,
       "template": {
@@ -344191,7 +344191,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2288,
       "template": {
@@ -344271,7 +344271,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2289,
       "template": {
@@ -344324,7 +344324,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2290,
       "template": {
@@ -344405,7 +344405,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2291,
       "template": {
@@ -344458,7 +344458,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2292,
       "template": {
@@ -344538,7 +344538,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2293,
       "template": {
@@ -344563,7 +344563,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2294,
       "template": {
@@ -344588,7 +344588,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2295,
       "template": {
@@ -344669,7 +344669,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2296,
       "template": {
@@ -344722,7 +344722,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2297,
       "template": {
@@ -344802,7 +344802,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2298,
       "template": {
@@ -344882,7 +344882,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2299,
       "template": {
@@ -344963,7 +344963,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2300,
       "template": {
@@ -345043,7 +345043,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2301,
       "template": {
@@ -345151,7 +345151,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2302,
       "template": {
@@ -345231,7 +345231,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2303,
       "template": {
@@ -345284,7 +345284,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2304,
       "template": {
@@ -345365,7 +345365,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2305,
       "template": {
@@ -345446,7 +345446,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2306,
       "template": {
@@ -345499,7 +345499,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2307,
       "template": {
@@ -345552,7 +345552,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2308,
       "template": {
@@ -345577,7 +345577,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2309,
       "template": {
@@ -345630,7 +345630,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2310,
       "template": {
@@ -345683,7 +345683,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2311,
       "template": {
@@ -345763,7 +345763,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2312,
       "template": {
@@ -345816,7 +345816,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2313,
       "template": {
@@ -345869,7 +345869,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2314,
       "template": {
@@ -345949,7 +345949,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2315,
       "template": {
@@ -346056,7 +346056,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2316,
       "template": {
@@ -346109,7 +346109,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2317,
       "template": {
@@ -346189,7 +346189,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2318,
       "template": {
@@ -346296,7 +346296,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2319,
       "template": {
@@ -346376,7 +346376,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2320,
       "template": {
@@ -346483,7 +346483,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2321,
       "template": {
@@ -346536,7 +346536,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2322,
       "template": {
@@ -346589,7 +346589,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2323,
       "template": {
@@ -346670,7 +346670,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2324,
       "template": {
@@ -346695,7 +346695,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2325,
       "template": {
@@ -346775,7 +346775,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2326,
       "template": {
@@ -346855,7 +346855,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2327,
       "template": {
@@ -346935,7 +346935,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2328,
       "template": {
@@ -346988,7 +346988,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2329,
       "template": {
@@ -347041,7 +347041,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2330,
       "template": {
@@ -347066,7 +347066,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2331,
       "template": {
@@ -347091,7 +347091,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2332,
       "template": {
@@ -347144,7 +347144,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2333,
       "template": {
@@ -347225,7 +347225,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2334,
       "template": {
@@ -347305,7 +347305,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2335,
       "template": {
@@ -347358,7 +347358,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2336,
       "template": {
@@ -347411,7 +347411,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2337,
       "template": {
@@ -347464,7 +347464,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2338,
       "template": {
@@ -347489,7 +347489,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2339,
       "template": {
@@ -347542,7 +347542,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2340,
       "template": {
@@ -347623,7 +347623,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2341,
       "template": {
@@ -347676,7 +347676,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2342,
       "template": {
@@ -347729,7 +347729,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2343,
       "template": {
@@ -347809,7 +347809,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2344,
       "template": {
@@ -347862,7 +347862,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2345,
       "template": {
@@ -347943,7 +347943,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2346,
       "template": {
@@ -348024,7 +348024,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2347,
       "template": {
@@ -348104,7 +348104,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2348,
       "template": {
@@ -348129,7 +348129,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2349,
       "template": {
@@ -348182,7 +348182,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2350,
       "template": {
@@ -348262,7 +348262,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2351,
       "template": {
@@ -348315,7 +348315,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2352,
       "template": {
@@ -348423,7 +348423,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2353,
       "template": {
@@ -348503,7 +348503,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2354,
       "template": {
@@ -348584,7 +348584,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2355,
       "template": {
@@ -348637,7 +348637,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2356,
       "template": {
@@ -348718,7 +348718,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2357,
       "template": {
@@ -348799,7 +348799,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2358,
       "template": {
@@ -348880,7 +348880,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2359,
       "template": {
@@ -348961,7 +348961,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2360,
       "template": {
@@ -348986,7 +348986,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2361,
       "template": {
@@ -349011,7 +349011,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2362,
       "template": {
@@ -349036,7 +349036,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2363,
       "template": {
@@ -349061,7 +349061,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2364,
       "template": {
@@ -349086,7 +349086,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2365,
       "template": {
@@ -349111,7 +349111,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2366,
       "template": {
@@ -349136,7 +349136,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2367,
       "template": {
@@ -389038,7 +389038,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2970,
       "template": {
@@ -389091,7 +389091,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2971,
       "template": {
@@ -389144,7 +389144,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2972,
       "template": {
@@ -389169,7 +389169,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2973,
       "template": {
@@ -389194,7 +389194,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2974,
       "template": {
@@ -389247,7 +389247,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2975,
       "template": {
@@ -389300,7 +389300,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2976,
       "template": {
@@ -389434,7 +389434,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2977,
       "template": {
@@ -389487,7 +389487,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2978,
       "template": {
@@ -389540,7 +389540,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2979,
       "template": {
@@ -389593,7 +389593,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2980,
       "template": {
@@ -389646,7 +389646,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2981,
       "template": {
@@ -389726,7 +389726,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2982,
       "template": {
@@ -389779,7 +389779,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2983,
       "template": {
@@ -389859,7 +389859,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2984,
       "template": {
@@ -389939,7 +389939,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2985,
       "template": {
@@ -389992,7 +389992,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2986,
       "template": {
@@ -390045,7 +390045,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2987,
       "template": {
@@ -390098,7 +390098,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2988,
       "template": {
@@ -390151,7 +390151,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2989,
       "template": {
@@ -390286,7 +390286,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2990,
       "template": {
@@ -390311,7 +390311,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2991,
       "template": {
@@ -390364,7 +390364,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2992,
       "template": {
@@ -390444,7 +390444,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2993,
       "template": {
@@ -390497,7 +390497,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2994,
       "template": {
@@ -390550,7 +390550,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2995,
       "template": {
@@ -390631,7 +390631,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2996,
       "template": {
@@ -390684,7 +390684,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2997,
       "template": {
@@ -390737,7 +390737,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2998,
       "template": {
@@ -390818,7 +390818,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 2999,
       "template": {
@@ -390899,7 +390899,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3000,
       "template": {
@@ -390952,7 +390952,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3001,
       "template": {
@@ -391005,7 +391005,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3002,
       "template": {
@@ -391058,7 +391058,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3003,
       "template": {
@@ -391139,7 +391139,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3004,
       "template": {
@@ -391164,7 +391164,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3005,
       "template": {
@@ -391189,7 +391189,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3006,
       "template": {
@@ -391242,7 +391242,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3007,
       "template": {
@@ -391295,7 +391295,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3008,
       "template": {
@@ -391348,7 +391348,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3009,
       "template": {
@@ -391401,7 +391401,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3010,
       "template": {
@@ -391454,7 +391454,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3011,
       "template": {
@@ -391534,7 +391534,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3012,
       "template": {
@@ -391587,7 +391587,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3013,
       "template": {
@@ -391694,7 +391694,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3014,
       "template": {
@@ -391747,7 +391747,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3015,
       "template": {
@@ -391800,7 +391800,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3016,
       "template": {
@@ -391880,7 +391880,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3017,
       "template": {
@@ -391933,7 +391933,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3018,
       "template": {
@@ -391986,7 +391986,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3019,
       "template": {
@@ -392066,7 +392066,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3020,
       "template": {
@@ -392174,7 +392174,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3021,
       "template": {
@@ -392227,7 +392227,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3022,
       "template": {
@@ -392252,7 +392252,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3023,
       "template": {
@@ -392277,7 +392277,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3024,
       "template": {
@@ -392302,7 +392302,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3025,
       "template": {
@@ -392716,7 +392716,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3032,
       "template": {
@@ -392823,7 +392823,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3033,
       "template": {
@@ -392958,7 +392958,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3034,
       "template": {
@@ -393255,7 +393255,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3035,
       "template": {
@@ -393741,7 +393741,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3036,
       "template": {
@@ -416167,7 +416167,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3838,
       "template": {
@@ -419900,7 +419900,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3953,
       "template": {
@@ -420062,7 +420062,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3954,
       "template": {
@@ -420197,7 +420197,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3955,
       "template": {
@@ -420386,7 +420386,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3956,
       "template": {
@@ -420656,7 +420656,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 3957,
       "template": {
@@ -458550,7 +458550,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4122,
       "template": {
@@ -458603,7 +458603,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4123,
       "template": {
@@ -458684,7 +458684,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4124,
       "template": {
@@ -458737,7 +458737,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4125,
       "template": {
@@ -458845,7 +458845,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4126,
       "template": {
@@ -458925,7 +458925,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4127,
       "template": {
@@ -458978,7 +458978,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4128,
       "template": {
@@ -459302,7 +459302,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4129,
       "template": {
@@ -459518,7 +459518,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4130,
       "template": {
@@ -459626,7 +459626,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4131,
       "template": {
@@ -459679,7 +459679,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4132,
       "template": {
@@ -459760,7 +459760,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4133,
       "template": {
@@ -459813,7 +459813,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4134,
       "template": {
@@ -459894,7 +459894,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4135,
       "template": {
@@ -459947,7 +459947,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4136,
       "template": {
@@ -460000,7 +460000,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4137,
       "template": {
@@ -460053,7 +460053,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4138,
       "template": {
@@ -460106,7 +460106,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4139,
       "template": {
@@ -460159,7 +460159,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4140,
       "template": {
@@ -460212,7 +460212,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4141,
       "template": {
@@ -460293,7 +460293,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4142,
       "template": {
@@ -460346,7 +460346,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4143,
       "template": {
@@ -460427,7 +460427,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4144,
       "template": {
@@ -460480,7 +460480,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4145,
       "template": {
@@ -460561,7 +460561,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4146,
       "template": {
@@ -460642,7 +460642,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4147,
       "template": {
@@ -460695,7 +460695,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4148,
       "template": {
@@ -460748,7 +460748,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4149,
       "template": {
@@ -460829,7 +460829,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4150,
       "template": {
@@ -460882,7 +460882,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4151,
       "template": {
@@ -460935,7 +460935,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4152,
       "template": {
@@ -460988,7 +460988,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4153,
       "template": {
@@ -461096,7 +461096,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4154,
       "template": {
@@ -461203,7 +461203,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4155,
       "template": {
@@ -461256,7 +461256,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4156,
       "template": {
@@ -461309,7 +461309,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4157,
       "template": {
@@ -461389,7 +461389,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4158,
       "template": {
@@ -461551,7 +461551,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4159,
       "template": {
@@ -461686,7 +461686,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4160,
       "template": {
@@ -461766,7 +461766,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4161,
       "template": {
@@ -461846,7 +461846,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4162,
       "template": {
@@ -461926,7 +461926,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4163,
       "template": {
@@ -462033,7 +462033,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4164,
       "template": {
@@ -462086,7 +462086,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4165,
       "template": {
@@ -462139,7 +462139,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4166,
       "template": {
@@ -462219,7 +462219,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4167,
       "template": {
@@ -462272,7 +462272,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4168,
       "template": {
@@ -462325,7 +462325,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4169,
       "template": {
@@ -462378,7 +462378,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4170,
       "template": {
@@ -462431,7 +462431,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4171,
       "template": {
@@ -462484,7 +462484,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4172,
       "template": {
@@ -462591,7 +462591,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4173,
       "template": {
@@ -462671,7 +462671,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4174,
       "template": {
@@ -462751,7 +462751,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4175,
       "template": {
@@ -462804,7 +462804,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4176,
       "template": {
@@ -462884,7 +462884,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4177,
       "template": {
@@ -462964,7 +462964,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4178,
       "template": {
@@ -463017,7 +463017,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4179,
       "template": {
@@ -463152,7 +463152,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4180,
       "template": {
@@ -463177,7 +463177,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4181,
       "template": {
@@ -463257,7 +463257,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4182,
       "template": {
@@ -463364,7 +463364,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4183,
       "template": {
@@ -463471,7 +463471,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4184,
       "template": {
@@ -463524,7 +463524,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4185,
       "template": {
@@ -463577,7 +463577,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4186,
       "template": {
@@ -463630,7 +463630,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4187,
       "template": {
@@ -463710,7 +463710,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4188,
       "template": {
@@ -463763,7 +463763,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4189,
       "template": {
@@ -463816,7 +463816,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4190,
       "template": {
@@ -463869,7 +463869,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4191,
       "template": {
@@ -463922,7 +463922,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4192,
       "template": {
@@ -464002,7 +464002,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4193,
       "template": {
@@ -464055,7 +464055,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4194,
       "template": {
@@ -464136,7 +464136,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4195,
       "template": {
@@ -464217,7 +464217,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4196,
       "template": {
@@ -464297,7 +464297,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4197,
       "template": {
@@ -464350,7 +464350,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4198,
       "template": {
@@ -464431,7 +464431,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4199,
       "template": {
@@ -471112,7 +471112,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4440,
       "template": {
@@ -471137,7 +471137,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 4441,
       "template": {
@@ -489420,7 +489420,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 5231,
       "template": {
@@ -505212,7 +505212,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 5472,
       "template": {
@@ -505373,7 +505373,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 5473,
       "template": {
@@ -505398,7 +505398,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 5474,
       "template": {
@@ -505423,7 +505423,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 5475,
       "template": {
@@ -505448,7 +505448,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 5476,
       "template": {
@@ -505473,7 +505473,7 @@
     "template": {
       "etc": {
         "consumable": false,
-        "stackable": false
+        "stackable": true
       },
       "selfId": 5477,
       "template": {

--- a/data/KnowledgeBase/manifest.json
+++ b/data/KnowledgeBase/manifest.json
@@ -40,7 +40,7 @@
   },
   "counts": {
     "dropEntries": 13071,
-    "items": 5062,
+    "items": 5067,
     "knownReachableMobs": 1642,
     "knownReachableSourcedItems": 1645,
     "mobs": 2068,
@@ -113,7 +113,7 @@
   },
   "schemaVersion": 1,
   "sha256": {
-    "items.json": "01e1d0a06da2c604a91660569beecfb2b01afcd6bfdc86e48b3d4e5d651b7789",
+    "items.json": "8738a9fa58466023fc82a67c7c5b61e846498b2d7210aad0a03c69e19b3504c1",
     "mobs.json": "ac5345082bcb45e0f5391c7dae2392d03fd53b105453d07465285343bfa14c5d",
     "skills.json": "f6d3894f116457eacfc9a57359b73fa4b10c86d361338edcfaf6fa3a5c8cf2e8",
     "spawns.json": "875a09059e5b66062a6c419bb57706566a80e6c336b3f23b7ec40b56a37d5cd4"

--- a/data/KnowledgeBase/manifest.json
+++ b/data/KnowledgeBase/manifest.json
@@ -113,7 +113,7 @@
   },
   "schemaVersion": 1,
   "sha256": {
-    "items.json": "6ad3ab26fab068b1795f0b4f3988cc2760619813e1643ae10eadbf39d827eefd",
+    "items.json": "01e1d0a06da2c604a91660569beecfb2b01afcd6bfdc86e48b3d4e5d651b7789",
     "mobs.json": "4dae340bcb32442e2c3ac67912d025d63a26a622b0282d4bbd38d72ae7423748",
     "skills.json": "f6d3894f116457eacfc9a57359b73fa4b10c86d361338edcfaf6fa3a5c8cf2e8",
     "spawns.json": "875a09059e5b66062a6c419bb57706566a80e6c336b3f23b7ec40b56a37d5cd4"

--- a/data/KnowledgeBase/manifest.json
+++ b/data/KnowledgeBase/manifest.json
@@ -114,7 +114,7 @@
   "schemaVersion": 1,
   "sha256": {
     "items.json": "01e1d0a06da2c604a91660569beecfb2b01afcd6bfdc86e48b3d4e5d651b7789",
-    "mobs.json": "4dae340bcb32442e2c3ac67912d025d63a26a622b0282d4bbd38d72ae7423748",
+    "mobs.json": "ac5345082bcb45e0f5391c7dae2392d03fd53b105453d07465285343bfa14c5d",
     "skills.json": "f6d3894f116457eacfc9a57359b73fa4b10c86d361338edcfaf6fa3a5c8cf2e8",
     "spawns.json": "875a09059e5b66062a6c419bb57706566a80e6c336b3f23b7ec40b56a37d5cd4"
   }

--- a/data/KnowledgeBase/mobs.json
+++ b/data/KnowledgeBase/mobs.json
@@ -11772,8 +11772,8 @@
     "minions": [],
     "name": "Mana Seeker",
     "progression": {
-      "baseExp": 496.000000000044,
-      "baseSp": 21,
+      "baseExp": 992.000000000088,
+      "baseSp": 42,
       "expModifier": 1.530864197531
     },
     "raidBoss": false,
@@ -28446,8 +28446,8 @@
     "minions": [],
     "name": "Ant Overseer",
     "progression": {
-      "baseExp": 1200,
-      "baseSp": 67,
+      "baseExp": 2400,
+      "baseSp": 134,
       "expModifier": 1.171875
     },
     "raidBoss": false,
@@ -31182,8 +31182,8 @@
     "minions": [],
     "name": "Ant Soldier",
     "progression": {
-      "baseExp": 1780.00000000025,
-      "baseSp": 105,
+      "baseExp": 3560.0000000005,
+      "baseSp": 210,
       "expModifier": 1.45306122449
     },
     "raidBoss": false,
@@ -31625,8 +31625,8 @@
     "minions": [],
     "name": "Ant Warrior Captain",
     "progression": {
-      "baseExp": 1984.000000000176,
-      "baseSp": 120,
+      "baseExp": 3968.000000000352,
+      "baseSp": 240,
       "expModifier": 1.530864197531
     },
     "raidBoss": false,
@@ -32840,8 +32840,8 @@
     "minions": [],
     "name": "Noble Ant Leader",
     "progression": {
-      "baseExp": 1829.00000000006,
-      "baseSp": 114,
+      "baseExp": 3658.00000000012,
+      "baseSp": 228,
       "expModifier": 1.266620498615
     },
     "raidBoss": false,
@@ -38809,8 +38809,8 @@
     "minions": [],
     "name": "Salamander",
     "progression": {
-      "baseExp": 494.000000000106,
-      "baseSp": 21,
+      "baseExp": 988.000000000212,
+      "baseSp": 42,
       "expModifier": 1.709342560554
     },
     "raidBoss": false,
@@ -39168,8 +39168,8 @@
     "minions": [],
     "name": "Undine",
     "progression": {
-      "baseExp": 479.000000000063,
-      "baseSp": 20,
+      "baseExp": 958.000000000126,
+      "baseSp": 40,
       "expModifier": 1.657439446367
     },
     "raidBoss": false,
@@ -39330,8 +39330,8 @@
     "minions": [],
     "name": "Wererat Leader",
     "progression": {
-      "baseExp": 479.000000000063,
-      "baseSp": 20,
+      "baseExp": 958.000000000126,
+      "baseSp": 40,
       "expModifier": 1.657439446367
     },
     "raidBoss": false,
@@ -39434,8 +39434,8 @@
     "minions": [],
     "name": "Salamander Elder",
     "progression": {
-      "baseExp": 496.000000000044,
-      "baseSp": 21,
+      "baseExp": 992.000000000088,
+      "baseSp": 42,
       "expModifier": 1.530864197531
     },
     "raidBoss": false,
@@ -39540,8 +39540,8 @@
     "minions": [],
     "name": "Undine Elder",
     "progression": {
-      "baseExp": 505.000000000116,
-      "baseSp": 22,
+      "baseExp": 1010.000000000232,
+      "baseSp": 44,
       "expModifier": 1.558641975309
     },
     "raidBoss": false,
@@ -39647,8 +39647,8 @@
     "minions": [],
     "name": "Salamander Noble",
     "progression": {
-      "baseExp": 525.000000000049,
-      "baseSp": 23,
+      "baseExp": 1050.000000000098,
+      "baseSp": 46,
       "expModifier": 1.454293628809
     },
     "raidBoss": false,
@@ -39753,8 +39753,8 @@
     "minions": [],
     "name": "Undine Noble",
     "progression": {
-      "baseExp": 535.999999999896,
-      "baseSp": 24,
+      "baseExp": 1071.999999999792,
+      "baseSp": 48,
       "expModifier": 1.484764542936
     },
     "raidBoss": false,
@@ -43916,8 +43916,8 @@
     "minions": [],
     "name": "Death Knight",
     "progression": {
-      "baseExp": 4651,
-      "baseSp": 350,
+      "baseExp": 9302,
+      "baseSp": 700,
       "expModifier": 1.8604
     },
     "raidBoss": false,
@@ -60608,8 +60608,8 @@
     "minions": [],
     "name": "Ol Mahum Guerilla",
     "progression": {
-      "baseExp": 981.999999999668,
-      "baseSp": 49,
+      "baseExp": 1963.999999999336,
+      "baseSp": 98,
       "expModifier": 1.452662721893
     },
     "raidBoss": false,
@@ -60996,8 +60996,8 @@
     "minions": [],
     "name": "Ol Mahum Raider",
     "progression": {
-      "baseExp": 1035.00000000018,
-      "baseSp": 53,
+      "baseExp": 2070.00000000036,
+      "baseSp": 106,
       "expModifier": 1.41975308642
     },
     "raidBoss": false,
@@ -61391,8 +61391,8 @@
     "minions": [],
     "name": "Ol Mahum Marksman",
     "progression": {
-      "baseExp": 1127.999999999936,
-      "baseSp": 59,
+      "baseExp": 2255.999999999872,
+      "baseSp": 118,
       "expModifier": 1.438775510204
     },
     "raidBoss": false,
@@ -61786,8 +61786,8 @@
     "minions": [],
     "name": "Ol Mahum Sergeant",
     "progression": {
-      "baseExp": 1155.999999999819,
-      "baseSp": 62,
+      "baseExp": 2311.999999999638,
+      "baseSp": 124,
       "expModifier": 1.374554102259
     },
     "raidBoss": false,
@@ -62331,8 +62331,8 @@
     "minions": [],
     "name": "Ol Mahum Captain",
     "progression": {
-      "baseExp": 1241.0000000001,
-      "baseSp": 68,
+      "baseExp": 2482.0000000002,
+      "baseSp": 136,
       "expModifier": 1.378888888889
     },
     "raidBoss": false,
@@ -62499,8 +62499,8 @@
     "minions": [],
     "name": "Bloody Axe Turmak",
     "progression": {
-      "baseExp": 1469.0000000003,
-      "baseSp": 86,
+      "baseExp": 2938.0000000006,
+      "baseSp": 172,
       "expModifier": 1.270761245675
     },
     "raidBoss": false,
@@ -62843,8 +62843,8 @@
     "minions": [],
     "name": "Porta",
     "progression": {
-      "baseExp": 2364,
-      "baseSp": 152,
+      "baseExp": 4728,
+      "baseSp": 304,
       "expModifier": 1.4775
     },
     "raidBoss": false,
@@ -63349,8 +63349,8 @@
     "minions": [],
     "name": "Excuro",
     "progression": {
-      "baseExp": 2027.999999999494,
-      "baseSp": 132,
+      "baseExp": 4055.999999998988,
+      "baseSp": 264,
       "expModifier": 1.206424747174
     },
     "raidBoss": false,
@@ -63727,8 +63727,8 @@
     "minions": [],
     "name": "Mordeo",
     "progression": {
-      "baseExp": 2624.99999999958,
-      "baseSp": 175,
+      "baseExp": 5249.999999999161,
+      "baseSp": 350,
       "expModifier": 1.488095238095
     },
     "raidBoss": false,
@@ -64352,8 +64352,8 @@
     "minions": [],
     "name": "Ricenseo",
     "progression": {
-      "baseExp": 2103.999999999977,
-      "baseSp": 142,
+      "baseExp": 4207.999999999954,
+      "baseSp": 284,
       "expModifier": 1.137912385073
     },
     "raidBoss": false,
@@ -65045,8 +65045,8 @@
     "minions": [],
     "name": "Krator",
     "progression": {
-      "baseExp": 2687.999999999776,
-      "baseSp": 184,
+      "baseExp": 5375.999999999553,
+      "baseSp": 368,
       "expModifier": 1.388429752066
     },
     "raidBoss": false,
@@ -65619,8 +65619,8 @@
     "minions": [],
     "name": "Premo",
     "progression": {
-      "baseExp": 2812.000000000725,
-      "baseSp": 195,
+      "baseExp": 5624.00000000145,
+      "baseSp": 390,
       "expModifier": 1.388641975309
     },
     "raidBoss": false,
@@ -66032,8 +66032,8 @@
     "minions": [],
     "name": "Validus",
     "progression": {
-      "baseExp": 2408.000000000712,
-      "baseSp": 170,
+      "baseExp": 4816.000000001423,
+      "baseSp": 340,
       "expModifier": 1.137996219282
     },
     "raidBoss": false,
@@ -66651,8 +66651,8 @@
     "minions": [],
     "name": "Dicor",
     "progression": {
-      "baseExp": 2867.000000001034,
-      "baseSp": 205,
+      "baseExp": 5734.000000002068,
+      "baseSp": 410,
       "expModifier": 1.297872340426
     },
     "raidBoss": false,
@@ -67271,8 +67271,8 @@
     "minions": [],
     "name": "Perum",
     "progression": {
-      "baseExp": 3438,
-      "baseSp": 251,
+      "baseExp": 6876,
+      "baseSp": 502,
       "expModifier": 1.4921875
     },
     "raidBoss": false,
@@ -67721,8 +67721,8 @@
     "minions": [],
     "name": "Torfe",
     "progression": {
-      "baseExp": 3025.000000000587,
-      "baseSp": 223,
+      "baseExp": 6050.000000001174,
+      "baseSp": 446,
       "expModifier": 1.259891711787
     },
     "raidBoss": false,
@@ -79131,8 +79131,8 @@
     "minions": [],
     "name": "Turak Bugbear Warrior",
     "progression": {
-      "baseExp": 1502.000000000379,
-      "baseSp": 86,
+      "baseExp": 3004.000000000758,
+      "baseSp": 172,
       "expModifier": 1.379247015611
     },
     "raidBoss": false,
@@ -82771,8 +82771,8 @@
     "minions": [],
     "name": "Monster Eye Searcher",
     "progression": {
-      "baseExp": 763.000000000128,
-      "baseSp": 36,
+      "baseExp": 1526.000000000256,
+      "baseSp": 72,
       "expModifier": 1.576446280992
     },
     "raidBoss": false,
@@ -118009,8 +118009,8 @@
     "minions": [],
     "name": "Varikan Brigand Leader",
     "progression": {
-      "baseExp": 503,
-      "baseSp": 17,
+      "baseExp": 1006,
+      "baseSp": 34,
       "expModifier": 5.03
     },
     "raidBoss": false,
@@ -118144,8 +118144,8 @@
     "minions": [],
     "name": "Varika's Bandit",
     "progression": {
-      "baseExp": 333.999999999988,
-      "baseSp": 12,
+      "baseExp": 166.999999999994,
+      "baseSp": 6,
       "expModifier": 6.816326530612
     },
     "raidBoss": false,
@@ -124001,8 +124001,8 @@
     "minions": [],
     "name": "Vrykolakas",
     "progression": {
-      "baseExp": 692.0000000001,
-      "baseSp": 28,
+      "baseExp": 1384.0000000002,
+      "baseSp": 56,
       "expModifier": 3.075555555556
     },
     "raidBoss": false,
@@ -124137,8 +124137,8 @@
     "minions": [],
     "name": "Vrykolakas Wolfkin",
     "progression": {
-      "baseExp": 353.99999999997,
-      "baseSp": 12,
+      "baseExp": 176.999999999985,
+      "baseSp": 6,
       "expModifier": 4.37037037037
     },
     "raidBoss": false,
@@ -137034,8 +137034,8 @@
     "minions": [],
     "name": "Uthanka Pirate",
     "progression": {
-      "baseExp": 307.000000000001,
-      "baseSp": 10,
+      "baseExp": 153.500000000001,
+      "baseSp": 5,
       "expModifier": 6.265306122449
     },
     "raidBoss": false,
@@ -139173,8 +139173,8 @@
     "minions": [],
     "name": "Relic Spartoi",
     "progression": {
-      "baseExp": 592.000000000038,
-      "baseSp": 27,
+      "baseExp": 1184.000000000076,
+      "baseSp": 54,
       "expModifier": 1.342403628118
     },
     "raidBoss": false,
@@ -139694,8 +139694,8 @@
     "minions": [],
     "name": "Oblivion Watcher",
     "progression": {
-      "baseExp": 453.999999999895,
-      "baseSp": 20,
+      "baseExp": 226.999999999947,
+      "baseSp": 10,
       "expModifier": 1.570934256055
     },
     "raidBoss": false,
@@ -151905,8 +151905,8 @@
     "minions": [],
     "name": "Turek War Hound",
     "progression": {
-      "baseExp": 869.000000000256,
-      "baseSp": 43,
+      "baseExp": 1738.000000000512,
+      "baseSp": 86,
       "expModifier": 1.508680555556
     },
     "raidBoss": false,
@@ -152326,8 +152326,8 @@
     "minions": [],
     "name": "Turek Orc Warlord",
     "progression": {
-      "baseExp": 1389.9999999996,
-      "baseSp": 76,
+      "baseExp": 2779.9999999992,
+      "baseSp": 152,
       "expModifier": 1.544444444444
     },
     "raidBoss": false,
@@ -152706,8 +152706,8 @@
     "minions": [],
     "name": "Turek Orc Archer",
     "progression": {
-      "baseExp": 1076.000000000328,
-      "baseSp": 55,
+      "baseExp": 2152.000000000656,
+      "baseSp": 110,
       "expModifier": 1.475994513032
     },
     "raidBoss": false,
@@ -153066,8 +153066,8 @@
     "minions": [],
     "name": "Turek Orc Skirmisher",
     "progression": {
-      "baseExp": 1116.999999999856,
-      "baseSp": 58,
+      "baseExp": 2233.999999999712,
+      "baseSp": 116,
       "expModifier": 1.424744897959
     },
     "raidBoss": false,
@@ -153449,8 +153449,8 @@
     "minions": [],
     "name": "Turek Orc Supplier",
     "progression": {
-      "baseExp": 1035.00000000018,
-      "baseSp": 53,
+      "baseExp": 2070.00000000036,
+      "baseSp": 106,
       "expModifier": 1.41975308642
     },
     "raidBoss": false,
@@ -153852,8 +153852,8 @@
     "minions": [],
     "name": "Turek Orc Footman",
     "progression": {
-      "baseExp": 981.999999999668,
-      "baseSp": 49,
+      "baseExp": 1963.999999999336,
+      "baseSp": 98,
       "expModifier": 1.452662721893
     },
     "raidBoss": false,
@@ -154265,8 +154265,8 @@
     "minions": [],
     "name": "Turek Orc Sentinel",
     "progression": {
-      "baseExp": 922,
-      "baseSp": 46,
+      "baseExp": 1844,
+      "baseSp": 92,
       "expModifier": 1.4752
     },
     "raidBoss": false,
@@ -154754,8 +154754,8 @@
     "minions": [],
     "name": "Turek Orc Shaman",
     "progression": {
-      "baseExp": 1155.999999999819,
-      "baseSp": 62,
+      "baseExp": 2311.999999999638,
+      "baseSp": 124,
       "expModifier": 1.374554102259
     },
     "raidBoss": false,
@@ -160067,8 +160067,8 @@
     "minions": [],
     "name": "Pirate Captain Uthanka",
     "progression": {
-      "baseExp": 463,
-      "baseSp": 16,
+      "baseExp": 926,
+      "baseSp": 32,
       "expModifier": 4.63
     },
     "raidBoss": false,
@@ -160683,8 +160683,8 @@
     "minions": [],
     "name": "White Fang",
     "progression": {
-      "baseExp": 458,
-      "baseSp": 15,
+      "baseExp": 916,
+      "baseSp": 30,
       "expModifier": 4.58
     },
     "raidBoss": false,
@@ -160940,8 +160940,8 @@
     "minions": [],
     "name": "Grey Wolf Elder",
     "progression": {
-      "baseExp": 303.999999999997,
-      "baseSp": 10,
+      "baseExp": 151.999999999998,
+      "baseSp": 5,
       "expModifier": 6.204081632653
     },
     "raidBoss": false,
@@ -169009,8 +169009,8 @@
     "minions": [],
     "name": "Ol Mahum Lord",
     "progression": {
-      "baseExp": 1762.99999999964,
-      "baseSp": 103,
+      "baseExp": 3525.99999999928,
+      "baseSp": 206,
       "expModifier": 1.52508650519
     },
     "raidBoss": false,
@@ -170250,8 +170250,8 @@
     "minions": [],
     "name": "Fettered Soul",
     "progression": {
-      "baseExp": 2146.000000000672,
-      "baseSp": 134,
+      "baseExp": 4292.000000001344,
+      "baseSp": 268,
       "expModifier": 1.486149584488
     },
     "raidBoss": false,
@@ -180971,8 +180971,8 @@
     "minions": [],
     "name": "Oel Mahum Witch Doctor",
     "progression": {
-      "baseExp": 4401.00000000045,
-      "baseSp": 355,
+      "baseExp": 8802.0000000009,
+      "baseSp": 710,
       "expModifier": 1.454876033058
     },
     "raidBoss": false,
@@ -182886,8 +182886,8 @@
     "minions": [],
     "name": "Leto Lizardman Warrior",
     "progression": {
-      "baseExp": 1952.999999999648,
-      "baseSp": 121,
+      "baseExp": 3905.999999999296,
+      "baseSp": 242,
       "expModifier": 1.352493074792
     },
     "raidBoss": false,
@@ -183787,8 +183787,8 @@
     "minions": [],
     "name": "Leto Lizardman Overlord",
     "progression": {
-      "baseExp": 2207,
-      "baseSp": 142,
+      "baseExp": 4414,
+      "baseSp": 284,
       "expModifier": 1.379375
     },
     "raidBoss": false,
@@ -186723,8 +186723,8 @@
     "minions": [],
     "name": "Fline",
     "progression": {
-      "baseExp": 2766.00000000015,
-      "baseSp": 192,
+      "baseExp": 5532.0000000003,
+      "baseSp": 384,
       "expModifier": 1.365925925926
     },
     "raidBoss": false,
@@ -187136,8 +187136,8 @@
     "minions": [],
     "name": "Liele",
     "progression": {
-      "baseExp": 2861.999999999732,
-      "baseSp": 203,
+      "baseExp": 5723.999999999464,
+      "baseSp": 406,
       "expModifier": 1.352551984877
     },
     "raidBoss": false,
@@ -187490,8 +187490,8 @@
     "minions": [],
     "name": "Valley Treant",
     "progression": {
-      "baseExp": 4223.999999999158,
-      "baseSp": 303,
+      "baseExp": 8447.999999998316,
+      "baseSp": 606,
       "expModifier": 1.912177455862
     },
     "raidBoss": false,
@@ -187903,8 +187903,8 @@
     "minions": [],
     "name": "Satyr",
     "progression": {
-      "baseExp": 3075.999999998976,
-      "baseSp": 224,
+      "baseExp": 9227.99999999693,
+      "baseSp": 672,
       "expModifier": 1.335069444444
     },
     "raidBoss": false,
@@ -188401,8 +188401,8 @@
     "minions": [],
     "name": "Unicorn",
     "progression": {
-      "baseExp": 3298.999999999221,
-      "baseSp": 244,
+      "baseExp": 9896.999999997663,
+      "baseSp": 732,
       "expModifier": 1.374010828821
     },
     "raidBoss": false,
@@ -188816,8 +188816,8 @@
     "minions": [],
     "name": "Forest Runner",
     "progression": {
-      "baseExp": 3381,
-      "baseSp": 254,
+      "baseExp": 6762,
+      "baseSp": 508,
       "expModifier": 1.3524
     },
     "raidBoss": false,
@@ -189208,8 +189208,8 @@
     "minions": [],
     "name": "Fline Elder",
     "progression": {
-      "baseExp": 3517.999999999758,
-      "baseSp": 268,
+      "baseExp": 7035.999999999516,
+      "baseSp": 536,
       "expModifier": 1.352556708958
     },
     "raidBoss": false,
@@ -189888,8 +189888,8 @@
     "minions": [],
     "name": "Liele Elder",
     "progression": {
-      "baseExp": 3729.999999998688,
-      "baseSp": 288,
+      "baseExp": 7459.999999997376,
+      "baseSp": 576,
       "expModifier": 1.379437869822
     },
     "raidBoss": false,
@@ -190285,8 +190285,8 @@
     "minions": [],
     "name": "Valley treant Elder",
     "progression": {
-      "baseExp": 5199.000000001086,
-      "baseSp": 408,
+      "baseExp": 15597.000000003258,
+      "baseSp": 1224,
       "expModifier": 1.850836596654
     },
     "raidBoss": false,
@@ -190680,8 +190680,8 @@
     "minions": [],
     "name": "Satyr Elder",
     "progression": {
-      "baseExp": 3816.000000001044,
-      "baseSp": 304,
+      "baseExp": 11448.00000000313,
+      "baseSp": 912,
       "expModifier": 1.308641975309
     },
     "raidBoss": false,
@@ -191411,8 +191411,8 @@
     "minions": [],
     "name": "Unicorn Elder",
     "progression": {
-      "baseExp": 3959.000000001475,
-      "baseSp": 319,
+      "baseExp": 11877.000000004426,
+      "baseSp": 957,
       "expModifier": 1.308760330579
     },
     "raidBoss": false,
@@ -194480,8 +194480,8 @@
     "minions": [],
     "name": "Kuran Kobold",
     "progression": {
-      "baseExp": 950.000000000211,
-      "baseSp": 48,
+      "baseExp": 1900.000000000422,
+      "baseSp": 96,
       "expModifier": 1.303155006859
     },
     "raidBoss": false,
@@ -194906,8 +194906,8 @@
     "minions": [],
     "name": "Kuran Kobold Warrior",
     "progression": {
-      "baseExp": 1005.999999999904,
-      "baseSp": 53,
+      "baseExp": 2011.999999999808,
+      "baseSp": 106,
       "expModifier": 1.283163265306
     },
     "raidBoss": false,
@@ -195229,8 +195229,8 @@
     "minions": [],
     "name": "Patin Archer",
     "progression": {
-      "baseExp": 1022.000000000179,
-      "baseSp": 55,
+      "baseExp": 2044.000000000358,
+      "baseSp": 110,
       "expModifier": 1.215219976219
     },
     "raidBoss": false,
@@ -195557,8 +195557,8 @@
     "minions": [],
     "name": "Lakin Salamander",
     "progression": {
-      "baseExp": 1068.0000000003,
-      "baseSp": 58,
+      "baseExp": 2136.0000000006,
+      "baseSp": 116,
       "expModifier": 1.186666666667
     },
     "raidBoss": false,
@@ -195897,8 +195897,8 @@
     "minions": [],
     "name": "Sentinel Of Water",
     "progression": {
-      "baseExp": 1083.000000000132,
-      "baseSp": 60,
+      "baseExp": 2166.000000000264,
+      "baseSp": 120,
       "expModifier": 1.126951092612
     },
     "raidBoss": false,
@@ -196488,8 +196488,8 @@
     "minions": [],
     "name": "Dre Vanul Warrior",
     "progression": {
-      "baseExp": 1154,
-      "baseSp": 65,
+      "baseExp": 2308,
+      "baseSp": 130,
       "expModifier": 1.126953125
     },
     "raidBoss": false,
@@ -196859,8 +196859,8 @@
     "minions": [],
     "name": "Salamander Rowin",
     "progression": {
-      "baseExp": 1319.000000000364,
-      "baseSp": 75,
+      "baseExp": 2638.000000000728,
+      "baseSp": 150,
       "expModifier": 1.211202938476
     },
     "raidBoss": false,
@@ -197248,8 +197248,8 @@
     "minions": [],
     "name": "Lafi Lizardman",
     "progression": {
-      "baseExp": 950.000000000211,
-      "baseSp": 48,
+      "baseExp": 1900.000000000422,
+      "baseSp": 96,
       "expModifier": 1.303155006859
     },
     "raidBoss": false,
@@ -197589,8 +197589,8 @@
     "minions": [],
     "name": "Lafi Lizardman Scout",
     "progression": {
-      "baseExp": 940.000000000208,
-      "baseSp": 49,
+      "baseExp": 1880.000000000416,
+      "baseSp": 98,
       "expModifier": 1.198979591837
     },
     "raidBoss": false,
@@ -197956,8 +197956,8 @@
     "minions": [],
     "name": "Ritmal Swordsman",
     "progression": {
-      "baseExp": 1093.999999999609,
-      "baseSp": 58,
+      "baseExp": 2187.999999999218,
+      "baseSp": 116,
       "expModifier": 1.300832342449
     },
     "raidBoss": false,
@@ -198404,8 +198404,8 @@
     "minions": [],
     "name": "Lakin Undine",
     "progression": {
-      "baseExp": 1433.9999999997,
-      "baseSp": 78,
+      "baseExp": 2867.9999999994,
+      "baseSp": 156,
       "expModifier": 1.593333333333
     },
     "raidBoss": false,
@@ -198762,8 +198762,8 @@
     "minions": [],
     "name": "Sentinel Of Water",
     "progression": {
-      "baseExp": 1092.999999999875,
-      "baseSp": 60,
+      "baseExp": 2185.99999999975,
+      "baseSp": 120,
       "expModifier": 1.137356919875
     },
     "raidBoss": false,
@@ -199121,8 +199121,8 @@
     "minions": [],
     "name": "Kanil Succubus",
     "progression": {
-      "baseExp": 1216,
-      "baseSp": 68,
+      "baseExp": 2432,
+      "baseSp": 136,
       "expModifier": 1.1875
     },
     "raidBoss": false,
@@ -199456,8 +199456,8 @@
     "minions": [],
     "name": "Rowin Undine",
     "progression": {
-      "baseExp": 1251.999999999936,
-      "baseSp": 72,
+      "baseExp": 2503.999999999872,
+      "baseSp": 144,
       "expModifier": 1.149678604224
     },
     "raidBoss": false,
@@ -199894,8 +199894,8 @@
     "minions": [],
     "name": "Cave Beast",
     "progression": {
-      "baseExp": 4304.000000001321,
-      "baseSp": 378,
+      "baseExp": 12912.000000003965,
+      "baseSp": 1134,
       "expModifier": 1.156678312282
     },
     "raidBoss": false,
@@ -200266,8 +200266,8 @@
     "minions": [],
     "name": "Death Wave",
     "progression": {
-      "baseExp": 4638.999999998308,
-      "baseSp": 413,
+      "baseExp": 13916.999999994925,
+      "baseSp": 1239,
       "expModifier": 1.206815816857
     },
     "raidBoss": false,
@@ -200792,8 +200792,8 @@
     "minions": [],
     "name": "Malruk Soldier",
     "progression": {
-      "baseExp": 4953.000000001852,
-      "baseSp": 447,
+      "baseExp": 14859.000000005555,
+      "baseSp": 1341,
       "expModifier": 1.247921390779
     },
     "raidBoss": false,
@@ -201322,8 +201322,8 @@
     "minions": [],
     "name": "Plando",
     "progression": {
-      "baseExp": 4953,
-      "baseSp": 453,
+      "baseExp": 19812,
+      "baseSp": 1812,
       "expModifier": 1.209228515625
     },
     "raidBoss": false,
@@ -201783,8 +201783,8 @@
     "minions": [],
     "name": "Cave Howler",
     "progression": {
-      "baseExp": 5036.9999999982,
-      "baseSp": 468,
+      "baseExp": 20147.9999999928,
+      "baseSp": 1872,
       "expModifier": 1.192189349112
     },
     "raidBoss": false,
@@ -202238,8 +202238,8 @@
     "minions": [],
     "name": "Malruk Knight",
     "progression": {
-      "baseExp": 5030.0000000019,
-      "baseSp": 473,
+      "baseExp": 20120.0000000076,
+      "baseSp": 1892,
       "expModifier": 1.154729109275
     },
     "raidBoss": false,
@@ -202587,8 +202587,8 @@
     "minions": [],
     "name": "Malruk Berserker",
     "progression": {
-      "baseExp": 7219.999999998744,
-      "baseSp": 687,
+      "baseExp": 28879.999999994976,
+      "baseSp": 2748,
       "expModifier": 1.608376030296
     },
     "raidBoss": false,
@@ -203011,8 +203011,8 @@
     "minions": [],
     "name": "Malruk Lord",
     "progression": {
-      "baseExp": 4964.000000001361,
-      "baseSp": 479,
+      "baseExp": 24820.000000006803,
+      "baseSp": 2395,
       "expModifier": 1.073529411765
     },
     "raidBoss": false,
@@ -203599,8 +203599,8 @@
     "minions": [],
     "name": "Limal Karinness",
     "progression": {
-      "baseExp": 5348.999999997738,
-      "baseSp": 523,
+      "baseExp": 26744.99999998869,
+      "baseSp": 2615,
       "expModifier": 1.123503465658
     },
     "raidBoss": false,
@@ -204093,8 +204093,8 @@
     "minions": [],
     "name": "Karik",
     "progression": {
-      "baseExp": 6584.0000000012,
-      "baseSp": 652,
+      "baseExp": 32920.000000005995,
+      "baseSp": 3260,
       "expModifier": 1.343673469388
     },
     "raidBoss": false,
@@ -206431,8 +206431,8 @@
     "minions": [],
     "name": "Taik Orc Captain",
     "progression": {
-      "baseExp": 2942.999999999664,
-      "baseSp": 201,
+      "baseExp": 5885.999999999328,
+      "baseSp": 402,
       "expModifier": 1.520144628099
     },
     "raidBoss": false,
@@ -208866,8 +208866,8 @@
     "minions": [],
     "name": "Mirror",
     "progression": {
-      "baseExp": 4254.000000000331,
-      "baseSp": 314,
+      "baseExp": 8508.000000000662,
+      "baseSp": 628,
       "expModifier": 1.771761765931
     },
     "raidBoss": false,
@@ -211281,8 +211281,8 @@
     "minions": [],
     "name": "Harit Lizardman Matriarch",
     "progression": {
-      "baseExp": 4767.999999998675,
-      "baseSp": 385,
+      "baseExp": 9535.99999999735,
+      "baseSp": 770,
       "expModifier": 1.576198347107
     },
     "raidBoss": false,
@@ -211735,8 +211735,8 @@
     "minions": [],
     "name": "Halingka",
     "progression": {
-      "baseExp": 3592.000000000225,
-      "baseSp": 290,
+      "baseExp": 7184.000000000449,
+      "baseSp": 580,
       "expModifier": 1.187438016529
     },
     "raidBoss": false,
@@ -212441,8 +212441,8 @@
     "minions": [],
     "name": "Yintzu",
     "progression": {
-      "baseExp": 3605.000000001344,
-      "baseSp": 296,
+      "baseExp": 7210.000000002688,
+      "baseSp": 592,
       "expModifier": 1.149553571429
     },
     "raidBoss": false,
@@ -213150,8 +213150,8 @@
     "minions": [],
     "name": "Paliote",
     "progression": {
-      "baseExp": 4094.000000000127,
-      "baseSp": 340,
+      "baseExp": 8188.000000000254,
+      "baseSp": 680,
       "expModifier": 1.260080024623
     },
     "raidBoss": false,
@@ -213551,8 +213551,8 @@
     "minions": [],
     "name": "Hamrut",
     "progression": {
-      "baseExp": 4075.000000000048,
-      "baseSp": 344,
+      "baseExp": 8150.000000000095,
+      "baseSp": 688,
       "expModifier": 1.211355529132
     },
     "raidBoss": false,
@@ -213997,8 +213997,8 @@
     "minions": [],
     "name": "Kranrot",
     "progression": {
-      "baseExp": 4409.999999998619,
-      "baseSp": 377,
+      "baseExp": 8819.999999997239,
+      "baseSp": 754,
       "expModifier": 1.266877334099
     },
     "raidBoss": false,
@@ -214482,8 +214482,8 @@
     "minions": [],
     "name": "Gamlin",
     "progression": {
-      "baseExp": 4097.0000000016,
-      "baseSp": 355,
+      "baseExp": 8194.0000000032,
+      "baseSp": 710,
       "expModifier": 1.138055555556
     },
     "raidBoss": false,
@@ -214965,8 +214965,8 @@
     "minions": [],
     "name": "Leogul",
     "progression": {
-      "baseExp": 4319.999999999418,
-      "baseSp": 380,
+      "baseExp": 8639.999999998836,
+      "baseSp": 760,
       "expModifier": 1.160978231658
     },
     "raidBoss": false,
@@ -215156,8 +215156,8 @@
     "minions": [],
     "name": "Lesser Giant",
     "progression": {
-      "baseExp": 4058.000000000828,
-      "baseSp": 357,
+      "baseExp": 12174.000000002483,
+      "baseSp": 1071,
       "expModifier": 1.090567051868
     },
     "raidBoss": false,
@@ -215521,8 +215521,8 @@
     "minions": [],
     "name": "Lesser Giant Soldier",
     "progression": {
-      "baseExp": 6223.999999998416,
-      "baseSp": 554,
+      "baseExp": 18671.99999999525,
+      "baseSp": 1662,
       "expModifier": 1.619146722164
     },
     "raidBoss": false,
@@ -215926,8 +215926,8 @@
     "minions": [],
     "name": "Lesser Giant Shooter",
     "progression": {
-      "baseExp": 5085.000000000017,
-      "baseSp": 459,
+      "baseExp": 15255.000000000051,
+      "baseSp": 1377,
       "expModifier": 1.281179138322
     },
     "raidBoss": false,
@@ -216344,8 +216344,8 @@
     "minions": [],
     "name": "Lesser Giant Scout",
     "progression": {
-      "baseExp": 4638.999999998574,
-      "baseSp": 419,
+      "baseExp": 13916.999999995722,
+      "baseSp": 1257,
       "expModifier": 1.168808264046
     },
     "raidBoss": false,
@@ -216826,8 +216826,8 @@
     "minions": [],
     "name": "Lesser Giant Mage",
     "progression": {
-      "baseExp": 5511,
-      "baseSp": 504,
+      "baseExp": 11022,
+      "baseSp": 1008,
       "expModifier": 1.345458984375
     },
     "raidBoss": false,
@@ -217268,8 +217268,8 @@
     "minions": [],
     "name": "Lesser Giant Elder",
     "progression": {
-      "baseExp": 5323.999999998875,
-      "baseSp": 494,
+      "baseExp": 10647.99999999775,
+      "baseSp": 988,
       "expModifier": 1.260118343195
     },
     "raidBoss": false,
@@ -230091,8 +230091,8 @@
     "minions": [],
     "name": "Vanor Silenos Chieftain",
     "progression": {
-      "baseExp": 3637,
-      "baseSp": 274,
+      "baseExp": 7274.000000000001,
+      "baseSp": 548,
       "expModifier": 1.4548
     },
     "raidBoss": false,
@@ -240376,8 +240376,8 @@
     "minions": [],
     "name": "Kobold Looter Bepook",
     "progression": {
-      "baseExp": 663.000000000013,
-      "baseSp": 26,
+      "baseExp": 1326.000000000026,
+      "baseSp": 52,
       "expModifier": 3.923076923077
     },
     "raidBoss": false,
@@ -240534,8 +240534,8 @@
     "minions": [],
     "name": "Bepook's Pet",
     "progression": {
-      "baseExp": 439,
-      "baseSp": 14,
+      "baseExp": 219.5,
+      "baseSp": 7,
       "expModifier": 4.39
     },
     "raidBoss": false,
@@ -242549,8 +242549,8 @@
     "minions": [],
     "name": "Roxide",
     "progression": {
-      "baseExp": 1459,
-      "baseSp": 82,
+      "baseExp": 2918,
+      "baseSp": 164,
       "expModifier": 1.4248046875
     },
     "raidBoss": false,
@@ -242963,8 +242963,8 @@
     "minions": [],
     "name": "Roxide Cohort",
     "progression": {
-      "baseExp": 1348.999999999903,
-      "baseSp": 72,
+      "baseExp": 2697.999999999806,
+      "baseSp": 144,
       "expModifier": 1.604042806183
     },
     "raidBoss": false,
@@ -243273,8 +243273,8 @@
     "minions": [],
     "name": "Death Fire",
     "progression": {
-      "baseExp": 1459,
-      "baseSp": 82,
+      "baseExp": 2918,
+      "baseSp": 164,
       "expModifier": 1.4248046875
     },
     "raidBoss": false,
@@ -243639,8 +243639,8 @@
     "minions": [],
     "name": "Fire Archer",
     "progression": {
-      "baseExp": 1397.000000000364,
-      "baseSp": 75,
+      "baseExp": 2794.000000000728,
+      "baseSp": 150,
       "expModifier": 1.661117717004
     },
     "raidBoss": false,
@@ -244300,8 +244300,8 @@
     "minions": [],
     "name": "Snipe",
     "progression": {
-      "baseExp": 3386.999999999264,
-      "baseSp": 232,
+      "baseExp": 6773.999999998528,
+      "baseSp": 464,
       "expModifier": 1.749483471074
     },
     "raidBoss": false,
@@ -244732,8 +244732,8 @@
     "minions": [],
     "name": "Snipe Cohort",
     "progression": {
-      "baseExp": 3289.999999999356,
-      "baseSp": 219,
+      "baseExp": 6579.999999998712,
+      "baseSp": 438,
       "expModifier": 1.865079365079
     },
     "raidBoss": false,
@@ -245304,8 +245304,8 @@
     "minions": [],
     "name": "Dark Lord",
     "progression": {
-      "baseExp": 4282,
-      "baseSp": 322,
+      "baseExp": 8564,
+      "baseSp": 644,
       "expModifier": 1.7128
     },
     "raidBoss": false,
@@ -245653,8 +245653,8 @@
     "minions": [],
     "name": "Dark Knight",
     "progression": {
-      "baseExp": 4960.000000000512,
-      "baseSp": 362,
+      "baseExp": 9920.000000001024,
+      "baseSp": 724,
       "expModifier": 2.152777777778
     },
     "raidBoss": false,
@@ -248280,8 +248280,8 @@
     "minions": [],
     "name": "Pytan",
     "progression": {
-      "baseExp": 6632.999999998434,
-      "baseSp": 649,
+      "baseExp": 19898.9999999953,
+      "baseSp": 1947,
       "expModifier": 1.393194706994
     },
     "raidBoss": false,
@@ -248689,8 +248689,8 @@
     "minions": [],
     "name": "Pytan Knight",
     "progression": {
-      "baseExp": 7020.999999999184,
-      "baseSp": 678,
+      "baseExp": 14041.999999998368,
+      "baseSp": 1356,
       "expModifier": 1.518382352941
     },
     "raidBoss": false,
@@ -252507,8 +252507,8 @@
     "minions": [],
     "name": "Barif",
     "progression": {
-      "baseExp": 6515,
-      "baseSp": 596,
+      "baseExp": 13030,
+      "baseSp": 1192,
       "expModifier": 1.590576171875
     },
     "raidBoss": false,
@@ -252876,8 +252876,8 @@
     "minions": [],
     "name": "Barif's Pet",
     "progression": {
-      "baseExp": 6332.000000001855,
-      "baseSp": 557,
+      "baseExp": 12664.00000000371,
+      "baseSp": 1114,
       "expModifier": 1.701693093255
     },
     "raidBoss": false,
@@ -256693,8 +256693,8 @@
     "minions": [],
     "name": "Dread Wolf",
     "progression": {
-      "baseExp": 1634.999999999975,
-      "baseSp": 96,
+      "baseExp": 817.499999999987,
+      "baseSp": 48,
       "expModifier": 1.334693877551
     },
     "raidBoss": false,
@@ -257189,8 +257189,8 @@
     "minions": [],
     "name": "Tasaba Lizardman",
     "progression": {
-      "baseExp": 1851.999999999984,
-      "baseSp": 112,
+      "baseExp": 925.999999999992,
+      "baseSp": 56,
       "expModifier": 1.429012345679
     },
     "raidBoss": false,
@@ -257972,8 +257972,8 @@
     "minions": [],
     "name": "Tasaba Lizardman Shaman",
     "progression": {
-      "baseExp": 1790.999999999874,
-      "baseSp": 110,
+      "baseExp": 895.499999999937,
+      "baseSp": 55,
       "expModifier": 1.308254200146
     },
     "raidBoss": false,
@@ -258469,8 +258469,8 @@
     "minions": [],
     "name": "Lienrik",
     "progression": {
-      "baseExp": 1989.999999999648,
-      "baseSp": 126,
+      "baseExp": 994.999999999824,
+      "baseSp": 63,
       "expModifier": 1.308349769888
     },
     "raidBoss": false,
@@ -259032,8 +259032,8 @@
     "minions": [],
     "name": "Lienrik Lad",
     "progression": {
-      "baseExp": 2421,
-      "baseSp": 156,
+      "baseExp": 1210.5,
+      "baseSp": 78,
       "expModifier": 1.513125
     },
     "raidBoss": false,
@@ -261030,8 +261030,8 @@
     "minions": [],
     "name": "Crokian Warrior",
     "progression": {
-      "baseExp": 2210.999999999932,
-      "baseSp": 138,
+      "baseExp": 4421.999999999864,
+      "baseSp": 276,
       "expModifier": 1.531163434903
     },
     "raidBoss": false,
@@ -261527,8 +261527,8 @@
     "minions": [],
     "name": "Farhite",
     "progression": {
-      "baseExp": 2056.999999999815,
-      "baseSp": 131,
+      "baseExp": 4113.99999999963,
+      "baseSp": 262,
       "expModifier": 1.352399737015
     },
     "raidBoss": false,
@@ -262026,8 +262026,8 @@
     "minions": [],
     "name": "Nos",
     "progression": {
-      "baseExp": 2251,
-      "baseSp": 145,
+      "baseExp": 4502,
+      "baseSp": 290,
       "expModifier": 1.406875
     },
     "raidBoss": false,
@@ -262568,8 +262568,8 @@
     "minions": [],
     "name": "Crokian Lad",
     "progression": {
-      "baseExp": 2573.999999999875,
-      "baseSp": 168,
+      "baseExp": 5147.99999999975,
+      "baseSp": 336,
       "expModifier": 1.531231409875
     },
     "raidBoss": false,
@@ -263131,8 +263131,8 @@
     "minions": [],
     "name": "Dailaon Lad",
     "progression": {
-      "baseExp": 2789.999999999604,
-      "baseSp": 186,
+      "baseExp": 5579.999999999209,
+      "baseSp": 372,
       "expModifier": 1.581632653061
     },
     "raidBoss": false,
@@ -263606,8 +263606,8 @@
     "minions": [],
     "name": "Crokian Lad Warrior",
     "progression": {
-      "baseExp": 2678.000000000092,
-      "baseSp": 181,
+      "baseExp": 5356.000000000184,
+      "baseSp": 362,
       "expModifier": 1.448350459708
     },
     "raidBoss": false,
@@ -264125,8 +264125,8 @@
     "minions": [],
     "name": "Farhite Lad",
     "progression": {
-      "baseExp": 2816.999999999856,
-      "baseSp": 193,
+      "baseExp": 5633.999999999712,
+      "baseSp": 386,
       "expModifier": 1.455061983471
     },
     "raidBoss": false,
@@ -264580,8 +264580,8 @@
     "minions": [],
     "name": "Nos Lad",
     "progression": {
-      "baseExp": 3487.00000000005,
-      "baseSp": 242,
+      "baseExp": 6974.0000000001,
+      "baseSp": 484,
       "expModifier": 1.721975308642
     },
     "raidBoss": false,
@@ -264991,8 +264991,8 @@
     "minions": [],
     "name": "Archer of Despair",
     "progression": {
-      "baseExp": 4708.000000001619,
-      "baseSp": 414,
+      "baseExp": 14124.000000004857,
+      "baseSp": 1242,
       "expModifier": 1.265251276539
     },
     "raidBoss": false,
@@ -265425,8 +265425,8 @@
     "minions": [],
     "name": "Crendion",
     "progression": {
-      "baseExp": 4275.999999998892,
-      "baseSp": 381,
+      "baseExp": 12827.999999996677,
+      "baseSp": 1143,
       "expModifier": 1.112382934443
     },
     "raidBoss": false,
@@ -265902,8 +265902,8 @@
     "minions": [],
     "name": "Hound Dog of Hallate",
     "progression": {
-      "baseExp": 4583.000000001276,
-      "baseSp": 413,
+      "baseExp": 18332.000000005104,
+      "baseSp": 1652,
       "expModifier": 1.154698916604
     },
     "raidBoss": false,
@@ -266399,8 +266399,8 @@
     "minions": [],
     "name": "Hallate's Royal Guard",
     "progression": {
-      "baseExp": 5098.00000000095,
-      "baseSp": 460,
+      "baseExp": 15294.000000002849,
+      "baseSp": 1380,
       "expModifier": 1.28445452255
     },
     "raidBoss": false,
@@ -266835,8 +266835,8 @@
     "minions": [],
     "name": "Corrupt Sage",
     "progression": {
-      "baseExp": 5315,
-      "baseSp": 486,
+      "baseExp": 15945,
+      "baseSp": 1458,
       "expModifier": 1.297607421875
     },
     "raidBoss": false,
@@ -267293,8 +267293,8 @@
     "minions": [],
     "name": "Hallate's Warrior",
     "progression": {
-      "baseExp": 4926,
-      "baseSp": 451,
+      "baseExp": 14778,
+      "baseSp": 1353,
       "expModifier": 1.20263671875
     },
     "raidBoss": false,
@@ -267837,8 +267837,8 @@
     "minions": [],
     "name": "Archer of Abyss",
     "progression": {
-      "baseExp": 4889.00000000165,
-      "baseSp": 454,
+      "baseExp": 14667.00000000495,
+      "baseSp": 1362,
       "expModifier": 1.157159763314
     },
     "raidBoss": false,
@@ -268360,8 +268360,8 @@
     "minions": [],
     "name": "Hallate's Knight",
     "progression": {
-      "baseExp": 7310.000000000426,
-      "baseSp": 679,
+      "baseExp": 29240.000000001703,
+      "baseSp": 2716,
       "expModifier": 1.730177514793
     },
     "raidBoss": false,
@@ -268799,8 +268799,8 @@
     "minions": [],
     "name": "Erin Ediunce",
     "progression": {
-      "baseExp": 5334.999999997932,
-      "baseSp": 502,
+      "baseExp": 21339.999999991727,
+      "baseSp": 2008,
       "expModifier": 1.224747474747
     },
     "raidBoss": false,
@@ -269257,8 +269257,8 @@
     "minions": [],
     "name": "Hallate's Maid",
     "progression": {
-      "baseExp": 4963.999999999788,
-      "baseSp": 467,
+      "baseExp": 19855.999999999152,
+      "baseSp": 1868,
       "expModifier": 1.139577594123
     },
     "raidBoss": false,
@@ -269827,8 +269827,8 @@
     "minions": [],
     "name": "Platinum Tribe Soldier",
     "progression": {
-      "baseExp": 5764.000000001631,
-      "baseSp": 549,
+      "baseExp": 23056.000000006523,
+      "baseSp": 2196,
       "expModifier": 1.284027623079
     },
     "raidBoss": false,
@@ -270369,8 +270369,8 @@
     "minions": [],
     "name": "Hallate's Commander",
     "progression": {
-      "baseExp": 5183.999999998847,
-      "baseSp": 493,
+      "baseExp": 20735.999999995387,
+      "baseSp": 1972,
       "expModifier": 1.154822900423
     },
     "raidBoss": false,
@@ -270891,8 +270891,8 @@
     "minions": [],
     "name": "Hallate's Inspector",
     "progression": {
-      "baseExp": 5413.99999999976,
-      "baseSp": 523,
+      "baseExp": 21655.99999999904,
+      "baseSp": 2092,
       "expModifier": 1.170847750865
     },
     "raidBoss": false,
@@ -271411,8 +271411,8 @@
     "minions": [],
     "name": "Platinum Tribe Archer",
     "progression": {
-      "baseExp": 7650.000000000544,
-      "baseSp": 739,
+      "baseExp": 22950.00000000163,
+      "baseSp": 2217,
       "expModifier": 1.654411764706
     },
     "raidBoss": false,
@@ -271904,8 +271904,8 @@
     "minions": [],
     "name": "Platinum Tribe Warrior",
     "progression": {
-      "baseExp": 5990.999999998086,
-      "baseSp": 586,
+      "baseExp": 23963.999999992346,
+      "baseSp": 2344,
       "expModifier": 1.258349086326
     },
     "raidBoss": false,
@@ -272407,8 +272407,8 @@
     "minions": [],
     "name": "Platinum Tribe Shaman",
     "progression": {
-      "baseExp": 5881.0000000017,
-      "baseSp": 583,
+      "baseExp": 29405.0000000085,
+      "baseSp": 2915,
       "expModifier": 1.200204081633
     },
     "raidBoss": false,
@@ -272931,8 +272931,8 @@
     "minions": [],
     "name": "Platinum Tribe Overlord",
     "progression": {
-      "baseExp": 8448.999999999149,
-      "baseSp": 847,
+      "baseExp": 42244.99999999574,
+      "baseSp": 4235,
       "expModifier": 1.676056338028
     },
     "raidBoss": false,
@@ -274742,8 +274742,8 @@
     "minions": [],
     "name": "Mardian",
     "progression": {
-      "baseExp": 2251.000000000584,
-      "baseSp": 150,
+      "baseExp": 4502.000000001168,
+      "baseSp": 300,
       "expModifier": 1.276077097506
     },
     "raidBoss": false,
@@ -275783,8 +275783,8 @@
     "minions": [],
     "name": "Pirate Zombie",
     "progression": {
-      "baseExp": 2831.99999999928,
-      "baseSp": 194,
+      "baseExp": 5663.99999999856,
+      "baseSp": 388,
       "expModifier": 1.462809917355
     },
     "raidBoss": false,
@@ -281266,8 +281266,8 @@
     "minions": [],
     "name": "Elmo-Aden's Lady",
     "progression": {
-      "baseExp": 7512.999999999975,
-      "baseSp": 698,
+      "baseExp": 15025.99999999995,
+      "baseSp": 1396,
       "expModifier": 1.778224852071
     },
     "raidBoss": false,
@@ -281768,8 +281768,8 @@
     "minions": [],
     "name": "Hallate's Follower Mul",
     "progression": {
-      "baseExp": 7606.000000001728,
-      "baseSp": 735,
+      "baseExp": 15212.000000003456,
+      "baseSp": 1470,
       "expModifier": 1.644896193772
     },
     "raidBoss": false,
@@ -282291,8 +282291,8 @@
     "minions": [],
     "name": "Binder",
     "progression": {
-      "baseExp": 10342.000000000342,
-      "baseSp": 1064,
+      "baseExp": 20684.000000000684,
+      "baseSp": 2128,
       "expModifier": 1.940701820229
     },
     "raidBoss": false,
@@ -282767,8 +282767,8 @@
     "minions": [],
     "name": "Sairon",
     "progression": {
-      "baseExp": 5524.000000000524,
-      "baseSp": 440,
+      "baseExp": 11048.000000001048,
+      "baseSp": 880,
       "expModifier": 1.894375857339
     },
     "raidBoss": false,
@@ -283743,8 +283743,8 @@
     "minions": [],
     "name": "Swamp Tribe",
     "progression": {
-      "baseExp": 5139.00000000045,
-      "baseSp": 357,
+      "baseExp": 10278.0000000009,
+      "baseSp": 714,
       "expModifier": 2.537777777778
     },
     "raidBoss": false,
@@ -285939,8 +285939,8 @@
     "minions": [],
     "name": "Ogre",
     "progression": {
-      "baseExp": 3593.99999999996,
-      "baseSp": 224,
+      "baseExp": 1796.99999999998,
+      "baseSp": 112,
       "expModifier": 2.48891966759
     },
     "raidBoss": false,
@@ -286462,8 +286462,8 @@
     "minions": [],
     "name": "Hallate's Guardian",
     "progression": {
-      "baseExp": 6395.999999998617,
-      "baseSp": 625,
+      "baseExp": 25583.999999994467,
+      "baseSp": 2500,
       "expModifier": 1.343415248897
     },
     "raidBoss": false,
@@ -287093,8 +287093,8 @@
     "minions": [],
     "name": "Platinum Guardian Archer",
     "progression": {
-      "baseExp": 8009.000000000394,
-      "baseSp": 803,
+      "baseExp": 32036.000000001575,
+      "baseSp": 3212,
       "expModifier": 1.588772069034
     },
     "raidBoss": false,
@@ -287658,8 +287658,8 @@
     "minions": [],
     "name": "Platinum Guardian Warrior",
     "progression": {
-      "baseExp": 6036.000000000768,
-      "baseSp": 613,
+      "baseExp": 30180.000000003838,
+      "baseSp": 3065,
       "expModifier": 1.164351851852
     },
     "raidBoss": false,
@@ -288174,8 +288174,8 @@
     "minions": [],
     "name": "Platinum Guardian Shaman",
     "progression": {
-      "baseExp": 6529.000000000324,
-      "baseSp": 672,
+      "baseExp": 32645.00000000162,
+      "baseSp": 3360,
       "expModifier": 1.225182961156
     },
     "raidBoss": false,
@@ -288875,8 +288875,8 @@
     "minions": [],
     "name": "Platinum Guardian Prefect",
     "progression": {
-      "baseExp": 8909.000000002525,
-      "baseSp": 928,
+      "baseExp": 44545.000000012624,
+      "baseSp": 4640,
       "expModifier": 1.626917457999
     },
     "raidBoss": false,
@@ -289510,8 +289510,8 @@
     "minions": [],
     "name": "Platinum Guardian Chief",
     "progression": {
-      "baseExp": 6752.000000002499,
-      "baseSp": 712,
+      "baseExp": 33760.0000000125,
+      "baseSp": 3560,
       "expModifier": 1.200355555556
     },
     "raidBoss": false,
@@ -290076,8 +290076,8 @@
     "minions": [],
     "name": "Slaughter Bathin",
     "progression": {
-      "baseExp": 6995.000000001699,
-      "baseSp": 631,
+      "baseExp": 13990.000000003398,
+      "baseSp": 1262,
       "expModifier": 1.762408667171
     },
     "raidBoss": false,
@@ -290578,8 +290578,8 @@
     "minions": [],
     "name": "Magus Valac",
     "progression": {
-      "baseExp": 8481.000000001899,
-      "baseSp": 841,
+      "baseExp": 16962.000000003798,
+      "baseSp": 1682,
       "expModifier": 1.730816326531
     },
     "raidBoss": false,
@@ -291080,8 +291080,8 @@
     "minions": [],
     "name": "Power Angel Amon",
     "progression": {
-      "baseExp": 8886.999999999374,
-      "baseSp": 937,
+      "baseExp": 17773.99999999875,
+      "baseSp": 1874,
       "expModifier": 1.579911111111
     },
     "raidBoss": false,
@@ -294301,8 +294301,8 @@
     "minions": [],
     "name": "Catacomb Barbed Bat",
     "progression": {
-      "baseExp": 654.999999999742,
-      "baseSp": 31,
+      "baseExp": 2619.999999998968,
+      "baseSp": 124,
       "expModifier": 1.238185255198
     },
     "raidBoss": false,
@@ -294667,8 +294667,8 @@
     "minions": [],
     "name": "Catacomb Wisp",
     "progression": {
-      "baseExp": 788.000000000148,
-      "baseSp": 39,
+      "baseExp": 3152.000000000592,
+      "baseSp": 156,
       "expModifier": 1.165680473373
     },
     "raidBoss": false,
@@ -295057,8 +295057,8 @@
     "minions": [],
     "name": "Catacomb Serpent",
     "progression": {
-      "baseExp": 926.00000000032,
-      "baseSp": 48,
+      "baseExp": 3704.00000000128,
+      "baseSp": 192,
       "expModifier": 1.18112244898
     },
     "raidBoss": false,
@@ -295466,8 +295466,8 @@
     "minions": [],
     "name": "Grave Keeper Spartoi",
     "progression": {
-      "baseExp": 927.00000000002,
-      "baseSp": 49,
+      "baseExp": 3708.00000000008,
+      "baseSp": 196,
       "expModifier": 1.10225921522
     },
     "raidBoss": false,
@@ -295878,8 +295878,8 @@
     "minions": [],
     "name": "Catacomb Scavenger Bat",
     "progression": {
-      "baseExp": 1041.999999999552,
-      "baseSp": 57,
+      "baseExp": 4167.999999998207,
+      "baseSp": 228,
       "expModifier": 1.084287200832
     },
     "raidBoss": false,
@@ -296289,8 +296289,8 @@
     "minions": [],
     "name": "Catacomb Shadow",
     "progression": {
-      "baseExp": 1253.99999999978,
-      "baseSp": 73,
+      "baseExp": 5015.999999999121,
+      "baseSp": 292,
       "expModifier": 1.084775086505
     },
     "raidBoss": false,
@@ -296725,8 +296725,8 @@
     "minions": [],
     "name": "Catacomb Stakato Soldier",
     "progression": {
-      "baseExp": 1610.999999999876,
-      "baseSp": 100,
+      "baseExp": 6443.999999999504,
+      "baseSp": 400,
       "expModifier": 1.115650969529
     },
     "raidBoss": false,
@@ -297223,8 +297223,8 @@
     "minions": [],
     "name": "Grave Keeper Dark Horror",
     "progression": {
-      "baseExp": 1735,
-      "baseSp": 112,
+      "baseExp": 6940.000000000001,
+      "baseSp": 448,
       "expModifier": 1.084375
     },
     "raidBoss": false,
@@ -297635,8 +297635,8 @@
     "minions": [],
     "name": "Catacomb Gargoyle",
     "progression": {
-      "baseExp": 2113.999999999251,
-      "baseSp": 143,
+      "baseExp": 8455.999999997004,
+      "baseSp": 572,
       "expModifier": 1.143320713899
     },
     "raidBoss": false,
@@ -298070,8 +298070,8 @@
     "minions": [],
     "name": "Catacomb Liviona",
     "progression": {
-      "baseExp": 2100.000000000672,
-      "baseSp": 143,
+      "baseExp": 8400.000000002688,
+      "baseSp": 572,
       "expModifier": 1.084710743802
     },
     "raidBoss": false,
@@ -298549,8 +298549,8 @@
     "minions": [],
     "name": "Decayed Ancient Pikeman",
     "progression": {
-      "baseExp": 2418.999999999304,
-      "baseSp": 171,
+      "baseExp": 9675.999999997217,
+      "baseSp": 684,
       "expModifier": 1.143194706994
     },
     "raidBoss": false,
@@ -299030,8 +299030,8 @@
     "minions": [],
     "name": "Decayed Ancient Soldier",
     "progression": {
-      "baseExp": 2744.999999999985,
-      "baseSp": 203,
+      "baseExp": 10979.99999999994,
+      "baseSp": 812,
       "expModifier": 1.143273635985
     },
     "raidBoss": false,
@@ -299485,8 +299485,8 @@
     "minions": [],
     "name": "Decayed Ancient Knight",
     "progression": {
-      "baseExp": 2858,
-      "baseSp": 215,
+      "baseExp": 11432,
+      "baseSp": 860,
       "expModifier": 1.1432
     },
     "raidBoss": false,
@@ -300031,8 +300031,8 @@
     "minions": [],
     "name": "Purgatory Wisp",
     "progression": {
-      "baseExp": 3046.999999999001,
-      "baseSp": 239,
+      "baseExp": 12187.999999996004,
+      "baseSp": 956,
       "expModifier": 1.084727661089
     },
     "raidBoss": false,
@@ -300597,8 +300597,8 @@
     "minions": [],
     "name": "Purgatory Serpent",
     "progression": {
-      "baseExp": 3585.999999999424,
-      "baseSp": 294,
+      "baseExp": 14343.999999997697,
+      "baseSp": 1176,
       "expModifier": 1.143494897959
     },
     "raidBoss": false,
@@ -301073,8 +301073,8 @@
     "minions": [],
     "name": "Hell Keeper Medusa",
     "progression": {
-      "baseExp": 3753.000000001616,
-      "baseSp": 317,
+      "baseExp": 15012.000000006463,
+      "baseSp": 1268,
       "expModifier": 1.115636147444
     },
     "raidBoss": false,
@@ -301571,8 +301571,8 @@
     "minions": [],
     "name": "Purgatory Conjurer",
     "progression": {
-      "baseExp": 3776.000000000472,
-      "baseSp": 322,
+      "baseExp": 15104.000000001888,
+      "baseSp": 1288,
       "expModifier": 1.084745762712
     },
     "raidBoss": false,
@@ -302137,8 +302137,8 @@
     "minions": [],
     "name": "Purgatory Shadow",
     "progression": {
-      "baseExp": 4035.999999999725,
-      "baseSp": 355,
+      "baseExp": 16143.9999999989,
+      "baseSp": 1420,
       "expModifier": 1.084654662725
     },
     "raidBoss": false,
@@ -302661,8 +302661,8 @@
     "minions": [],
     "name": "Purgatory Tarantula",
     "progression": {
-      "baseExp": 4569,
-      "baseSp": 418,
+      "baseExp": 18276,
+      "baseSp": 1672,
       "expModifier": 1.115478515625
     },
     "raidBoss": false,
@@ -303137,8 +303137,8 @@
     "minions": [],
     "name": "Hell Keeper Crimson Doll",
     "progression": {
-      "baseExp": 5132.9999999995,
-      "baseSp": 488,
+      "baseExp": 20531.999999998,
+      "baseSp": 1952,
       "expModifier": 1.1434617955
     },
     "raidBoss": false,
@@ -303655,8 +303655,8 @@
     "minions": [],
     "name": "Purgatory Gargoyle",
     "progression": {
-      "baseExp": 5286.999999999184,
-      "baseSp": 510,
+      "baseExp": 21147.999999996737,
+      "baseSp": 2040,
       "expModifier": 1.143382352941
     },
     "raidBoss": false,
@@ -304178,8 +304178,8 @@
     "minions": [],
     "name": "Purgatory Liviona",
     "progression": {
-      "baseExp": 5467.999999999271,
-      "baseSp": 548,
+      "baseExp": 21871.999999997086,
+      "baseSp": 2192,
       "expModifier": 1.084705415592
     },
     "raidBoss": false,
@@ -304674,8 +304674,8 @@
     "minions": [],
     "name": "Lesser Ancient Soldier",
     "progression": {
-      "baseExp": 5944.99999999974,
-      "baseSp": 611,
+      "baseExp": 23779.99999999896,
+      "baseSp": 2444,
       "expModifier": 1.11559392006
     },
     "raidBoss": false,
@@ -305194,8 +305194,8 @@
     "minions": [],
     "name": "Lesser Ancient Scout",
     "progression": {
-      "baseExp": 5940.000000001755,
-      "baseSp": 619,
+      "baseExp": 23760.00000000702,
+      "baseSp": 2476,
       "expModifier": 1.084733382031
     },
     "raidBoss": false,
@@ -305695,8 +305695,8 @@
     "minions": [],
     "name": "Lesser Ancient Shaman",
     "progression": {
-      "baseExp": 6265.000000000319,
-      "baseSp": 669,
+      "baseExp": 25060.000000001277,
+      "baseSp": 2676,
       "expModifier": 1.08466066482
     },
     "raidBoss": false,
@@ -306196,8 +306196,8 @@
     "minions": [],
     "name": "Guardian Spirit of Ancient Holy Ground",
     "progression": {
-      "baseExp": 7136.000000001688,
-      "baseSp": 791,
+      "baseExp": 28544.000000006752,
+      "baseSp": 3164,
       "expModifier": 1.143406505368
     },
     "raidBoss": false,
@@ -306676,8 +306676,8 @@
     "minions": [],
     "name": "Lesser Ancient Warrior",
     "progression": {
-      "baseExp": 7761,
-      "baseSp": 871,
+      "baseExp": 31044,
+      "baseSp": 3484,
       "expModifier": 1.21265625
     },
     "raidBoss": false,
@@ -307163,8 +307163,8 @@
     "minions": [],
     "name": "Lith Scout",
     "progression": {
-      "baseExp": 593.99999999991,
-      "baseSp": 27,
+      "baseExp": 2375.99999999964,
+      "baseSp": 108,
       "expModifier": 1.34693877551
     },
     "raidBoss": false,
@@ -307559,8 +307559,8 @@
     "minions": [],
     "name": "Lith Witch",
     "progression": {
-      "baseExp": 690.000000000192,
-      "baseSp": 34,
+      "baseExp": 2760.000000000768,
+      "baseSp": 136,
       "expModifier": 1.197916666667
     },
     "raidBoss": false,
@@ -308043,8 +308043,8 @@
     "minions": [],
     "name": "Lith Warrior",
     "progression": {
-      "baseExp": 855.000000000117,
-      "baseSp": 43,
+      "baseExp": 3420.000000000468,
+      "baseSp": 172,
       "expModifier": 1.172839506173
     },
     "raidBoss": false,
@@ -308464,8 +308464,8 @@
     "minions": [],
     "name": "Lith Guard",
     "progression": {
-      "baseExp": 1133.0000000001,
-      "baseSp": 62,
+      "baseExp": 4532.0000000004,
+      "baseSp": 248,
       "expModifier": 1.258888888889
     },
     "raidBoss": false,
@@ -308934,8 +308934,8 @@
     "minions": [],
     "name": "Lith Medium",
     "progression": {
-      "baseExp": 1306.999999999881,
-      "baseSp": 75,
+      "baseExp": 5227.999999999523,
+      "baseSp": 300,
       "expModifier": 1.200183654729
     },
     "raidBoss": false,
@@ -309448,8 +309448,8 @@
     "minions": [],
     "name": "Lith Overlord",
     "progression": {
-      "baseExp": 1668.9999999996,
-      "baseSp": 101,
+      "baseExp": 6675.999999998399,
+      "baseSp": 404,
       "expModifier": 1.287808641975
     },
     "raidBoss": false,
@@ -310073,8 +310073,8 @@
     "minions": [],
     "name": "Lith Patrolman",
     "progression": {
-      "baseExp": 1972.000000000602,
-      "baseSp": 125,
+      "baseExp": 7888.000000002408,
+      "baseSp": 500,
       "expModifier": 1.296515450362
     },
     "raidBoss": false,
@@ -310587,8 +310587,8 @@
     "minions": [],
     "name": "Lith Shaman",
     "progression": {
-      "baseExp": 2118.000000000276,
-      "baseSp": 141,
+      "baseExp": 8472.000000001104,
+      "baseSp": 564,
       "expModifier": 1.200680272109
     },
     "raidBoss": false,
@@ -311078,8 +311078,8 @@
     "minions": [],
     "name": "Lith Commander",
     "progression": {
-      "baseExp": 2731.000000000725,
-      "baseSp": 190,
+      "baseExp": 10924.0000000029,
+      "baseSp": 760,
       "expModifier": 1.348641975309
     },
     "raidBoss": false,
@@ -311587,8 +311587,8 @@
     "minions": [],
     "name": "Lilim Butcher",
     "progression": {
-      "baseExp": 3093.000000000768,
-      "baseSp": 226,
+      "baseExp": 12372.000000003072,
+      "baseSp": 904,
       "expModifier": 1.342447916667
     },
     "raidBoss": false,
@@ -312073,8 +312073,8 @@
     "minions": [],
     "name": "Lilim Magus",
     "progression": {
-      "baseExp": 3122.999999998722,
-      "baseSp": 238,
+      "baseExp": 12491.999999994887,
+      "baseSp": 952,
       "expModifier": 1.200692041522
     },
     "raidBoss": false,
@@ -312679,8 +312679,8 @@
     "minions": [],
     "name": "Lilim Knight Errant",
     "progression": {
-      "baseExp": 4384.999999999044,
-      "baseSp": 349,
+      "baseExp": 17539.999999996176,
+      "baseSp": 1396,
       "expModifier": 1.503772290809
     },
     "raidBoss": false,
@@ -313284,8 +313284,8 @@
     "minions": [],
     "name": "Lilim Marauder",
     "progression": {
-      "baseExp": 4697.00000000001,
-      "baseSp": 390,
+      "baseExp": 18788.00000000004,
+      "baseSp": 1560,
       "expModifier": 1.44567559249
     },
     "raidBoss": false,
@@ -313908,8 +313908,8 @@
     "minions": [],
     "name": "Lilim Priest",
     "progression": {
-      "baseExp": 4322.0000000016,
-      "baseSp": 375,
+      "baseExp": 17288.0000000064,
+      "baseSp": 1500,
       "expModifier": 1.200555555556
     },
     "raidBoss": false,
@@ -314487,8 +314487,8 @@
     "minions": [],
     "name": "Lilim Knight",
     "progression": {
-      "baseExp": 6489.000000001449,
-      "baseSp": 586,
+      "baseExp": 25956.000000005795,
+      "baseSp": 2344,
       "expModifier": 1.634920634921
     },
     "raidBoss": false,
@@ -315042,8 +315042,8 @@
     "minions": [],
     "name": "Lilim Assassin",
     "progression": {
-      "baseExp": 6867.999999999468,
-      "baseSp": 646,
+      "baseExp": 27471.99999999787,
+      "baseSp": 2584,
       "expModifier": 1.576675849403
     },
     "raidBoss": false,
@@ -315639,8 +315639,8 @@
     "minions": [],
     "name": "Lilim Soldier",
     "progression": {
-      "baseExp": 5717.000000000889,
-      "baseSp": 559,
+      "baseExp": 22868.000000003558,
+      "baseSp": 2236,
       "expModifier": 1.200798151649
     },
     "raidBoss": false,
@@ -316122,8 +316122,8 @@
     "minions": [],
     "name": "Lilim Knight Captain",
     "progression": {
-      "baseExp": 8475.000000000193,
-      "baseSp": 861,
+      "baseExp": 33900.00000000077,
+      "baseSp": 3444,
       "expModifier": 1.634837962963
     },
     "raidBoss": false,
@@ -316591,8 +316591,8 @@
     "minions": [],
     "name": "Lilim Slayer",
     "progression": {
-      "baseExp": 8868.999999999374,
-      "baseSp": 935,
+      "baseExp": 35475.9999999975,
+      "baseSp": 3740,
       "expModifier": 1.576711111111
     },
     "raidBoss": false,
@@ -317056,8 +317056,8 @@
     "minions": [],
     "name": "Lilim Great Mystic",
     "progression": {
-      "baseExp": 7305.000000001703,
-      "baseSp": 799,
+      "baseExp": 29220.000000006814,
+      "baseSp": 3196,
       "expModifier": 1.200690335306
     },
     "raidBoss": false,
@@ -317591,8 +317591,8 @@
     "minions": [],
     "name": "Lilim Court Knight",
     "progression": {
-      "baseExp": 10464,
-      "baseSp": 1174,
+      "baseExp": 41856,
+      "baseSp": 4696,
       "expModifier": 1.635
     },
     "raidBoss": false,
@@ -318081,8 +318081,8 @@
     "minions": [],
     "name": "Gigant Slave",
     "progression": {
-      "baseExp": 593.99999999991,
-      "baseSp": 27,
+      "baseExp": 2375.99999999964,
+      "baseSp": 108,
       "expModifier": 1.34693877551
     },
     "raidBoss": false,
@@ -318476,8 +318476,8 @@
     "minions": [],
     "name": "Gigant Acolyte",
     "progression": {
-      "baseExp": 690.000000000192,
-      "baseSp": 34,
+      "baseExp": 2760.000000000768,
+      "baseSp": 136,
       "expModifier": 1.197916666667
     },
     "raidBoss": false,
@@ -318937,8 +318937,8 @@
     "minions": [],
     "name": "Gigant Overseer",
     "progression": {
-      "baseExp": 855.000000000117,
-      "baseSp": 43,
+      "baseExp": 3420.000000000468,
+      "baseSp": 172,
       "expModifier": 1.172839506173
     },
     "raidBoss": false,
@@ -319379,8 +319379,8 @@
     "minions": [],
     "name": "Gigant Footman",
     "progression": {
-      "baseExp": 1133.0000000001,
-      "baseSp": 62,
+      "baseExp": 4532.0000000004,
+      "baseSp": 248,
       "expModifier": 1.258888888889
     },
     "raidBoss": false,
@@ -319826,8 +319826,8 @@
     "minions": [],
     "name": "Gigant Cleric",
     "progression": {
-      "baseExp": 1306.999999999881,
-      "baseSp": 75,
+      "baseExp": 5227.999999999523,
+      "baseSp": 300,
       "expModifier": 1.200183654729
     },
     "raidBoss": false,
@@ -320339,8 +320339,8 @@
     "minions": [],
     "name": "Gigant Officer",
     "progression": {
-      "baseExp": 1668.9999999996,
-      "baseSp": 101,
+      "baseExp": 6675.999999998399,
+      "baseSp": 404,
       "expModifier": 1.287808641975
     },
     "raidBoss": false,
@@ -320919,8 +320919,8 @@
     "minions": [],
     "name": "Gigant Raider",
     "progression": {
-      "baseExp": 1972.000000000602,
-      "baseSp": 125,
+      "baseExp": 7888.000000002408,
+      "baseSp": 500,
       "expModifier": 1.296515450362
     },
     "raidBoss": false,
@@ -321410,8 +321410,8 @@
     "minions": [],
     "name": "Gigant Confessor",
     "progression": {
-      "baseExp": 2118.000000000276,
-      "baseSp": 141,
+      "baseExp": 8472.000000001104,
+      "baseSp": 564,
       "expModifier": 1.200680272109
     },
     "raidBoss": false,
@@ -321922,8 +321922,8 @@
     "minions": [],
     "name": "Gigant Commander",
     "progression": {
-      "baseExp": 2731.000000000725,
-      "baseSp": 190,
+      "baseExp": 10924.0000000029,
+      "baseSp": 760,
       "expModifier": 1.348641975309
     },
     "raidBoss": false,
@@ -322380,8 +322380,8 @@
     "minions": [],
     "name": "Nephilim Sentinel",
     "progression": {
-      "baseExp": 3093.000000000768,
-      "baseSp": 226,
+      "baseExp": 12372.000000003072,
+      "baseSp": 904,
       "expModifier": 1.342447916667
     },
     "raidBoss": false,
@@ -322843,8 +322843,8 @@
     "minions": [],
     "name": "Nephilim Priest",
     "progression": {
-      "baseExp": 3390.999999999471,
-      "baseSp": 258,
+      "baseExp": 13563.999999997883,
+      "baseSp": 1032,
       "expModifier": 1.303729334871
     },
     "raidBoss": false,
@@ -323449,8 +323449,8 @@
     "minions": [],
     "name": "Nephilim Swordsman",
     "progression": {
-      "baseExp": 4384.999999999044,
-      "baseSp": 349,
+      "baseExp": 17539.999999996176,
+      "baseSp": 1396,
       "expModifier": 1.503772290809
     },
     "raidBoss": false,
@@ -324031,8 +324031,8 @@
     "minions": [],
     "name": "Nephilim Guard",
     "progression": {
-      "baseExp": 4697.00000000001,
-      "baseSp": 390,
+      "baseExp": 18788.00000000004,
+      "baseSp": 1560,
       "expModifier": 1.44567559249
     },
     "raidBoss": false,
@@ -324654,8 +324654,8 @@
     "minions": [],
     "name": "Nephilim Bishop",
     "progression": {
-      "baseExp": 4694.000000000399,
-      "baseSp": 407,
+      "baseExp": 18776.000000001597,
+      "baseSp": 1628,
       "expModifier": 1.303888888889
     },
     "raidBoss": false,
@@ -325255,8 +325255,8 @@
     "minions": [],
     "name": "Nephilim Centurion",
     "progression": {
-      "baseExp": 6489.000000001449,
-      "baseSp": 586,
+      "baseExp": 25956.000000005795,
+      "baseSp": 2344,
       "expModifier": 1.634920634921
     },
     "raidBoss": false,
@@ -325787,8 +325787,8 @@
     "minions": [],
     "name": "Nephilim Scout",
     "progression": {
-      "baseExp": 6867.999999999468,
-      "baseSp": 646,
+      "baseExp": 27471.99999999787,
+      "baseSp": 2584,
       "expModifier": 1.576675849403
     },
     "raidBoss": false,
@@ -326383,8 +326383,8 @@
     "minions": [],
     "name": "Nephilim Archbishop",
     "progression": {
-      "baseExp": 6208.000000000992,
-      "baseSp": 607,
+      "baseExp": 24832.00000000397,
+      "baseSp": 2428,
       "expModifier": 1.303927746272
     },
     "raidBoss": false,
@@ -326894,8 +326894,8 @@
     "minions": [],
     "name": "Nephilim Praetorian",
     "progression": {
-      "baseExp": 8475.000000000193,
-      "baseSp": 861,
+      "baseExp": 33900.00000000077,
+      "baseSp": 3444,
       "expModifier": 1.634837962963
     },
     "raidBoss": false,
@@ -327406,8 +327406,8 @@
     "minions": [],
     "name": "Nephilim Royal Guard",
     "progression": {
-      "baseExp": 8868.999999999374,
-      "baseSp": 935,
+      "baseExp": 35475.9999999975,
+      "baseSp": 3740,
       "expModifier": 1.576711111111
     },
     "raidBoss": false,
@@ -327892,8 +327892,8 @@
     "minions": [],
     "name": "Nephilim Cardinal",
     "progression": {
-      "baseExp": 7933.000000001544,
-      "baseSp": 868,
+      "baseExp": 31732.000000006177,
+      "baseSp": 3472,
       "expModifier": 1.303911900066
     },
     "raidBoss": false,
@@ -328427,8 +328427,8 @@
     "minions": [],
     "name": "Nephilim Commander",
     "progression": {
-      "baseExp": 10464,
-      "baseSp": 1174,
+      "baseExp": 41856,
+      "baseSp": 4696,
       "expModifier": 1.635
     },
     "raidBoss": false,
@@ -328800,8 +328800,8 @@
     "minions": [],
     "name": "Holy Land Watchman",
     "progression": {
-      "baseExp": 521,
-      "baseSp": 23,
+      "baseExp": 2084,
+      "baseSp": 92,
       "expModifier": 1.3025
     },
     "raidBoss": false,
@@ -329146,8 +329146,8 @@
     "minions": [],
     "name": "Holy Land Seer",
     "progression": {
-      "baseExp": 611.999999999828,
-      "baseSp": 29,
+      "baseExp": 2447.999999999312,
+      "baseSp": 116,
       "expModifier": 1.264462809917
     },
     "raidBoss": false,
@@ -329557,8 +329557,8 @@
     "minions": [],
     "name": "Vault Guardian",
     "progression": {
-      "baseExp": 780,
-      "baseSp": 39,
+      "baseExp": 3120,
+      "baseSp": 156,
       "expModifier": 1.248
     },
     "raidBoss": false,
@@ -329968,8 +329968,8 @@
     "minions": [],
     "name": "Vault Seer",
     "progression": {
-      "baseExp": 830.000000000169,
-      "baseSp": 42,
+      "baseExp": 3320.000000000676,
+      "baseSp": 168,
       "expModifier": 1.138545953361
     },
     "raidBoss": false,
@@ -330379,8 +330379,8 @@
     "minions": [],
     "name": "Holy Land Monk",
     "progression": {
-      "baseExp": 1110,
-      "baseSp": 62,
+      "baseExp": 4440,
+      "baseSp": 248,
       "expModifier": 1.083984375
     },
     "raidBoss": false,
@@ -330806,8 +330806,8 @@
     "minions": [],
     "name": "Vault Sentinel",
     "progression": {
-      "baseExp": 1399.999999999825,
-      "baseSp": 83,
+      "baseExp": 5599.9999999993,
+      "baseSp": 332,
       "expModifier": 1.142857142857
     },
     "raidBoss": false,
@@ -331217,8 +331217,8 @@
     "minions": [],
     "name": "Vault Monk",
     "progression": {
-      "baseExp": 1485.000000000439,
-      "baseSp": 91,
+      "baseExp": 5940.000000001755,
+      "baseSp": 364,
       "expModifier": 1.084733382031
     },
     "raidBoss": false,
@@ -331628,8 +331628,8 @@
     "minions": [],
     "name": "Holy Land Priest",
     "progression": {
-      "baseExp": 1912.999999999284,
-      "baseSp": 127,
+      "baseExp": 7651.999999997137,
+      "baseSp": 508,
       "expModifier": 1.084467120181
     },
     "raidBoss": false,
@@ -332083,8 +332083,8 @@
     "minions": [],
     "name": "Vault Overlord",
     "progression": {
-      "baseExp": 2314.999999999575,
-      "baseSp": 161,
+      "baseExp": 9259.999999998301,
+      "baseSp": 644,
       "expModifier": 1.143209876543
     },
     "raidBoss": false,
@@ -332406,8 +332406,8 @@
     "minions": [],
     "name": "Vault Priest",
     "progression": {
-      "baseExp": 2395.999999999468,
-      "baseSp": 171,
+      "baseExp": 9583.999999997872,
+      "baseSp": 684,
       "expModifier": 1.084653689452
     },
     "raidBoss": false,
@@ -332949,8 +332949,8 @@
     "minions": [],
     "name": "Sepulcher Inquisitor",
     "progression": {
-      "baseExp": 2932.999999998848,
-      "baseSp": 227,
+      "baseExp": 11731.999999995392,
+      "baseSp": 908,
       "expModifier": 1.084689349112
     },
     "raidBoss": false,
@@ -333448,8 +333448,8 @@
     "minions": [],
     "name": "Sepulcher Archon",
     "progression": {
-      "baseExp": 3458.9999999995,
-      "baseSp": 279,
+      "baseExp": 13835.999999998001,
+      "baseSp": 1116,
       "expModifier": 1.14347107438
     },
     "raidBoss": false,
@@ -333969,8 +333969,8 @@
     "minions": [],
     "name": "Sepulcher Inquisitor",
     "progression": {
-      "baseExp": 3524.000000000868,
-      "baseSp": 293,
+      "baseExp": 14096.000000003472,
+      "baseSp": 1172,
       "expModifier": 1.084641428132
     },
     "raidBoss": false,
@@ -334424,8 +334424,8 @@
     "minions": [],
     "name": "Sepulcher Guardian",
     "progression": {
-      "baseExp": 3827.9999999988,
-      "baseSp": 332,
+      "baseExp": 15311.9999999952,
+      "baseSp": 1328,
       "expModifier": 1.063333333333
     },
     "raidBoss": false,
@@ -334794,8 +334794,8 @@
     "minions": [],
     "name": "Sepulcher Sage",
     "progression": {
-      "baseExp": 4168.999999999816,
-      "baseSp": 371,
+      "baseExp": 16675.999999999265,
+      "baseSp": 1484,
       "expModifier": 1.084547346514
     },
     "raidBoss": false,
@@ -335205,8 +335205,8 @@
     "minions": [],
     "name": "Sepulcher Guardian",
     "progression": {
-      "baseExp": 4831.000000001174,
-      "baseSp": 448,
+      "baseExp": 19324.000000004697,
+      "baseSp": 1792,
       "expModifier": 1.143431952663
     },
     "raidBoss": false,
@@ -335617,8 +335617,8 @@
     "minions": [],
     "name": "Sepulcher Sage",
     "progression": {
-      "baseExp": 5444.000000000095,
-      "baseSp": 518,
+      "baseExp": 21776.000000000382,
+      "baseSp": 2072,
       "expModifier": 1.212742258855
     },
     "raidBoss": false,
@@ -336118,8 +336118,8 @@
     "minions": [],
     "name": "Sepulcher Guard",
     "progression": {
-      "baseExp": 5210.999999999501,
-      "baseSp": 516,
+      "baseExp": 20843.999999998003,
+      "baseSp": 2064,
       "expModifier": 1.063469387755
     },
     "raidBoss": false,
@@ -336594,8 +336594,8 @@
     "minions": [],
     "name": "Sepulcher Preacher",
     "progression": {
-      "baseExp": 5622.999999998399,
-      "baseSp": 571,
+      "baseExp": 22491.999999993597,
+      "baseSp": 2284,
       "expModifier": 1.084683641975
     },
     "raidBoss": false,
@@ -337071,8 +337071,8 @@
     "minions": [],
     "name": "Sepulcher Guard",
     "progression": {
-      "baseExp": 6432.000000001874,
-      "baseSp": 678,
+      "baseExp": 25728.000000007498,
+      "baseSp": 2712,
       "expModifier": 1.143466666667
     },
     "raidBoss": false,
@@ -337571,8 +337571,8 @@
     "minions": [],
     "name": "Sepulcher Preacher",
     "progression": {
-      "baseExp": 6430.999999999575,
-      "baseSp": 696,
+      "baseExp": 25723.9999999983,
+      "baseSp": 2784,
       "expModifier": 1.084668578175
     },
     "raidBoss": false,
@@ -338006,8 +338006,8 @@
     "minions": [],
     "name": "Barrow Sentinel",
     "progression": {
-      "baseExp": 956.9999999997,
-      "baseSp": 52,
+      "baseExp": 3827.9999999988,
+      "baseSp": 208,
       "expModifier": 1.063333333333
     },
     "raidBoss": false,
@@ -338594,8 +338594,8 @@
     "minions": [],
     "name": "Barrow Monk",
     "progression": {
-      "baseExp": 1110,
-      "baseSp": 62,
+      "baseExp": 4440,
+      "baseSp": 248,
       "expModifier": 1.083984375
     },
     "raidBoss": false,
@@ -338999,8 +338999,8 @@
     "minions": [],
     "name": "Grave Sentinel",
     "progression": {
-      "baseExp": 1399.999999999825,
-      "baseSp": 83,
+      "baseExp": 5599.9999999993,
+      "baseSp": 332,
       "expModifier": 1.142857142857
     },
     "raidBoss": false,
@@ -339410,8 +339410,8 @@
     "minions": [],
     "name": "Grave Monk",
     "progression": {
-      "baseExp": 1485.000000000439,
-      "baseSp": 91,
+      "baseExp": 5940.000000001755,
+      "baseSp": 364,
       "expModifier": 1.084733382031
     },
     "raidBoss": false,
@@ -339821,8 +339821,8 @@
     "minions": [],
     "name": "Barrow Overlord",
     "progression": {
-      "baseExp": 1701,
-      "baseSp": 110,
+      "baseExp": 6804.000000000001,
+      "baseSp": 440,
       "expModifier": 1.063125
     },
     "raidBoss": false,
@@ -340255,8 +340255,8 @@
     "minions": [],
     "name": "Barrow Priest",
     "progression": {
-      "baseExp": 1912.999999999284,
-      "baseSp": 127,
+      "baseExp": 7651.999999997137,
+      "baseSp": 508,
       "expModifier": 1.084467120181
     },
     "raidBoss": false,
@@ -340754,8 +340754,8 @@
     "minions": [],
     "name": "Grave Overlord",
     "progression": {
-      "baseExp": 2314.999999999575,
-      "baseSp": 161,
+      "baseExp": 9259.999999998301,
+      "baseSp": 644,
       "expModifier": 1.143209876543
     },
     "raidBoss": false,
@@ -341297,8 +341297,8 @@
     "minions": [],
     "name": "Grave Priest",
     "progression": {
-      "baseExp": 2395.999999999468,
-      "baseSp": 171,
+      "baseExp": 9583.999999997872,
+      "baseSp": 684,
       "expModifier": 1.084653689452
     },
     "raidBoss": false,
@@ -341730,8 +341730,8 @@
     "minions": [],
     "name": "Crypt Archon",
     "progression": {
-      "baseExp": 2658,
-      "baseSp": 200,
+      "baseExp": 10632,
+      "baseSp": 800,
       "expModifier": 1.0632
     },
     "raidBoss": false,
@@ -342164,8 +342164,8 @@
     "minions": [],
     "name": "Crypt Inquisitor",
     "progression": {
-      "baseExp": 2932.999999998848,
-      "baseSp": 227,
+      "baseExp": 11731.999999995392,
+      "baseSp": 908,
       "expModifier": 1.084689349112
     },
     "raidBoss": false,
@@ -342707,8 +342707,8 @@
     "minions": [],
     "name": "Tomb Archon",
     "progression": {
-      "baseExp": 3458.9999999995,
-      "baseSp": 279,
+      "baseExp": 13835.999999998001,
+      "baseSp": 1116,
       "expModifier": 1.14347107438
     },
     "raidBoss": false,
@@ -343272,8 +343272,8 @@
     "minions": [],
     "name": "Tomb Inquisitor",
     "progression": {
-      "baseExp": 3524.000000000868,
-      "baseSp": 293,
+      "baseExp": 14096.000000003472,
+      "baseSp": 1172,
       "expModifier": 1.084641428132
     },
     "raidBoss": false,
@@ -343837,8 +343837,8 @@
     "minions": [],
     "name": "Crypt Guardian",
     "progression": {
-      "baseExp": 3827.9999999988,
-      "baseSp": 332,
+      "baseExp": 15311.9999999952,
+      "baseSp": 1328,
       "expModifier": 1.063333333333
     },
     "raidBoss": false,
@@ -344273,8 +344273,8 @@
     "minions": [],
     "name": "Crypt Sage",
     "progression": {
-      "baseExp": 4168.999999999816,
-      "baseSp": 371,
+      "baseExp": 16675.999999999265,
+      "baseSp": 1484,
       "expModifier": 1.084547346514
     },
     "raidBoss": false,
@@ -344794,8 +344794,8 @@
     "minions": [],
     "name": "Tomb Guardian",
     "progression": {
-      "baseExp": 4831.000000001174,
-      "baseSp": 448,
+      "baseExp": 19324.000000004697,
+      "baseSp": 1792,
       "expModifier": 1.143431952663
     },
     "raidBoss": false,
@@ -345359,8 +345359,8 @@
     "minions": [],
     "name": "Tomb Sage",
     "progression": {
-      "baseExp": 5444.000000000095,
-      "baseSp": 518,
+      "baseExp": 21776.000000000382,
+      "baseSp": 2072,
       "expModifier": 1.212742258855
     },
     "raidBoss": false,
@@ -345882,8 +345882,8 @@
     "minions": [],
     "name": "Crypt Guard",
     "progression": {
-      "baseExp": 5210.999999999501,
-      "baseSp": 516,
+      "baseExp": 20843.999999998003,
+      "baseSp": 2064,
       "expModifier": 1.063469387755
     },
     "raidBoss": false,
@@ -346406,8 +346406,8 @@
     "minions": [],
     "name": "Crypt Preacher",
     "progression": {
-      "baseExp": 5622.999999998399,
-      "baseSp": 571,
+      "baseExp": 22491.999999993597,
+      "baseSp": 2284,
       "expModifier": 1.084683641975
     },
     "raidBoss": false,
@@ -346833,8 +346833,8 @@
     "minions": [],
     "name": "Tomb Guard",
     "progression": {
-      "baseExp": 6432.000000001874,
-      "baseSp": 678,
+      "baseExp": 25728.000000007498,
+      "baseSp": 2712,
       "expModifier": 1.143466666667
     },
     "raidBoss": false,
@@ -347267,8 +347267,8 @@
     "minions": [],
     "name": "Tomb Preacher",
     "progression": {
-      "baseExp": 7190.000000002204,
-      "baseSp": 778,
+      "baseExp": 28760.000000008815,
+      "baseSp": 3112,
       "expModifier": 1.212683420476
     },
     "raidBoss": false,
@@ -347791,8 +347791,8 @@
     "minions": [],
     "name": "Kookaburra",
     "progression": {
-      "baseExp": 8355.99999999881,
-      "baseSp": 796,
+      "baseExp": 4177.999999999405,
+      "baseSp": 398,
       "expModifier": 1.86143907329
     },
     "raidBoss": false,
@@ -348310,8 +348310,8 @@
     "minions": [],
     "name": "Kookaburra",
     "progression": {
-      "baseExp": 8355.99999999881,
-      "baseSp": 796,
+      "baseExp": 4177.999999999405,
+      "baseSp": 398,
       "expModifier": 1.86143907329
     },
     "raidBoss": false,
@@ -348829,8 +348829,8 @@
     "minions": [],
     "name": "Kookaburra",
     "progression": {
-      "baseExp": 8355.99999999881,
-      "baseSp": 796,
+      "baseExp": 4177.999999999405,
+      "baseSp": 398,
       "expModifier": 1.86143907329
     },
     "raidBoss": false,
@@ -349348,8 +349348,8 @@
     "minions": [],
     "name": "Kookaburra",
     "progression": {
-      "baseExp": 5875.000000001266,
-      "baseSp": 560,
+      "baseExp": 2937.500000000633,
+      "baseSp": 280,
       "expModifier": 1.308754733794
     },
     "raidBoss": false,
@@ -349802,8 +349802,8 @@
     "minions": [],
     "name": "Antelope",
     "progression": {
-      "baseExp": 8608.000000001248,
-      "baseSp": 832,
+      "baseExp": 4304.000000000624,
+      "baseSp": 416,
       "expModifier": 1.861591695502
     },
     "raidBoss": false,
@@ -350255,8 +350255,8 @@
     "minions": [],
     "name": "Antelope",
     "progression": {
-      "baseExp": 8608.000000001248,
-      "baseSp": 832,
+      "baseExp": 4304.000000000624,
+      "baseSp": 416,
       "expModifier": 1.861591695502
     },
     "raidBoss": false,
@@ -350708,8 +350708,8 @@
     "minions": [],
     "name": "Antelope",
     "progression": {
-      "baseExp": 8608.000000001248,
-      "baseSp": 832,
+      "baseExp": 4304.000000000624,
+      "baseSp": 416,
       "expModifier": 1.861591695502
     },
     "raidBoss": false,
@@ -351161,8 +351161,8 @@
     "minions": [],
     "name": "Antelope",
     "progression": {
-      "baseExp": 6052.000000001089,
-      "baseSp": 584,
+      "baseExp": 3026.000000000544,
+      "baseSp": 292,
       "expModifier": 1.308823529412
     },
     "raidBoss": false,
@@ -351615,8 +351615,8 @@
     "minions": [],
     "name": "Bandersnatch",
     "progression": {
-      "baseExp": 9039.999999998745,
-      "baseSp": 884,
+      "baseExp": 4519.999999999372,
+      "baseSp": 442,
       "expModifier": 1.898760764545
     },
     "raidBoss": false,
@@ -352068,8 +352068,8 @@
     "minions": [],
     "name": "Bandersnatch",
     "progression": {
-      "baseExp": 9039.999999998745,
-      "baseSp": 884,
+      "baseExp": 4519.999999999372,
+      "baseSp": 442,
       "expModifier": 1.898760764545
     },
     "raidBoss": false,
@@ -352521,8 +352521,8 @@
     "minions": [],
     "name": "Bandersnatch",
     "progression": {
-      "baseExp": 9039.999999998745,
-      "baseSp": 884,
+      "baseExp": 4519.999999999372,
+      "baseSp": 442,
       "expModifier": 1.898760764545
     },
     "raidBoss": false,
@@ -352974,8 +352974,8 @@
     "minions": [],
     "name": "Bandersnatch",
     "progression": {
-      "baseExp": 6356.000000000034,
-      "baseSp": 622,
+      "baseExp": 3178.000000000017,
+      "baseSp": 311,
       "expModifier": 1.335013652594
     },
     "raidBoss": false,
@@ -353516,8 +353516,8 @@
     "minions": [],
     "name": "Buffalo",
     "progression": {
-      "baseExp": 9121.0000000021,
-      "baseSp": 904,
+      "baseExp": 4560.50000000105,
+      "baseSp": 452,
       "expModifier": 1.861428571429
     },
     "raidBoss": false,
@@ -354057,8 +354057,8 @@
     "minions": [],
     "name": "Buffalo",
     "progression": {
-      "baseExp": 9121.0000000021,
-      "baseSp": 904,
+      "baseExp": 4560.50000000105,
+      "baseSp": 452,
       "expModifier": 1.861428571429
     },
     "raidBoss": false,
@@ -354598,8 +354598,8 @@
     "minions": [],
     "name": "Buffalo",
     "progression": {
-      "baseExp": 9121.0000000021,
-      "baseSp": 904,
+      "baseExp": 4560.50000000105,
+      "baseSp": 452,
       "expModifier": 1.861428571429
     },
     "raidBoss": false,
@@ -355139,8 +355139,8 @@
     "minions": [],
     "name": "Buffalo",
     "progression": {
-      "baseExp": 6412.9999999996,
-      "baseSp": 636,
+      "baseExp": 3206.4999999998,
+      "baseSp": 318,
       "expModifier": 1.308775510204
     },
     "raidBoss": false,
@@ -355593,8 +355593,8 @@
     "minions": [],
     "name": "Grendel",
     "progression": {
-      "baseExp": 9571.999999999382,
-      "baseSp": 960,
+      "baseExp": 4785.999999999691,
+      "baseSp": 480,
       "expModifier": 1.898829597302
     },
     "raidBoss": false,
@@ -356047,8 +356047,8 @@
     "minions": [],
     "name": "Grendel",
     "progression": {
-      "baseExp": 9571.999999999382,
-      "baseSp": 960,
+      "baseExp": 4785.999999999691,
+      "baseSp": 480,
       "expModifier": 1.898829597302
     },
     "raidBoss": false,
@@ -356501,8 +356501,8 @@
     "minions": [],
     "name": "Grendel",
     "progression": {
-      "baseExp": 9571.999999999382,
-      "baseSp": 960,
+      "baseExp": 4785.999999999691,
+      "baseSp": 480,
       "expModifier": 1.898829597302
     },
     "raidBoss": false,
@@ -356955,8 +356955,8 @@
     "minions": [],
     "name": "Grendel",
     "progression": {
-      "baseExp": 6730.000000001334,
-      "baseSp": 676,
+      "baseExp": 3365.000000000667,
+      "baseSp": 338,
       "expModifier": 1.335052568935
     },
     "raidBoss": false,
@@ -357410,8 +357410,8 @@
     "minions": [],
     "name": "Canyon Antelope",
     "progression": {
-      "baseExp": 6893.000000002208,
-      "baseSp": 666,
+      "baseExp": 13786.000000004417,
+      "baseSp": 1332,
       "expModifier": 1.490700692042
     },
     "raidBoss": false,
@@ -357863,8 +357863,8 @@
     "minions": [],
     "name": "Canyon Antelope Slave",
     "progression": {
-      "baseExp": 7310.999999998935,
-      "baseSp": 715,
+      "baseExp": 14621.99999999787,
+      "baseSp": 1430,
       "expModifier": 1.535601764335
     },
     "raidBoss": false,
@@ -358273,8 +358273,8 @@
     "minions": [],
     "name": "Canyon Bandersnatch",
     "progression": {
-      "baseExp": 7244.0000000011,
-      "baseSp": 718,
+      "baseExp": 21732.0000000033,
+      "baseSp": 2154,
       "expModifier": 1.478367346939
     },
     "raidBoss": false,
@@ -358682,8 +358682,8 @@
     "minions": [],
     "name": "Canyon Bandersnatch Slave",
     "progression": {
-      "baseExp": 7274.999999997844,
-      "baseSp": 730,
+      "baseExp": 21824.99999999353,
+      "baseSp": 2190,
       "expModifier": 1.443166038484
     },
     "raidBoss": false,
@@ -359247,8 +359247,8 @@
     "minions": [],
     "name": "Eye of Restrainer",
     "progression": {
-      "baseExp": 7022.999999998191,
-      "baseSp": 705,
+      "baseExp": 14045.999999996382,
+      "baseSp": 1410,
       "expModifier": 1.393175957151
     },
     "raidBoss": false,
@@ -359725,8 +359725,8 @@
     "minions": [],
     "name": "Buffalo Slave",
     "progression": {
-      "baseExp": 7480.999999997568,
-      "baseSp": 760,
+      "baseExp": 22442.999999992702,
+      "baseSp": 2280,
       "expModifier": 1.443094135802
     },
     "raidBoss": false,
@@ -360158,8 +360158,8 @@
     "minions": [],
     "name": "Eye of Guide",
     "progression": {
-      "baseExp": 7360.000000001281,
-      "baseSp": 747,
+      "baseExp": 22080.00000000384,
+      "baseSp": 2241,
       "expModifier": 1.41975308642
     },
     "raidBoss": false,
@@ -360594,8 +360594,8 @@
     "minions": [],
     "name": "Gaze of Nightmare",
     "progression": {
-      "baseExp": 6624.000000001151,
-      "baseSp": 673,
+      "baseExp": 26496.000000004606,
+      "baseSp": 2692,
       "expModifier": 1.277777777778
     },
     "raidBoss": false,
@@ -361053,8 +361053,8 @@
     "minions": [],
     "name": "Eye of Watchman",
     "progression": {
-      "baseExp": 7105.000000001119,
-      "baseSp": 731,
+      "baseExp": 21315.000000003354,
+      "baseSp": 2193,
       "expModifier": 1.333270782511
     },
     "raidBoss": false,
@@ -361536,8 +361536,8 @@
     "minions": [],
     "name": "Homunculus",
     "progression": {
-      "baseExp": 7184.99999999901,
-      "baseSp": 739,
+      "baseExp": 21554.999999997028,
+      "baseSp": 2217,
       "expModifier": 1.348282979921
     },
     "raidBoss": false,
@@ -361993,8 +361993,8 @@
     "minions": [],
     "name": "Grendel Slave",
     "progression": {
-      "baseExp": 7918.000000000296,
-      "baseSp": 825,
+      "baseExp": 31672.000000001186,
+      "baseSp": 3300,
       "expModifier": 1.445945945946
     },
     "raidBoss": false,
@@ -362450,8 +362450,8 @@
     "minions": [],
     "name": "Eye of Pilgrim",
     "progression": {
-      "baseExp": 7774.999999998256,
-      "baseSp": 810,
+      "baseExp": 23324.99999999477,
+      "baseSp": 2430,
       "expModifier": 1.419831994156
     },
     "raidBoss": false,
@@ -362886,8 +362886,8 @@
     "minions": [],
     "name": "Disciples of Protection",
     "progression": {
-      "baseExp": 8441.00000000033,
-      "baseSp": 880,
+      "baseExp": 42205.000000001644,
+      "baseSp": 4400,
       "expModifier": 1.541453615778
     },
     "raidBoss": false,
@@ -363345,8 +363345,8 @@
     "minions": [],
     "name": "Elder Homunculus",
     "progression": {
-      "baseExp": 7394.000000000626,
-      "baseSp": 780,
+      "baseExp": 29576.000000002503,
+      "baseSp": 3120,
       "expModifier": 1.314488888889
     },
     "raidBoss": false,
@@ -363825,8 +363825,8 @@
     "minions": [],
     "name": "Disciples of Punishment",
     "progression": {
-      "baseExp": 7859.999999998126,
-      "baseSp": 829,
+      "baseExp": 39299.99999999063,
+      "baseSp": 4145,
       "expModifier": 1.397333333333
     },
     "raidBoss": false,
@@ -364307,8 +364307,8 @@
     "minions": [],
     "name": "Disciples of Punishment",
     "progression": {
-      "baseExp": 8192.0000000025,
-      "baseSp": 864,
+      "baseExp": 40960.0000000125,
+      "baseSp": 4320,
       "expModifier": 1.456355555556
     },
     "raidBoss": false,
@@ -364768,8 +364768,8 @@
     "minions": [],
     "name": "Disciples of Authority",
     "progression": {
-      "baseExp": 8071.000000000863,
-      "baseSp": 863,
+      "baseExp": 40355.000000004315,
+      "baseSp": 4315,
       "expModifier": 1.397333795014
     },
     "raidBoss": false,
@@ -365228,8 +365228,8 @@
     "minions": [],
     "name": "Disciples of Authority",
     "progression": {
-      "baseExp": 7440.999999998928,
-      "baseSp": 795,
+      "baseExp": 37204.99999999464,
+      "baseSp": 3975,
       "expModifier": 1.288261772853
     },
     "raidBoss": false,
@@ -365642,8 +365642,8 @@
     "minions": [],
     "name": "Eye of Ruler",
     "progression": {
-      "baseExp": 10751.999999999904,
-      "baseSp": 1121,
+      "baseExp": 32255.99999999971,
+      "baseSp": 3363,
       "expModifier": 1.963476990504
     },
     "raidBoss": false,
@@ -366037,8 +366037,8 @@
     "minions": [],
     "name": "Hot Springs Bandersnatchling",
     "progression": {
-      "baseExp": 8608.999999998754,
-      "baseSp": 886,
+      "baseExp": 17217.999999997508,
+      "baseSp": 1772,
       "expModifier": 1.615500093826
     },
     "raidBoss": false,
@@ -366477,8 +366477,8 @@
     "minions": [],
     "name": "Hot Springs Buffalo",
     "progression": {
-      "baseExp": 8970.999999998532,
-      "baseSp": 923,
+      "baseExp": 17941.999999997064,
+      "baseSp": 1846,
       "expModifier": 1.683430287108
     },
     "raidBoss": false,
@@ -366915,8 +366915,8 @@
     "minions": [],
     "name": "Hot Springs Flava",
     "progression": {
-      "baseExp": 10556.00000000025,
-      "baseSp": 1100,
+      "baseExp": 21112.0000000005,
+      "baseSp": 2200,
       "expModifier": 1.927684441198
     },
     "raidBoss": false,
@@ -367335,8 +367335,8 @@
     "minions": [],
     "name": "Hot Springs Atroxspawn",
     "progression": {
-      "baseExp": 8845.999999998332,
-      "baseSp": 922,
+      "baseExp": 17691.999999996664,
+      "baseSp": 1844,
       "expModifier": 1.615412710007
     },
     "raidBoss": false,
@@ -367907,8 +367907,8 @@
     "minions": [],
     "name": "Hot Springs Antelope",
     "progression": {
-      "baseExp": 9247.000000001372,
-      "baseSp": 964,
+      "baseExp": 18494.000000002743,
+      "baseSp": 1928,
       "expModifier": 1.688641344047
     },
     "raidBoss": false,
@@ -368323,8 +368323,8 @@
     "minions": [],
     "name": "Hot Springs Nepenthes",
     "progression": {
-      "baseExp": 11635.999999998749,
-      "baseSp": 1227,
+      "baseExp": 23271.999999997497,
+      "baseSp": 2454,
       "expModifier": 2.068622222222
     },
     "raidBoss": false,
@@ -368744,8 +368744,8 @@
     "minions": [],
     "name": "Hot Springs Yeti",
     "progression": {
-      "baseExp": 9470.0000000025,
-      "baseSp": 999,
+      "baseExp": 18940.000000005,
+      "baseSp": 1998,
       "expModifier": 1.683555555556
     },
     "raidBoss": false,
@@ -369160,8 +369160,8 @@
     "minions": [],
     "name": "Hot Springs Atrox",
     "progression": {
-      "baseExp": 11134.999999998416,
-      "baseSp": 1190,
+      "baseExp": 22269.99999999683,
+      "baseSp": 2380,
       "expModifier": 1.927804709141
     },
     "raidBoss": false,
@@ -369601,8 +369601,8 @@
     "minions": [],
     "name": "Hot Springs Bandersnatch",
     "progression": {
-      "baseExp": 11134.999999998416,
-      "baseSp": 1190,
+      "baseExp": 22269.99999999683,
+      "baseSp": 2380,
       "expModifier": 1.927804709141
     },
     "raidBoss": false,
@@ -370020,8 +370020,8 @@
     "minions": [],
     "name": "Hot Springs Grendel",
     "progression": {
-      "baseExp": 9752.999999997488,
-      "baseSp": 1042,
+      "baseExp": 19505.999999994976,
+      "baseSp": 2084,
       "expModifier": 1.688538781163
     },
     "raidBoss": false,
@@ -370502,8 +370502,8 @@
     "minions": [],
     "name": "Ketra Orc Footman",
     "progression": {
-      "baseExp": 9323.000000002843,
-      "baseSp": 1009,
+      "baseExp": 18646.000000005686,
+      "baseSp": 2018,
       "expModifier": 1.572440546467
     },
     "raidBoss": false,
@@ -370937,8 +370937,8 @@
     "minions": [],
     "name": "Ketra's War Hound",
     "progression": {
-      "baseExp": 9014.999999997222,
-      "baseSp": 975,
+      "baseExp": 18029.999999994445,
+      "baseSp": 1950,
       "expModifier": 1.520492494518
     },
     "raidBoss": false,
@@ -371370,8 +371370,8 @@
     "minions": [],
     "name": "Grazing Kookaburra",
     "progression": {
-      "baseExp": 9014.999999997222,
-      "baseSp": 975,
+      "baseExp": 18029.999999994445,
+      "baseSp": 1950,
       "expModifier": 1.520492494518
     },
     "raidBoss": false,
@@ -371802,8 +371802,8 @@
     "minions": [],
     "name": "Ketra Orc Raider",
     "progression": {
-      "baseExp": 10240.000000001459,
-      "baseSp": 1120,
+      "baseExp": 20480.000000002918,
+      "baseSp": 2240,
       "expModifier": 1.683103221565
     },
     "raidBoss": false,
@@ -372306,8 +372306,8 @@
     "minions": [],
     "name": "Ketra Orc Scout",
     "progression": {
-      "baseExp": 9816.000000000948,
-      "baseSp": 1074,
+      "baseExp": 19632.000000001895,
+      "baseSp": 2148,
       "expModifier": 1.613412228797
     },
     "raidBoss": false,
@@ -372761,8 +372761,8 @@
     "minions": [],
     "name": "Ketra Orc Shaman",
     "progression": {
-      "baseExp": 9954.999999999913,
-      "baseSp": 1103,
+      "baseExp": 19909.999999999825,
+      "baseSp": 2206,
       "expModifier": 1.595096939593
     },
     "raidBoss": false,
@@ -373242,8 +373242,8 @@
     "minions": [],
     "name": "Grazing Kookaburra",
     "progression": {
-      "baseExp": 9488.999999997242,
-      "baseSp": 1051,
+      "baseExp": 18977.999999994485,
+      "baseSp": 2102,
       "expModifier": 1.520429418362
     },
     "raidBoss": false,
@@ -373762,8 +373762,8 @@
     "minions": [],
     "name": "Ketra Orc Warrior",
     "progression": {
-      "baseExp": 9304,
-      "baseSp": 1044,
+      "baseExp": 18608,
+      "baseSp": 2088,
       "expModifier": 1.45375
     },
     "raidBoss": false,
@@ -374197,8 +374197,8 @@
     "minions": [],
     "name": "Ketra Orc Lieutenant",
     "progression": {
-      "baseExp": 10420,
-      "baseSp": 1169,
+      "baseExp": 20840,
+      "baseSp": 2338,
       "expModifier": 1.628125
     },
     "raidBoss": false,
@@ -374657,8 +374657,8 @@
     "minions": [],
     "name": "Grazing Windsus",
     "progression": {
-      "baseExp": 9975.999999999312,
-      "baseSp": 1133,
+      "baseExp": 19951.999999998625,
+      "baseSp": 2266,
       "expModifier": 1.520499923792
     },
     "raidBoss": false,
@@ -375111,8 +375111,8 @@
     "minions": [],
     "name": "Ketra Orc Medium",
     "progression": {
-      "baseExp": 14933.000000002588,
-      "baseSp": 1695,
+      "baseExp": 29866.000000005177,
+      "baseSp": 3390,
       "expModifier": 2.27602499619
     },
     "raidBoss": false,
@@ -375499,8 +375499,8 @@
     "minions": [],
     "name": "Ketra Orc Elite Soldier",
     "progression": {
-      "baseExp": 9624.999999998376,
-      "baseSp": 1106,
+      "baseExp": 19249.99999999675,
+      "baseSp": 2212,
       "expModifier": 1.431439619274
     },
     "raidBoss": false,
@@ -375978,8 +375978,8 @@
     "minions": [],
     "name": "Ketra Orc White Captain",
     "progression": {
-      "baseExp": 11317.000000002032,
-      "baseSp": 1300,
+      "baseExp": 22634.000000004064,
+      "baseSp": 2600,
       "expModifier": 1.683075550268
     },
     "raidBoss": false,
@@ -376438,8 +376438,8 @@
     "minions": [],
     "name": "Grazing Elder Buffalo",
     "progression": {
-      "baseExp": 10474.99999999681,
-      "baseSp": 1217,
+      "baseExp": 20949.99999999362,
+      "baseSp": 2434,
       "expModifier": 1.52053999129
     },
     "raidBoss": false,
@@ -376958,8 +376958,8 @@
     "minions": [],
     "name": "Ketra Orc Seer",
     "progression": {
-      "baseExp": 13782.999999998307,
-      "baseSp": 1602,
+      "baseExp": 27565.999999996613,
+      "baseSp": 3204,
       "expModifier": 2.000725794745
     },
     "raidBoss": false,
@@ -377395,8 +377395,8 @@
     "minions": [],
     "name": "Ketra Orc General",
     "progression": {
-      "baseExp": 10493.999999998705,
-      "baseSp": 1234,
+      "baseExp": 20987.99999999741,
+      "baseSp": 2468,
       "expModifier": 1.487244897959
     },
     "raidBoss": false,
@@ -377921,8 +377921,8 @@
     "minions": [],
     "name": "Ketra Orc Battalion Commander",
     "progression": {
-      "baseExp": 10493.999999998705,
-      "baseSp": 1234,
+      "baseExp": 20987.99999999741,
+      "baseSp": 2468,
       "expModifier": 1.487244897959
     },
     "raidBoss": false,
@@ -378425,8 +378425,8 @@
     "minions": [],
     "name": "Grazing Elder Kookaburra",
     "progression": {
-      "baseExp": 10986.000000000051,
-      "baseSp": 1307,
+      "baseExp": 21972.000000000102,
+      "baseSp": 2614,
       "expModifier": 1.520553633218
     },
     "raidBoss": false,
@@ -378901,8 +378901,8 @@
     "minions": [],
     "name": "Ketra Orc Grand Seer",
     "progression": {
-      "baseExp": 14456.000000000076,
-      "baseSp": 1720,
+      "baseExp": 28912.000000000153,
+      "baseSp": 3440,
       "expModifier": 2.000830449827
     },
     "raidBoss": false,
@@ -379295,8 +379295,8 @@
     "minions": [],
     "name": "Ketra Commander",
     "progression": {
-      "baseExp": 16399.999999997963,
-      "baseSp": 1862,
+      "baseExp": 32799.999999995925,
+      "baseSp": 3724,
       "expModifier": 2.499618960524
     },
     "raidBoss": false,
@@ -379710,8 +379710,8 @@
     "minions": [],
     "name": "Ketra's Head Shaman",
     "progression": {
-      "baseExp": 12360.000000002776,
-      "baseSp": 1471,
+      "baseExp": 24720.00000000555,
+      "baseSp": 2942,
       "expModifier": 1.710726643599
     },
     "raidBoss": false,
@@ -380165,8 +380165,8 @@
     "minions": [],
     "name": "Ketra Prophet",
     "progression": {
-      "baseExp": 18778.99999999942,
-      "baseSp": 2289,
+      "baseExp": 37557.99999999884,
+      "baseSp": 4578,
       "expModifier": 2.481041088651
     },
     "raidBoss": false,
@@ -380580,8 +380580,8 @@
     "minions": [],
     "name": "Varka Silenos Recruit",
     "progression": {
-      "baseExp": 9850.999999999774,
-      "baseSp": 1066,
+      "baseExp": 19701.99999999955,
+      "baseSp": 2132,
       "expModifier": 1.661494349806
     },
     "raidBoss": false,
@@ -381015,8 +381015,8 @@
     "minions": [],
     "name": "Varka Silenos Footman",
     "progression": {
-      "baseExp": 8487.000000000291,
-      "baseSp": 918,
+      "baseExp": 16974.000000000582,
+      "baseSp": 1836,
       "expModifier": 1.431438691179
     },
     "raidBoss": false,
@@ -381514,8 +381514,8 @@
     "minions": [],
     "name": "Grazing Antelope",
     "progression": {
-      "baseExp": 9014.999999997222,
-      "baseSp": 975,
+      "baseExp": 18029.999999994445,
+      "baseSp": 1950,
       "expModifier": 1.520492494518
     },
     "raidBoss": false,
@@ -381924,8 +381924,8 @@
     "minions": [],
     "name": "Varka Silenos Scout",
     "progression": {
-      "baseExp": 9905.99999999922,
-      "baseSp": 1084,
+      "baseExp": 19811.99999999844,
+      "baseSp": 2168,
       "expModifier": 1.628205128205
     },
     "raidBoss": false,
@@ -382384,8 +382384,8 @@
     "minions": [],
     "name": "Varka Silenos Hunter",
     "progression": {
-      "baseExp": 9816.000000000948,
-      "baseSp": 1074,
+      "baseExp": 19632.000000001895,
+      "baseSp": 2148,
       "expModifier": 1.613412228797
     },
     "raidBoss": false,
@@ -382795,8 +382795,8 @@
     "minions": [],
     "name": "Varka Silenos Shaman",
     "progression": {
-      "baseExp": 9491.99999999872,
-      "baseSp": 1052,
+      "baseExp": 18983.99999999744,
+      "baseSp": 2104,
       "expModifier": 1.520910110559
     },
     "raidBoss": false,
@@ -383232,8 +383232,8 @@
     "minions": [],
     "name": "Grazing Nepenthes",
     "progression": {
-      "baseExp": 9488.999999997242,
-      "baseSp": 1051,
+      "baseExp": 18977.999999994485,
+      "baseSp": 2102,
       "expModifier": 1.520429418362
     },
     "raidBoss": false,
@@ -383644,8 +383644,8 @@
     "minions": [],
     "name": "Varka Silenos Priest",
     "progression": {
-      "baseExp": 10277,
-      "baseSp": 1153,
+      "baseExp": 20554,
+      "baseSp": 2306,
       "expModifier": 1.60578125
     },
     "raidBoss": false,
@@ -384079,8 +384079,8 @@
     "minions": [],
     "name": "Varka Silenos Warrior",
     "progression": {
-      "baseExp": 10771,
-      "baseSp": 1209,
+      "baseExp": 21542,
+      "baseSp": 2418,
       "expModifier": 1.68296875
     },
     "raidBoss": false,
@@ -384517,8 +384517,8 @@
     "minions": [],
     "name": "Grazing Bandersnatch",
     "progression": {
-      "baseExp": 9975.999999999312,
-      "baseSp": 1133,
+      "baseExp": 19951.999999998625,
+      "baseSp": 2266,
       "expModifier": 1.520499923792
     },
     "raidBoss": false,
@@ -384927,8 +384927,8 @@
     "minions": [],
     "name": "Varka Silenos Medium",
     "progression": {
-      "baseExp": 15891.999999998903,
-      "baseSp": 1804,
+      "baseExp": 31783.999999997806,
+      "baseSp": 3608,
       "expModifier": 2.422191739064
     },
     "raidBoss": false,
@@ -385409,8 +385409,8 @@
     "minions": [],
     "name": "Varka Silenos Magus",
     "progression": {
-      "baseExp": 9624.999999998376,
-      "baseSp": 1106,
+      "baseExp": 19249.99999999675,
+      "baseSp": 2212,
       "expModifier": 1.431439619274
     },
     "raidBoss": false,
@@ -385866,8 +385866,8 @@
     "minions": [],
     "name": "Varka Silenos Officer",
     "progression": {
-      "baseExp": 11317.000000002032,
-      "baseSp": 1300,
+      "baseExp": 22634.000000004064,
+      "baseSp": 2600,
       "expModifier": 1.683075550268
     },
     "raidBoss": false,
@@ -386414,8 +386414,8 @@
     "minions": [],
     "name": "Grazing Flava",
     "progression": {
-      "baseExp": 10474.99999999681,
-      "baseSp": 1217,
+      "baseExp": 20949.99999999362,
+      "baseSp": 2434,
       "expModifier": 1.52053999129
     },
     "raidBoss": false,
@@ -386936,8 +386936,8 @@
     "minions": [],
     "name": "Varka Silenos Seer",
     "progression": {
-      "baseExp": 13271.999999999309,
-      "baseSp": 1543,
+      "baseExp": 26543.999999998618,
+      "baseSp": 3086,
       "expModifier": 1.926549571781
     },
     "raidBoss": false,
@@ -387395,8 +387395,8 @@
     "minions": [],
     "name": "Varka Silenos Great Magus",
     "progression": {
-      "baseExp": 11525.00000000328,
-      "baseSp": 1355,
+      "baseExp": 23050.00000000656,
+      "baseSp": 2710,
       "expModifier": 1.633361678005
     },
     "raidBoss": false,
@@ -387855,8 +387855,8 @@
     "minions": [],
     "name": "Varka Silenos General",
     "progression": {
-      "baseExp": 12717.999999997488,
-      "baseSp": 1496,
+      "baseExp": 25435.999999994976,
+      "baseSp": 2992,
       "expModifier": 1.802437641723
     },
     "raidBoss": false,
@@ -388271,8 +388271,8 @@
     "minions": [],
     "name": "Grazing Elder Antelope",
     "progression": {
-      "baseExp": 10986.000000000051,
-      "baseSp": 1307,
+      "baseExp": 21972.000000000102,
+      "baseSp": 2614,
       "expModifier": 1.520553633218
     },
     "raidBoss": false,
@@ -388703,8 +388703,8 @@
     "minions": [],
     "name": "Varka Silenos Great Seer",
     "progression": {
-      "baseExp": 16964.000000002525,
-      "baseSp": 2019,
+      "baseExp": 33928.00000000505,
+      "baseSp": 4038,
       "expModifier": 2.347958477509
     },
     "raidBoss": false,
@@ -389141,8 +389141,8 @@
     "minions": [],
     "name": "Varka's Commander",
     "progression": {
-      "baseExp": 15953.000000000031,
-      "baseSp": 1811,
+      "baseExp": 31906.000000000062,
+      "baseSp": 3622,
       "expModifier": 2.431489102271
     },
     "raidBoss": false,
@@ -389556,8 +389556,8 @@
     "minions": [],
     "name": "Varka's Head Magus",
     "progression": {
-      "baseExp": 12360.000000002776,
-      "baseSp": 1471,
+      "baseExp": 24720.00000000555,
+      "baseSp": 2942,
       "expModifier": 1.710726643599
     },
     "raidBoss": false,
@@ -389989,8 +389989,8 @@
     "minions": [],
     "name": "Varka's Prophet",
     "progression": {
-      "baseExp": 18081.9999999966,
-      "baseSp": 2204,
+      "baseExp": 36163.9999999932,
+      "baseSp": 4408,
       "expModifier": 2.388954947813
     },
     "raidBoss": false,
@@ -390404,8 +390404,8 @@
     "minions": [],
     "name": "Scarlet Stakato Walker",
     "progression": {
-      "baseExp": 7054.000000003009,
-      "baseSp": 772,
+      "baseExp": 35270.00000001505,
+      "baseSp": 3860,
       "expModifier": 1.159434582512
     },
     "raidBoss": false,
@@ -390926,8 +390926,8 @@
     "minions": [],
     "name": "Scarlet Stakato Soldier",
     "progression": {
-      "baseExp": 6903.999999997776,
-      "baseSp": 755,
+      "baseExp": 34519.99999998888,
+      "baseSp": 3775,
       "expModifier": 1.134779750164
     },
     "raidBoss": false,
@@ -391338,8 +391338,8 @@
     "minions": [],
     "name": "Scarlet Stakato Noble",
     "progression": {
-      "baseExp": 9829.00000000029,
-      "baseSp": 1089,
+      "baseExp": 49145.00000000145,
+      "baseSp": 5445,
       "expModifier": 1.574907867329
     },
     "raidBoss": false,
@@ -391815,8 +391815,8 @@
     "minions": [],
     "name": "Tepra Scorpion",
     "progression": {
-      "baseExp": 7097.999999999623,
-      "baseSp": 786,
+      "baseExp": 35489.999999998116,
+      "baseSp": 3930,
       "expModifier": 1.137317737542
     },
     "raidBoss": false,
@@ -392273,8 +392273,8 @@
     "minions": [],
     "name": "Tepra Scarab",
     "progression": {
-      "baseExp": 7236.999999997326,
-      "baseSp": 802,
+      "baseExp": 36184.99999998663,
+      "baseSp": 4010,
       "expModifier": 1.159589809325
     },
     "raidBoss": false,
@@ -392709,8 +392709,8 @@
     "minions": [],
     "name": "Assassin Beetle",
     "progression": {
-      "baseExp": 8414,
-      "baseSp": 944,
+      "baseExp": 42070,
+      "baseSp": 4720,
       "expModifier": 1.3146875
     },
     "raidBoss": false,
@@ -393167,8 +393167,8 @@
     "minions": [],
     "name": "Mercenary of Destruction",
     "progression": {
-      "baseExp": 10380,
-      "baseSp": 1165,
+      "baseExp": 51900,
+      "baseSp": 5825,
       "expModifier": 1.621875
     },
     "raidBoss": false,
@@ -393651,8 +393651,8 @@
     "minions": [],
     "name": "Knight of Destruction",
     "progression": {
-      "baseExp": 10396,
-      "baseSp": 1167,
+      "baseExp": 51980,
+      "baseSp": 5835,
       "expModifier": 1.624375
     },
     "raidBoss": false,
@@ -394110,8 +394110,8 @@
     "minions": [],
     "name": "Necromancer of Destruction",
     "progression": {
-      "baseExp": 8914.999999997348,
-      "baseSp": 1012,
+      "baseExp": 44574.99999998674,
+      "baseSp": 5060,
       "expModifier": 1.358786770309
     },
     "raidBoss": false,
@@ -394592,8 +394592,8 @@
     "minions": [],
     "name": "Lavastone Golem",
     "progression": {
-      "baseExp": 8584.999999997597,
-      "baseSp": 975,
+      "baseExp": 42924.99999998799,
+      "baseSp": 4875,
       "expModifier": 1.308489559518
     },
     "raidBoss": false,
@@ -395050,8 +395050,8 @@
     "minions": [],
     "name": "Magma Golem",
     "progression": {
-      "baseExp": 9174.000000000951,
-      "baseSp": 1041,
+      "baseExp": 45870.00000000476,
+      "baseSp": 5205,
       "expModifier": 1.398262459991
     },
     "raidBoss": false,
@@ -395552,8 +395552,8 @@
     "minions": [],
     "name": "Arimanes of Destruction",
     "progression": {
-      "baseExp": 7313.999999999875,
-      "baseSp": 840,
+      "baseExp": 36569.999999999374,
+      "baseSp": 4200,
       "expModifier": 1.087745389649
     },
     "raidBoss": false,
@@ -396122,8 +396122,8 @@
     "minions": [],
     "name": "Iblis of Destruction",
     "progression": {
-      "baseExp": 9221.00000000286,
-      "baseSp": 1059,
+      "baseExp": 55326.00000001716,
+      "baseSp": 6354,
       "expModifier": 1.371356335515
     },
     "raidBoss": false,
@@ -396626,8 +396626,8 @@
     "minions": [],
     "name": "Balrog of Destruction",
     "progression": {
-      "baseExp": 9888.00000000291,
-      "baseSp": 1149,
+      "baseExp": 59328.00000001746,
+      "baseSp": 6894,
       "expModifier": 1.435331688199
     },
     "raidBoss": false,
@@ -397150,8 +397150,8 @@
     "minions": [],
     "name": "Ashuras of Destruction",
     "progression": {
-      "baseExp": 11407.999999996655,
-      "baseSp": 1342,
+      "baseExp": 68447.99999997993,
+      "baseSp": 8052,
       "expModifier": 1.616780045351
     },
     "raidBoss": false,
@@ -397631,8 +397631,8 @@
     "minions": [],
     "name": "Lavasillisk",
     "progression": {
-      "baseExp": 7885.999999999579,
-      "baseSp": 916,
+      "baseExp": 47315.999999997475,
+      "baseSp": 5496,
       "expModifier": 1.144723472202
     },
     "raidBoss": false,
@@ -398174,8 +398174,8 @@
     "minions": [],
     "name": "Blazing Ifrit",
     "progression": {
-      "baseExp": 11250.999999999647,
-      "baseSp": 1323,
+      "baseExp": 67505.99999999788,
+      "baseSp": 7938,
       "expModifier": 1.594529478458
     },
     "raidBoss": false,
@@ -398588,8 +398588,8 @@
     "minions": [],
     "name": "Magma Drake",
     "progression": {
-      "baseExp": 9494.000000003076,
-      "baseSp": 1130,
+      "baseExp": 56964.00000001845,
+      "baseSp": 6780,
       "expModifier": 1.314048442907
     },
     "raidBoss": false,
@@ -399002,8 +399002,8 @@
     "minions": [],
     "name": "Lavasaurus",
     "progression": {
-      "baseExp": 8988.000000000224,
-      "baseSp": 996,
+      "baseExp": 44940.00000000112,
+      "baseSp": 4980,
       "expModifier": 1.440153821503
     },
     "raidBoss": false,
@@ -399395,8 +399395,8 @@
     "minions": [],
     "name": "Elder Lavasaurus",
     "progression": {
-      "baseExp": 9759.999999998081,
-      "baseSp": 1134,
+      "baseExp": 58559.99999998849,
+      "baseSp": 6804,
       "expModifier": 1.41675134272
     },
     "raidBoss": false,
@@ -399854,8 +399854,8 @@
     "minions": [],
     "name": "Carrion Scarab",
     "progression": {
-      "baseExp": 8182.000000000008,
-      "baseSp": 895,
+      "baseExp": 24546.000000000025,
+      "baseSp": 2685,
       "expModifier": 1.344838921762
     },
     "raidBoss": false,
@@ -400315,8 +400315,8 @@
     "minions": [],
     "name": "Carrion Scarab",
     "progression": {
-      "baseExp": 7103.000000002608,
-      "baseSp": 777,
+      "baseExp": 21309.000000007825,
+      "baseSp": 2331,
       "expModifier": 1.167488494412
     },
     "raidBoss": false,
@@ -400707,8 +400707,8 @@
     "minions": [],
     "name": "Soldier Scarab",
     "progression": {
-      "baseExp": 6743.999999997468,
-      "baseSp": 738,
+      "baseExp": 40463.99999998481,
+      "baseSp": 4428,
       "expModifier": 1.108481262327
     },
     "raidBoss": false,
@@ -401098,8 +401098,8 @@
     "minions": [],
     "name": "Soldier Scarab",
     "progression": {
-      "baseExp": 7736.000000003029,
-      "baseSp": 846,
+      "baseExp": 38680.00000001514,
+      "baseSp": 4230,
       "expModifier": 1.271531886917
     },
     "raidBoss": false,
@@ -401514,8 +401514,8 @@
     "minions": [],
     "name": "Hexa Beetle",
     "progression": {
-      "baseExp": 6610.999999999094,
-      "baseSp": 732,
+      "baseExp": 33054.999999995474,
+      "baseSp": 3660,
       "expModifier": 1.059285370934
     },
     "raidBoss": false,
@@ -401927,8 +401927,8 @@
     "minions": [],
     "name": "Hexa Beetle",
     "progression": {
-      "baseExp": 7270.999999999502,
-      "baseSp": 806,
+      "baseExp": 29083.999999998006,
+      "baseSp": 3224,
       "expModifier": 1.165037654222
     },
     "raidBoss": false,
@@ -402341,8 +402341,8 @@
     "minions": [],
     "name": "Katraxis",
     "progression": {
-      "baseExp": 7502.999999999305,
-      "baseSp": 831,
+      "baseExp": 30011.99999999722,
+      "baseSp": 3324,
       "expModifier": 1.202211184105
     },
     "raidBoss": false,
@@ -402756,8 +402756,8 @@
     "minions": [],
     "name": "Katraxis",
     "progression": {
-      "baseExp": 6928.00000000122,
-      "baseSp": 767,
+      "baseExp": 34640.0000000061,
+      "baseSp": 3835,
       "expModifier": 1.110078513059
     },
     "raidBoss": false,
@@ -403213,8 +403213,8 @@
     "minions": [],
     "name": "Tera Beetle",
     "progression": {
-      "baseExp": 14906,
-      "baseSp": 1673,
+      "baseExp": 59624,
+      "baseSp": 6692,
       "expModifier": 2.3290625
     },
     "raidBoss": false,
@@ -403673,8 +403673,8 @@
     "minions": [],
     "name": "Tera Beetle",
     "progression": {
-      "baseExp": 7145.999999999999,
-      "baseSp": 802,
+      "baseExp": 28583.999999999996,
+      "baseSp": 3208,
       "expModifier": 1.1165625
     },
     "raidBoss": false,
@@ -404219,8 +404219,8 @@
     "minions": [],
     "name": "Knight of Empire",
     "progression": {
-      "baseExp": 8454,
-      "baseSp": 949,
+      "baseExp": 42270,
+      "baseSp": 4745,
       "expModifier": 1.3209375
     },
     "raidBoss": false,
@@ -404768,8 +404768,8 @@
     "minions": [],
     "name": "Knight of Empire",
     "progression": {
-      "baseExp": 9017,
-      "baseSp": 1012,
+      "baseExp": 27051,
+      "baseSp": 3036,
       "expModifier": 1.40890625
     },
     "raidBoss": false,
@@ -405272,8 +405272,8 @@
     "minions": [],
     "name": "Royal Guard of Empire",
     "progression": {
-      "baseExp": 7358,
-      "baseSp": 825,
+      "baseExp": 36790,
+      "baseSp": 4125,
       "expModifier": 1.1496875
     },
     "raidBoss": false,
@@ -405798,8 +405798,8 @@
     "minions": [],
     "name": "Guardian Scarab",
     "progression": {
-      "baseExp": 7601.999999998797,
-      "baseSp": 863,
+      "baseExp": 38009.99999999398,
+      "baseSp": 4315,
       "expModifier": 1.158664837677
     },
     "raidBoss": false,
@@ -406324,8 +406324,8 @@
     "minions": [],
     "name": "Guardian Scarab",
     "progression": {
-      "baseExp": 7583.999999998573,
-      "baseSp": 861,
+      "baseExp": 30335.999999994292,
+      "baseSp": 3444,
       "expModifier": 1.155921353452
     },
     "raidBoss": false,
@@ -406847,8 +406847,8 @@
     "minions": [],
     "name": "Ustralith",
     "progression": {
-      "baseExp": 9682.000000000011,
-      "baseSp": 1099,
+      "baseExp": 48410.00000000006,
+      "baseSp": 5495,
       "expModifier": 1.475689681451
     },
     "raidBoss": false,
@@ -407372,8 +407372,8 @@
     "minions": [],
     "name": "Ustralith",
     "progression": {
-      "baseExp": 7445.000000000844,
-      "baseSp": 845,
+      "baseExp": 37225.00000000422,
+      "baseSp": 4225,
       "expModifier": 1.134735558604
     },
     "raidBoss": false,
@@ -407852,8 +407852,8 @@
     "minions": [],
     "name": "Assassin of Empire",
     "progression": {
-      "baseExp": 7235.999999998596,
-      "baseSp": 821,
+      "baseExp": 36179.99999999298,
+      "baseSp": 4105,
       "expModifier": 1.102880658436
     },
     "raidBoss": false,
@@ -408334,8 +408334,8 @@
     "minions": [],
     "name": "Assassin of Empire",
     "progression": {
-      "baseExp": 7299.000000002665,
-      "baseSp": 828,
+      "baseExp": 36495.00000001332,
+      "baseSp": 4140,
       "expModifier": 1.112482853224
     },
     "raidBoss": false,
@@ -408770,8 +408770,8 @@
     "minions": [],
     "name": "Imperial Commander",
     "progression": {
-      "baseExp": 8637.000000001894,
-      "baseSp": 980,
+      "baseExp": 43185.000000009466,
+      "baseSp": 4900,
       "expModifier": 1.316415180613
     },
     "raidBoss": false,
@@ -409208,8 +409208,8 @@
     "minions": [],
     "name": "Imperial Commander",
     "progression": {
-      "baseExp": 12556.999999999134,
-      "baseSp": 1425,
+      "baseExp": 75341.9999999948,
+      "baseSp": 8550,
       "expModifier": 1.913885078494
     },
     "raidBoss": false,
@@ -409711,8 +409711,8 @@
     "minions": [],
     "name": "Imperial Royal Guard",
     "progression": {
-      "baseExp": 8029.999999999452,
-      "baseSp": 922,
+      "baseExp": 32119.99999999781,
+      "baseSp": 3688,
       "expModifier": 1.194229625223
     },
     "raidBoss": false,
@@ -410169,8 +410169,8 @@
     "minions": [],
     "name": "Ashuras",
     "progression": {
-      "baseExp": 7703.999999999908,
-      "baseSp": 885,
+      "baseExp": 38519.99999999954,
+      "baseSp": 4425,
       "expModifier": 1.145746579417
     },
     "raidBoss": false,
@@ -410630,8 +410630,8 @@
     "minions": [],
     "name": "Ashuras",
     "progression": {
-      "baseExp": 7230.999999997352,
-      "baseSp": 830,
+      "baseExp": 36154.999999986765,
+      "baseSp": 4150,
       "expModifier": 1.075401546698
     },
     "raidBoss": false,
@@ -411066,8 +411066,8 @@
     "minions": [],
     "name": "Ashkenas",
     "progression": {
-      "baseExp": 9288.000000001899,
-      "baseSp": 1067,
+      "baseExp": 55728.000000011394,
+      "baseSp": 6402,
       "expModifier": 1.381320642475
     },
     "raidBoss": false,
@@ -411483,8 +411483,8 @@
     "minions": [],
     "name": "Ashkenas",
     "progression": {
-      "baseExp": 9444.000000000568,
-      "baseSp": 1085,
+      "baseExp": 56664.000000003405,
+      "baseSp": 6510,
       "expModifier": 1.404521118382
     },
     "raidBoss": false,
@@ -411922,8 +411922,8 @@
     "minions": [],
     "name": "Abraxion",
     "progression": {
-      "baseExp": 16312.0000000021,
-      "baseSp": 1896,
+      "baseExp": 65248.0000000084,
+      "baseSp": 7584,
       "expModifier": 2.367832776891
     },
     "raidBoss": false,
@@ -412362,8 +412362,8 @@
     "minions": [],
     "name": "Abraxion",
     "progression": {
-      "baseExp": 9587.000000001615,
-      "baseSp": 1114,
+      "baseExp": 38348.00000000646,
+      "baseSp": 4456,
       "expModifier": 1.391638844535
     },
     "raidBoss": false,
@@ -412799,8 +412799,8 @@
     "minions": [],
     "name": "Hasturan",
     "progression": {
-      "baseExp": 7323.999999997204,
-      "baseSp": 851,
+      "baseExp": 36619.99999998602,
+      "baseSp": 4255,
       "expModifier": 1.063144142836
     },
     "raidBoss": false,
@@ -413236,8 +413236,8 @@
     "minions": [],
     "name": "Hasturan",
     "progression": {
-      "baseExp": 7646.999999997931,
-      "baseSp": 889,
+      "baseExp": 38234.99999998965,
+      "baseSp": 4445,
       "expModifier": 1.110030483379
     },
     "raidBoss": false,
@@ -413718,8 +413718,8 @@
     "minions": [],
     "name": "Arimanes",
     "progression": {
-      "baseExp": 8800.999999999398,
-      "baseSp": 1023,
+      "baseExp": 52805.99999999639,
+      "baseSp": 6138,
       "expModifier": 1.277543910582
     },
     "raidBoss": false,
@@ -414202,8 +414202,8 @@
     "minions": [],
     "name": "Arimanes",
     "progression": {
-      "baseExp": 7506.999999997169,
-      "baseSp": 872,
+      "baseExp": 45041.99999998301,
+      "baseSp": 5232,
       "expModifier": 1.089708230512
     },
     "raidBoss": false,
@@ -414616,8 +414616,8 @@
     "minions": [],
     "name": "Chakram Beetle",
     "progression": {
-      "baseExp": 12155,
-      "baseSp": 1364,
+      "baseExp": 72930,
+      "baseSp": 8184,
       "expModifier": 1.89921875
     },
     "raidBoss": false,
@@ -415077,8 +415077,8 @@
     "minions": [],
     "name": "Seer of Blood",
     "progression": {
-      "baseExp": 23561.000000000415,
-      "baseSp": 2707,
+      "baseExp": 141366.0000000025,
+      "baseSp": 16242,
       "expModifier": 3.504015466984
     },
     "raidBoss": false,
@@ -449669,8 +449669,8 @@
     "minions": [],
     "name": "Dread Wolf",
     "progression": {
-      "baseExp": 2303,
-      "baseSp": 136,
+      "baseExp": 1151.5,
+      "baseSp": 68,
       "expModifier": 1.88
     },
     "raidBoss": false,
@@ -450166,8 +450166,8 @@
     "minions": [],
     "name": "Tasaba Lizardman",
     "progression": {
-      "baseExp": 2724.99999999984,
-      "baseSp": 164,
+      "baseExp": 1362.49999999992,
+      "baseSp": 82,
       "expModifier": 2.10262345679
     },
     "raidBoss": false,
@@ -450440,8 +450440,8 @@
     "minions": [],
     "name": "Tasaba Lizardman Shaman",
     "progression": {
-      "baseExp": 2002.999999999921,
-      "baseSp": 124,
+      "baseExp": 1001.499999999961,
+      "baseSp": 62,
       "expModifier": 1.463111760409
     },
     "raidBoss": false,
@@ -451015,8 +451015,8 @@
     "minions": [],
     "name": "Ogre",
     "progression": {
-      "baseExp": 3555.000000000404,
-      "baseSp": 222,
+      "baseExp": 1777.500000000202,
+      "baseSp": 111,
       "expModifier": 2.461911357341
     },
     "raidBoss": false,
@@ -451429,8 +451429,8 @@
     "minions": [],
     "name": "Tasaba Lizardman Sniper",
     "progression": {
-      "baseExp": 3262.999999999779,
-      "baseSp": 208,
+      "baseExp": 1631.499999999889,
+      "baseSp": 104,
       "expModifier": 2.145299145299
     },
     "raidBoss": false,
@@ -451839,8 +451839,8 @@
     "minions": [],
     "name": "Tasaba Lizardman Sniper",
     "progression": {
-      "baseExp": 4146.0000000003,
-      "baseSp": 264,
+      "baseExp": 2073.00000000015,
+      "baseSp": 132,
       "expModifier": 2.7258382643
     },
     "raidBoss": false,
@@ -452339,8 +452339,8 @@
     "minions": [],
     "name": "Lienlik",
     "progression": {
-      "baseExp": 1989.999999999648,
-      "baseSp": 126,
+      "baseExp": 994.999999999824,
+      "baseSp": 63,
       "expModifier": 1.308349769888
     },
     "raidBoss": false,
@@ -452902,8 +452902,8 @@
     "minions": [],
     "name": "Lienlik Ladd",
     "progression": {
-      "baseExp": 3836,
-      "baseSp": 248,
+      "baseExp": 1918,
+      "baseSp": 124,
       "expModifier": 2.3975
     },
     "raidBoss": false,
@@ -456198,8 +456198,8 @@
     "minions": [],
     "name": "Scarlet Stakato Noble",
     "progression": {
-      "baseExp": 9381.99999999865,
-      "baseSp": 1039,
+      "baseExp": 46909.99999999325,
+      "baseSp": 5195,
       "expModifier": 1.503284730011
     },
     "raidBoss": false,
@@ -456608,8 +456608,8 @@
     "minions": [],
     "name": "Assassin Beetle",
     "progression": {
-      "baseExp": 6804.000000000001,
-      "baseSp": 763,
+      "baseExp": 34020.00000000001,
+      "baseSp": 3815,
       "expModifier": 1.063125
     },
     "raidBoss": false,
@@ -457130,8 +457130,8 @@
     "minions": [],
     "name": "Necromancer of Destruction",
     "progression": {
-      "baseExp": 8042.000000002839,
-      "baseSp": 913,
+      "baseExp": 40210.000000014195,
+      "baseSp": 4565,
       "expModifier": 1.225727785399
     },
     "raidBoss": false,
@@ -457609,8 +457609,8 @@
     "minions": [],
     "name": "Arimanes of Destruction",
     "progression": {
-      "baseExp": 7148.000000001553,
-      "baseSp": 821,
+      "baseExp": 35740.00000000776,
+      "baseSp": 4105,
       "expModifier": 1.063057703748
     },
     "raidBoss": false,
@@ -458133,8 +458133,8 @@
     "minions": [],
     "name": "Ashuras of Destruction",
     "progression": {
-      "baseExp": 10463.00000000069,
-      "baseSp": 1230,
+      "baseExp": 62778.00000000413,
+      "baseSp": 7380,
       "expModifier": 1.482851473923
     },
     "raidBoss": false,
@@ -458612,8 +458612,8 @@
     "minions": [],
     "name": "Magma Drake",
     "progression": {
-      "baseExp": 9061.999999997675,
-      "baseSp": 1078,
+      "baseExp": 54371.99999998605,
+      "baseSp": 6468,
       "expModifier": 1.254256055363
     },
     "raidBoss": false,
@@ -459134,8 +459134,8 @@
     "minions": [],
     "name": "Ghost of Gatekeeper",
     "progression": {
-      "baseExp": 7104.000000000432,
-      "baseSp": 759,
+      "baseExp": 14208.000000000864,
+      "baseSp": 1518,
       "expModifier": 1.229916897507
     },
     "raidBoss": false,
@@ -459481,8 +459481,8 @@
     "minions": [],
     "name": "Ghost of Gatekeeper",
     "progression": {
-      "baseExp": 8710.00000000192,
-      "baseSp": 931,
+      "baseExp": 26130.000000005763,
+      "baseSp": 2793,
       "expModifier": 1.50796398892
     },
     "raidBoss": false,
@@ -459962,8 +459962,8 @@
     "minions": [],
     "name": "Ghost of Vassal",
     "progression": {
-      "baseExp": 6615.999999999005,
-      "baseSp": 716,
+      "baseExp": 13231.99999999801,
+      "baseSp": 1432,
       "expModifier": 1.115871141845
     },
     "raidBoss": false,

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -115,6 +115,7 @@ const tests = [
     'tests/test_bot_craft_telemetry.js',
     'tests/test_bot_cold_market_purchase.js',
     'tests/test_cold_inventory_jewelry.js',
+    'tests/test_cold_inventory_instance_sync.js',
     'tests/test_bot_cold_market_listing.js',
     'tests/test_bot_recipe_disposition.js',
     'tests/test_bot_inventory_cleanup_goal.js',

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -377,6 +377,7 @@ const tests = [
     'tests/test_world_observer_equipment.js',
     'tests/test_world_observer_clans.js',
     'tests/test_world_npc_grid.js',
+    'tests/test_npc_object_index.js',
     'tests/test_toggle_skills.js',
     'tests/test_ui_test_window.js'
 ];

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -155,6 +155,7 @@ const tests = [
     'tests/test_bot_population_policy.js',
     'tests/test_floor_aware_activation_policy.js',
     'tests/test_bot_population_scheduler_slices.js',
+    'tests/test_bot_protected_party_formation.js',
     'tests/test_bot_population_scheduler_telemetry.js',
     'tests/test_background_work_governor.js',
     'tests/test_background_work_governor_integration.js',

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -306,6 +306,7 @@ const tests = [
     'tests/test_sell_junk_packet_bounds.js',
     'tests/test_personal_warehouse.js',
     'tests/test_clan_player_warehouse.js',
+    'tests/test_clan_warehouse_equipment_exchange.js',
     'tests/test_clan_gear_stall_and_spoil.js',
     'tests/test_npc_social_aggro.js',
     'tests/test_npc_hot_bot_aggro.js',

--- a/src/Database.js
+++ b/src/Database.js
@@ -5155,6 +5155,85 @@ const Database = {
             };
         }, 'clan-warehouse:deposit'));
     },
+    exchangeClanWarehouseEquipment({ clanId, characterId, warehouseId, expectedPhase, validateLive, validateCold } = {}) {
+        const clan = Number(clanId);
+        const id = Number(characterId);
+        return withCharacterFlush(id, () => inTransaction(() => {
+            const Policy = invoke('GameServer/Clan/ClanWarehouseEquipmentPolicy');
+            const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
+            const member = one('SELECT id, clanId, classId, level FROM characters WHERE id = ?', [id]);
+            const life = one('SELECT * FROM bot_life_state WHERE characterId = ?', [id]);
+            const stock = one('SELECT * FROM clan_warehouse_items WHERE id = ? AND clanId = ?', [Number(warehouseId), clan]);
+            if (!member || Number(member.clanId) !== clan || !life || !stock) return { ok: false, code: 'stock_or_member_changed' };
+            if (life.phase !== expectedPhase || !['cold', 'hot'].includes(life.phase)
+                || String(life.simulationOwner || LEGACY_SIMULATION_OWNER) !== LEGACY_SIMULATION_OWNER
+                || life.phase === 'cold' && (!['hunting', 'resting', 'grouped'].includes(life.activity)
+                    || validateCold && !validateCold())) {
+                return { ok: false, code: 'member_busy' };
+            }
+            if (one(`SELECT id FROM clan_orders WHERE clanId = ? AND itemId = ?
+                AND status IN ('active', 'paused', 'blocked') LIMIT 1`, [clan, stock.selfId])) {
+                return { ok: false, code: 'item_ordered' };
+            }
+            const rows = all('SELECT * FROM items WHERE characterId = ? AND amount > 0', [id]);
+            if (life.phase === 'hot' && (typeof validateLive !== 'function' || !validateLive(member, rows))) {
+                return { ok: false, code: 'live_state_changed' };
+            }
+            const plan = Policy.plan(member, rows, stock);
+            if (!plan) return { ok: false, code: 'not_an_upgrade' };
+            const timestamp = now();
+            const simulation = one('SELECT stateJson FROM clan_simulation_clans WHERE clanId = ?', [clan]);
+            const clanState = jsonObject(simulation?.stateJson);
+            const revision = Math.max(Number(clanState.warehouseRevision || 0), Number(one(
+                'SELECT COALESCE(MAX(warehouseRevision), 0) AS revision FROM clan_warehouse_ledger WHERE clanId = ?', [clan]
+            ).revision || 0)) + 1;
+            const key = `gear-exchange:${stock.id}:${id}:${revision}`;
+            const ledger = (selfId, operation) => write(`INSERT INTO clan_warehouse_ledger
+                (clanId, characterId, selfId, amount, operation, resolveKey, warehouseRevision, createdAt)
+                VALUES (?, ?, ?, 1, ?, ?, ?, ?)`, [clan, id, selfId, operation, key, revision, timestamp]);
+            for (const old of plan.returned) {
+                const item = Policy.materialize(old);
+                write(`INSERT INTO clan_warehouse_items
+                    (clanId, selfId, name, kind, amount, enchant, petData, createdAt, updatedAt)
+                    VALUES (?, ?, ?, ?, 1, ?, ?, ?, ?)`, [
+                    clan, old.selfId, item.fetchName(), item.fetchKind(), old.enchant, old.petData, timestamp, timestamp
+                ]);
+                write('DELETE FROM items WHERE id = ? AND characterId = ?', [old.id, id]);
+                ledger(old.selfId, 'deposit');
+            }
+            if (Number(stock.amount) === 1) write('DELETE FROM clan_warehouse_items WHERE id = ?', [stock.id]);
+            else write('UPDATE clan_warehouse_items SET amount = amount - 1, updatedAt = ? WHERE id = ?', [timestamp, stock.id]);
+            const inventoryId = Number(write(`INSERT INTO items
+                (characterId, selfId, name, amount, enchant, petData, equipped, slot)
+                VALUES (?, ?, ?, 1, ?, ?, 1, ?)`, [id, stock.selfId, stock.name, stock.enchant, stock.petData, plan.slot]).insertId);
+            ledger(stock.selfId, 'withdraw');
+            const updatedRows = all('SELECT * FROM items WHERE characterId = ? AND amount > 0', [id]);
+            const physical = LifeState.inventorySummaryFromItems(updatedRows);
+            const inventory = jsonObject(life.inventorySummary);
+            for (const selfId of new Set([stock.selfId, ...plan.returned.map((row) => row.selfId)])) {
+                delete inventory[String(selfId)];
+                if (physical[String(selfId)]) inventory[String(selfId)] = physical[String(selfId)];
+            }
+            const stats = jsonObject(life.statsJson);
+            stats.equipment = LifeState.equipmentSummaryFromInventory(inventory);
+            stats.clanGearExchangeRevision = Number(life.simulationRevision || 0) + 1;
+            stats.lastClanWarehouseTransfer = { operation: 'gear_exchange', clanId: clan, selfId: stock.selfId,
+                returned: plan.returned.map((row) => ({ selfId: row.selfId, enchant: row.enchant })), at: timestamp };
+            write(`UPDATE bot_life_state SET inventorySummary = ?, statsJson = ?,
+                simulationRevision = simulationRevision + 1, updatedAt = ? WHERE characterId = ?`, [
+                JSON.stringify(inventory), JSON.stringify(stats), timestamp, id
+            ]);
+            if (simulation) {
+                clanState.warehouseRevision = revision;
+                clanState.updatedAt = timestamp;
+                write('UPDATE clan_simulation_clans SET stateJson = ?, updatedAt = ? WHERE clanId = ?', [JSON.stringify(clanState), timestamp, clan]);
+            }
+            return { ok: true, code: 'gear_exchanged', inventoryId, slot: plan.slot,
+                received: { ...stock, id: inventoryId, amount: 1, slot: plan.slot, equipped: true },
+                returned: plan.returned, state: normalizeRow(one('SELECT * FROM bot_life_state WHERE characterId = ?', [id])) };
+        }, 'clan-warehouse:gear-exchange'));
+    },
+
     transferClanWarehouseToMember({
         clanId,
         characterId,

--- a/src/Database.js
+++ b/src/Database.js
@@ -1542,12 +1542,19 @@ function syncInventorySummaryUnsafe(characterId, inventory = {}) {
         }
 
         if (Array.isArray(item.instances)) {
+            const complete = invoke('GameServer/Bot/Population/InventorySummary').completeInstances(item);
+            const identifiedIds = new Set(complete.instances.map((instance) => Number(instance.id))
+                .filter((id) => byId.get(id)?.selfId === selfId));
             const desiredIds = new Set();
-            item.instances.slice(0, amount).forEach((instance, index) => {
+            complete.instances.forEach((instance) => {
                 const instanceId = Number(instance?.id || 0);
                 const identified = instanceId > 0 ? byId.get(instanceId) : null;
-                const current = identified && Number(identified.selfId) === selfId ? identified : (!instanceId ? rows[index] : null);
                 const instanceEnchant = Math.max(0, Number(instance?.enchant ?? (hasEnchant ? enchant : 0)) || 0);
+                // Summaries can still hold a null/old id after materialization.
+                // Reuse its matching row instead of replacing it on every sync.
+                const current = identified && Number(identified.selfId) === selfId && !desiredIds.has(instanceId)
+                    ? identified : rows.find((row) => !identifiedIds.has(Number(row.id))
+                        && !desiredIds.has(Number(row.id)) && Number(row.enchant || 0) === instanceEnchant);
                 const equipped = instance?.equipped ? 1 : 0;
                 const slot = Number(instance?.slot || 0);
                 if (current) {
@@ -1557,7 +1564,8 @@ function syncInventorySummaryUnsafe(characterId, inventory = {}) {
                         write('UPDATE items SET amount = 1, enchant = ?, equipped = ?, slot = ? WHERE id = ? AND characterId = ?', [instanceEnchant, equipped, slot, current.id, characterId]);
                     }
                 } else {
-                    write('INSERT INTO items (selfId, name, amount, enchant, equipped, slot, characterId) VALUES (?, ?, 1, ?, ?, ?, ?)', [selfId, item.name || `Item ${selfId}`, instanceEnchant, equipped, slot, characterId]);
+                    const inserted = write('INSERT INTO items (selfId, name, amount, enchant, equipped, slot, characterId) VALUES (?, ?, 1, ?, ?, ?, ?)', [selfId, item.name || `Item ${selfId}`, instanceEnchant, equipped, slot, characterId]);
+                    desiredIds.add(Number(inserted.insertId));
                 }
             });
             rows.filter((row) => !desiredIds.has(Number(row.id)))
@@ -5176,6 +5184,9 @@ const Database = {
                 return { ok: false, code: 'item_ordered' };
             }
             const rows = all('SELECT * FROM items WHERE characterId = ? AND amount > 0', [id]);
+            if (life.phase === 'cold' && !Policy.inventoryMatches(rows, jsonObject(life.inventorySummary))) {
+                return { ok: false, code: 'inventory_not_materialized' };
+            }
             if (life.phase === 'hot' && (typeof validateLive !== 'function' || !validateLive(member, rows))) {
                 return { ok: false, code: 'live_state_changed' };
             }

--- a/src/GameServer/Actor/Backpack.js
+++ b/src/GameServer/Actor/Backpack.js
@@ -20,6 +20,7 @@ const C4RecipeItems  = invoke('GameServer/Items/C4RecipeItems');
 const C4MercTickets  = invoke('GameServer/Items/C4MercTickets');
 const C4BeastItems   = invoke('GameServer/Items/C4BeastItems');
 const C4SkillRules   = invoke('GameServer/Skills/C4SkillRules');
+const ItemSlot        = invoke('GameServer/Item/ItemSlot');
 const ManorData      = invoke('GameServer/Manor/ManorData');
 const SpeckMath      = invoke('GameServer/SpeckMath');
 const BotEventJournal = invoke('GameServer/Bot/AI/BotEventJournal');
@@ -201,6 +202,8 @@ class Backpack extends BackpackModel {
     useItem(session, id) {
         this.fetchItem(id, (item) => {
             if (item.isWearable()) {
+                const slot = ItemSlot.slotFor(item);
+                if (slot !== item.fetchSlot()) item.setSlot(slot);
                 this.equipGear(session, item);
             }
             else {

--- a/src/GameServer/Actor/Generics/NpcDied.js
+++ b/src/GameServer/Actor/Generics/NpcDied.js
@@ -3,6 +3,7 @@ const BotEventJournal = invoke('GameServer/Bot/AI/BotEventJournal');
 const RaidBossMinionManager = invoke('GameServer/World/RaidBossMinionManager');
 const PartyRewardMath = invoke('GameServer/Actor/PartyRewardMath');
 const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
+const NpcObjectIndex = require('../../World/NpcObjectIndex');
 
 const PARTY_REWARD_RADIUS = 2500;
 const SWEEP_RETRY_DELAY_MS = 250;
@@ -121,6 +122,7 @@ function npcDied(session, actor, npc) {
     }
 
     if (npc.fetchIsSummon?.() === true) {
+        NpcObjectIndex.remove(World, npc);
         World.npc.spawns = World.npc.spawns.filter((spawn) => spawn.fetchId() !== npc.fetchId());
         session.dataSendToMeAndOthers?.(invoke('GameServer/Network/Response').deleteOb(npc.fetchId()), npc);
         if (actor?.fetchIsSummon?.() === true) actor.attack?.clearTimers?.();

--- a/src/GameServer/Actor/Generics/NpcDied.js
+++ b/src/GameServer/Actor/Generics/NpcDied.js
@@ -82,6 +82,13 @@ function partyRewardShares(participants, exp, sp) {
         .map((share) => ({ session: participants[share.index], exp: share.exp, sp: share.sp }));
 }
 
+function clearSweepRetry(spoilerSession, retries, npcId) {
+    retries.delete(npcId);
+    if (!retries.size && spoilerSession.sweepRetriesByNpcId === retries) {
+        delete spoilerSession.sweepRetriesByNpcId;
+    }
+}
+
 function autoSweepSpoiledCorpse(npc, Generics) {
     const spoil = npc?.model?.spoil;
     const spoilerId = Number(spoil?.spoilerId || 0);
@@ -94,23 +101,41 @@ function autoSweepSpoiledCorpse(npc, Generics) {
     const spoiler = spoilerSession?.actor;
     if (!spoiler || !BotRoles.isSpoiler(spoiler)) return false;
 
+    const npcId = Number(npc.fetchId?.() || 0);
+    if (!npcId) return false;
+    if (!(spoilerSession.sweepRetriesByNpcId instanceof Map)) {
+        spoilerSession.sweepRetriesByNpcId = new Map();
+    }
+    const retries = spoilerSession.sweepRetriesByNpcId;
+
     if (spoiler.state?.fetchCasts?.()) {
-        if (!spoilerSession.sweepRetryTimer) {
-            const deadline = Number(spoilerSession.sweepRetryDeadlineAt || 0) || Date.now() + SWEEP_RETRY_WINDOW_MS;
-            if (Date.now() < deadline) {
-                spoilerSession.sweepRetryDeadlineAt = deadline;
-                const retryTimer = setTimeout(() => {
-                    spoilerSession.sweepRetryTimer = null;
-                    autoSweepSpoiledCorpse(npc, Generics);
-                }, SWEEP_RETRY_DELAY_MS);
-                retryTimer.unref?.();
-                spoilerSession.sweepRetryTimer = retryTimer;
-            }
+        const timestamp = Date.now();
+        let retry = retries.get(npcId);
+        if (!retry) {
+            retry = { deadlineAt: timestamp + SWEEP_RETRY_WINDOW_MS, timer: null };
+            retries.set(npcId, retry);
+        }
+        if (timestamp >= retry.deadlineAt) {
+            clearSweepRetry(spoilerSession, retries, npcId);
+        } else if (!retry.timer) {
+            const retryTimer = setTimeout(() => {
+                const current = retries.get(npcId);
+                if (!current || current.timer !== retryTimer) return;
+                current.timer = null;
+                autoSweepSpoiledCorpse(npc, Generics);
+                if (retries.get(npcId) === current && !current.timer) {
+                    clearSweepRetry(spoilerSession, retries, npcId);
+                }
+            }, SWEEP_RETRY_DELAY_MS);
+            retryTimer.unref?.();
+            retry.timer = retryTimer;
         }
         return false;
     }
 
-    delete spoilerSession.sweepRetryDeadlineAt;
+    const retry = retries.get(npcId);
+    if (retry?.timer) clearTimeout(retry.timer);
+    clearSweepRetry(spoilerSession, retries, npcId);
     return invoke('GameServer/Bot/BotAI').trySweep(spoilerSession, spoiler, npc, Generics);
 }
 

--- a/src/GameServer/Actor/Generics/NpcDied.js
+++ b/src/GameServer/Actor/Generics/NpcDied.js
@@ -2,8 +2,11 @@ const World = invoke('GameServer/World/World');
 const BotEventJournal = invoke('GameServer/Bot/AI/BotEventJournal');
 const RaidBossMinionManager = invoke('GameServer/World/RaidBossMinionManager');
 const PartyRewardMath = invoke('GameServer/Actor/PartyRewardMath');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 
 const PARTY_REWARD_RADIUS = 2500;
+const SWEEP_RETRY_DELAY_MS = 250;
+const SWEEP_RETRY_WINDOW_MS = 25000;
 
 function distance2d(a, b) {
     const dx = a.fetchLocX() - b.fetchLocX();
@@ -78,6 +81,38 @@ function partyRewardShares(participants, exp, sp) {
         .map((share) => ({ session: participants[share.index], exp: share.exp, sp: share.sp }));
 }
 
+function autoSweepSpoiledCorpse(npc, Generics) {
+    const spoil = npc?.model?.spoil;
+    const spoilerId = Number(spoil?.spoilerId || 0);
+    if (!spoil?.spoiled || spoil.swept || !spoilerId) return false;
+
+    const spoilerSession = (World.user?.sessions || []).find((candidate) => (
+        String(candidate?.accountId || '').startsWith('bot_')
+        && Number(candidate.actor?.fetchId?.() || 0) === spoilerId
+    ));
+    const spoiler = spoilerSession?.actor;
+    if (!spoiler || !BotRoles.isSpoiler(spoiler)) return false;
+
+    if (spoiler.state?.fetchCasts?.()) {
+        if (!spoilerSession.sweepRetryTimer) {
+            const deadline = Number(spoilerSession.sweepRetryDeadlineAt || 0) || Date.now() + SWEEP_RETRY_WINDOW_MS;
+            if (Date.now() < deadline) {
+                spoilerSession.sweepRetryDeadlineAt = deadline;
+                const retryTimer = setTimeout(() => {
+                    spoilerSession.sweepRetryTimer = null;
+                    autoSweepSpoiledCorpse(npc, Generics);
+                }, SWEEP_RETRY_DELAY_MS);
+                retryTimer.unref?.();
+                spoilerSession.sweepRetryTimer = retryTimer;
+            }
+        }
+        return false;
+    }
+
+    delete spoilerSession.sweepRetryDeadlineAt;
+    return invoke('GameServer/Bot/BotAI').trySweep(spoilerSession, spoiler, npc, Generics);
+}
+
 function npcDied(session, actor, npc) {
     const Generics = invoke(path.actor);
 
@@ -101,6 +136,11 @@ function npcDied(session, actor, npc) {
     Generics.abortCombatState(session, actor);
 
     if (actor.isDead()) return;
+
+    // Death is the authoritative end of the encounter. Let the bot that
+    // successfully marked this corpse queue exactly one Sweeper cast, whether
+    // it was a solo hunter or a party companion.
+    autoSweepSpoiledCorpse(npc, Generics);
 
     const rewardActor = ownerSession?.actor || actor;
     const participants = rewardParticipants(session, rewardActor, npc);
@@ -132,3 +172,4 @@ module.exports = npcDied;
 module.exports.PARTY_EXP_SP_BONUS = PartyRewardMath.PARTY_EXP_SP_BONUS;
 module.exports.partyRewardShares = partyRewardShares;
 module.exports.validPartyMembers = validPartyMembers;
+module.exports.autoSweepSpoiledCorpse = autoSweepSpoiledCorpse;

--- a/src/GameServer/Bot/AI/BotEquipmentCompatibility.js
+++ b/src/GameServer/Bot/AI/BotEquipmentCompatibility.js
@@ -5,11 +5,11 @@ const CASTER_BUFFER_CLASSES = new Set([17, 49, 50, 51, 52]);
 
 const CLASS_PROFILES = {
     2: {
-        weaponKinds: ['Weapon.Dual', 'Weapon.Sword', 'Weapon.Blunt'],
+        weaponKinds: ['Weapon.Dual'],
         preferredWeaponKinds: ['Weapon.Dual'],
         armorStyle: 'heavy',
         twoHandedWeaponKinds: ['Weapon.Dual'],
-        shield: true,
+        shield: false,
         weaponHint: 'dual_swords'
     },
     3: {

--- a/src/GameServer/Bot/AI/BotGear.js
+++ b/src/GameServer/Bot/AI/BotGear.js
@@ -151,9 +151,9 @@ function chooseWeapon(rank, level, role, classId) {
     const exact = chooseKinds(preferredKinds) || chooseKinds(allowedKinds);
     if (exact || !allowedKinds.includes('Weapon.Dual')) return exact;
 
-    // The current C4 item catalog ends its dual-sword combinations at B grade.
-    // Bladedancers must keep that compatible weapon until higher-grade duals
-    // are added instead of generating an empty weapon slot at level 61+.
+    // Dual-only classes must keep a compatible lower-grade dual when the
+    // current grade has no catalog entry instead of generating an empty
+    // weapon slot during a temporary progression gap.
     for (let index = RANK_ORDER.indexOf(rank) - 1; index >= 0; index--) {
         const fallback = chooseKinds(preferredKinds, RANK_ORDER[index]) || chooseKinds(allowedKinds, RANK_ORDER[index]);
         if (fallback) return fallback;

--- a/src/GameServer/Bot/AI/BotRangedCombatPositioning.js
+++ b/src/GameServer/Bot/AI/BotRangedCombatPositioning.js
@@ -4,6 +4,7 @@ const BotRetreatPlanner = invoke('GameServer/Bot/AI/BotRetreatPlanner');
 const ARCHER_KITE_TRIGGER_DISTANCE = 450;
 const ARCHER_KITE_RETREAT_DISTANCE = 500;
 const ARCHER_KITE_COOLDOWN_MS = 3500;
+const ARCHER_KITE_FAILURE_RETRY_MS = 3500;
 
 function distance2d(first, second) {
     const dx = Number(first?.fetchLocX?.() || 0) - Number(second?.fetchLocX?.() || 0);
@@ -43,6 +44,19 @@ function reposition(session, bot, target, options = {}) {
         return true;
     }
 
+    const targetId = Number(target.fetchId());
+    const failedKiteAt = Number(session.archerKiteFailureAt || 0);
+    if (session.archerKiteFailureTargetId === targetId &&
+        Date.now() - failedKiteAt < ARCHER_KITE_FAILURE_RETRY_MS) {
+        // A failed route must not be retried by the duplicate positioning
+        // guard in HuntingState and then suppress the actual combat action.
+        record(session, target, 'kite_failed', 'retreat_unusable', distance, {
+            routeUsable: false,
+            retryAt: failedKiteAt + ARCHER_KITE_FAILURE_RETRY_MS
+        });
+        return false;
+    }
+
     const now = Date.now();
     if (now < Number(session.nextArcherKiteAt || 0)) {
         // The target is still too close. Waiting is intentional: the final
@@ -56,11 +70,29 @@ function reposition(session, bot, target, options = {}) {
 
     session.nextArcherKiteAt = now + ARCHER_KITE_COOLDOWN_MS;
     const retreat = BotRetreatPlanner.retreat(session, bot, target, {
-        distance: ARCHER_KITE_RETREAT_DISTANCE
+        distance: ARCHER_KITE_RETREAT_DISTANCE,
+        requireSafe: true
     });
+    if (retreat?.safe !== true) {
+        session.archerKiteFailureTargetId = targetId;
+        session.archerKiteFailureAt = now;
+        session.nextArcherKiteAt = undefined;
+        record(session, target, 'kite_failed', retreat?.routeUsable === true
+            ? 'retreat_unsafe'
+            : 'retreat_unusable', distance, {
+            retreatDistance: ARCHER_KITE_RETREAT_DISTANCE,
+            routeSafe: retreat?.safe === true,
+            routeUsable: retreat?.routeUsable === true,
+            retryAt: now + ARCHER_KITE_FAILURE_RETRY_MS
+        });
+        return false;
+    }
+    session.archerKiteFailureTargetId = undefined;
+    session.archerKiteFailureAt = undefined;
     record(session, target, 'kite', 'target_too_close', distance, {
         retreatDistance: ARCHER_KITE_RETREAT_DISTANCE,
-        routeSafe: retreat.safe
+        routeSafe: retreat.safe,
+        routeUsable: retreat.routeUsable
     });
     return true;
 }
@@ -69,6 +101,7 @@ module.exports = {
     ARCHER_KITE_TRIGGER_DISTANCE,
     ARCHER_KITE_RETREAT_DISTANCE,
     ARCHER_KITE_COOLDOWN_MS,
+    ARCHER_KITE_FAILURE_RETRY_MS,
     distance2d,
     isAutonomousArcher,
     reposition

--- a/src/GameServer/Bot/AI/BotRetreatPlanner.js
+++ b/src/GameServer/Bot/AI/BotRetreatPlanner.js
@@ -4,6 +4,8 @@ const NpcAggro      = invoke('GameServer/Npc/NpcAggro');
 
 const DEFAULT_RETREAT_DISTANCE = 850;
 const AGGRO_BUFFER = 120;
+const SAME_FLOOR_Z_DELTA = 512;
+const RETREAT_PATH_TOLERANCE = 64;
 const CANDIDATE_ANGLES = [0, -30, 30, -60, 60, -90, 90, -120, 120];
 
 function point(actor) {
@@ -105,7 +107,7 @@ function groundHeight(geodata, to, fallbackZ) {
     }
 }
 
-function routeCandidate(options, geodata, from, requestedTo) {
+function routeCandidateOnce(options, geodata, from, requestedTo) {
     if (typeof options.previewRoute === 'function') {
         try {
             const diagnostics = options.previewRoute(from, requestedTo);
@@ -138,6 +140,30 @@ function routeCandidate(options, geodata, from, requestedTo) {
     };
 }
 
+function routeCandidate(options, geodata, from, requestedTo) {
+    const candidate = routeCandidateOnce(options, geodata, from, requestedTo);
+    const zDelta = Math.abs(Number(requestedTo.locZ) - Number(from.locZ));
+
+    // getHeight() can snap a retreat endpoint onto a neighbouring floor in a
+    // multilevel cell. If that endpoint is unreachable, retry the same XY on
+    // the floor the bot is actually standing on before declaring the escape
+    // direction unusable. The selected requestedTo is also the command sent
+    // to MoveTo, so this prevents a second pathfinding pass from restoring
+    // the bad cross-floor target.
+    if (candidate.routeUsable || zDelta <= SAME_FLOOR_Z_DELTA) return candidate;
+
+    const sameFloorTo = { ...requestedTo, locZ: from.locZ };
+    const sameFloorCandidate = routeCandidateOnce(options, geodata, from, sameFloorTo);
+    if (!sameFloorCandidate.routeUsable) return candidate;
+
+    return {
+        ...sameFloorCandidate,
+        routeStrategy: [sameFloorCandidate.routeStrategy, 'same_floor_fallback']
+            .filter(Boolean)
+            .join('_')
+    };
+}
+
 function evaluateCandidate(candidate, from, threat, hazards, aggroRadius) {
     let newAggroCount = 0;
     let endpointAggroCount = 0;
@@ -164,7 +190,7 @@ function evaluateCandidate(candidate, from, threat, hazards, aggroRadius) {
     const threatDistance = distance2d(candidate.to, threat);
     const minimumThreatDistance = distanceToRoute(threat, from, candidate);
     const movesAway = threatDistance > initialThreatDistance &&
-        minimumThreatDistance >= initialThreatDistance - 1;
+        minimumThreatDistance >= initialThreatDistance - RETREAT_PATH_TOLERANCE;
     return {
         ...candidate,
         newAggroCount,
@@ -286,7 +312,9 @@ function retreat(session, bot, threat, options = {}) {
         candidates: result.candidates.map((candidate) => ({ ...candidate })),
         at: Date.now()
     };
-    bot.moveTo({ from: result.from, to: { ...result.requestedTo } });
+    if (planOptions.requireSafe !== true || result.safe === true) {
+        bot.moveTo({ from: result.from, to: { ...result.requestedTo } });
+    }
     return result;
 }
 
@@ -294,6 +322,8 @@ module.exports = {
     AGGRO_BUFFER,
     CANDIDATE_ANGLES,
     DEFAULT_RETREAT_DISTANCE,
+    RETREAT_PATH_TOLERANCE,
+    SAME_FLOOR_Z_DELTA,
     distanceToSegment,
     plan,
     retreat

--- a/src/GameServer/Bot/AI/BotRoles.js
+++ b/src/GameServer/Bot/AI/BotRoles.js
@@ -9,8 +9,11 @@ const ROLE_CLASSES = {
     dagger: [7, 8, 23, 35, 36],
     archer: [9, 22, 24, 37],
     mage: [10, 11, 12, 13, 14, 25, 26, 27, 28, 38, 39, 40, 41],
+    spoiler: [53, 54, 55],
     crafter: [56, 57]
 };
+const DWARF_CLASS_IDS = new Set([53, 54, 55, 56, 57, 117, 118]);
+const SPOILER_CLASS_IDS = new Set([53, 54, 55, 117]);
 const MANA_REST_ROLES = new Set(['mage', 'archer', 'healer']);
 // Prophet and the Orc mystic line cast as their primary party job. Sword
 // Singer and Bladedancer share the buffer role, but they are melee fighters
@@ -60,10 +63,30 @@ function roleClassId(value) {
     return Number(ClassProgression.getThirdClass(classId)?.parentClassId || classId);
 }
 
+function levelOf(value) {
+    const raw = value && typeof value.fetchLevel === 'function'
+        ? value.fetchLevel()
+        : value?.level ?? value?.stats?.level;
+    const level = Number(raw);
+    return Number.isFinite(level) && level > 0 ? level : null;
+}
+
+function isSpoiler(value) {
+    const classId = normalizedClassId(value);
+    if (classId === null) return false;
+
+    const baseClassId = roleClassId(value);
+    if (SPOILER_CLASS_IDS.has(classId) || SPOILER_CLASS_IDS.has(baseClassId)) return true;
+
+    const level = levelOf(value);
+    return DWARF_CLASS_IDS.has(classId) && level !== null && level < 40;
+}
+
 function inferRole(value) {
     const classId = roleClassId(value);
     if (classId === null || classId === undefined) return 'dps';
 
+    if (isSpoiler(value)) return 'spoiler';
     if (ROLE_CLASSES.healer.includes(classId)) return 'healer';
     if (ROLE_CLASSES.buffer.includes(classId)) return 'buffer';
     if (ROLE_CLASSES.tank.includes(classId)) return 'tank';
@@ -75,9 +98,19 @@ function inferRole(value) {
 }
 
 function isRole(value, role) {
+    if (role === 'spoiler') return isSpoiler(value);
+    if (role === 'crafter' && isSpoiler(value)) return false;
     const classId = roleClassId(value);
     const classes = ROLE_CLASSES[role];
     return !!classes && classes.includes(classId);
+}
+
+// Crafting remains a separate economic identity, but until its dedicated
+// combat policy exists a non-spoiler dwarf should fight as a normal DPS.
+function combatRoleFor(value) {
+    if (isSpoiler(value)) return 'spoiler';
+    const role = inferRole(value);
+    return role === 'crafter' && DWARF_CLASS_IDS.has(normalizedClassId(value)) ? 'dps' : role;
 }
 
 function isHealer(value) {
@@ -149,8 +182,10 @@ module.exports = {
     NECROMANCER_CLASSES,
     className,
     roleClassId,
+    isSpoiler,
     presentation,
     inferRole,
+    combatRoleFor,
     isRole,
     isHealer,
     isTank,

--- a/src/GameServer/Bot/AI/BotStatus.js
+++ b/src/GameServer/Bot/AI/BotStatus.js
@@ -13,6 +13,7 @@ const BotInferenceBudget = invoke('GameServer/Bot/AI/BotInferenceBudget');
 const LangfuseTracing = invoke('GameServer/Bot/AI/LangfuseTracing');
 const BotTargetScorer = invoke('GameServer/Bot/AI/BotTargetScorer');
 const BotRaidSafety = invoke('GameServer/Bot/AI/BotRaidSafety');
+const NpcObjectIndex = require('../../World/NpcObjectIndex');
 
 function ratio(value, max) {
     if (!max) return 0;
@@ -109,7 +110,7 @@ function findTarget(session, bot) {
         return { type: 'user', ...actorSummary(userSession.actor, bot) };
     }
 
-    const npc = World.npc.spawns.find((ob) => ob.fetchId() === session.currentTargetId);
+    const npc = NpcObjectIndex.find(World, session.currentTargetId);
     if (npc) {
         if (BotRaidSafety.isProtectedRaidEntity(npc)) return null;
         return {

--- a/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
+++ b/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
@@ -103,6 +103,7 @@ function gradeForLevel(level) {
 }
 
 function roleFor(state = {}) {
+    if (BotRoles.isSpoiler(state)) return 'spoiler';
     return state.party?.role || state.stats?.role || BotRoles.inferRole({
         fetchClassId: () => Number(state.stats?.classId || state.classId || 0)
     }) || 'dps';

--- a/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
+++ b/src/GameServer/Bot/AI/GearAcquisitionPlanner.js
@@ -16,6 +16,7 @@ const MarketOpportunity = invoke('GameServer/Bot/Economy/MarketOpportunity');
 const NpcShopBuyLists = invoke('GameServer/World/Generics/NpcShopBuyLists');
 const BotRaidSafety = invoke('GameServer/Bot/AI/BotRaidSafety');
 const BotHuntingTargetPolicy = invoke('GameServer/Bot/AI/BotHuntingTargetPolicy');
+const InventorySummary = invoke('GameServer/Bot/Population/InventorySummary');
 
 const RANKS = ['none', 'd', 'c', 'b', 'a', 's'];
 const WEAPON_SLOTS = new Set([7, 14]);
@@ -490,12 +491,7 @@ function equipInventoryUpgrades(state = {}, inventory = {}) {
     }
     Object.values(next).forEach((owned) => {
         if (!Array.isArray(owned?.instances)) return;
-        const slots = equippedSlotsFor(owned, owned.slot);
-        owned.instances = owned.instances.map((instance, index) => ({
-            ...instance,
-            equipped: Number(slots[index] || 0) > 0,
-            slot: Number(slots[index] || 0)
-        }));
+        Object.assign(owned, InventorySummary.completeInstances(owned));
     });
     return next;
 }

--- a/src/GameServer/Bot/AI/GearSkillHints.js
+++ b/src/GameServer/Bot/AI/GearSkillHints.js
@@ -1,5 +1,4 @@
 const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
-const LevelingRoutes = invoke('GameServer/Bot/AI/LevelingRoutes');
 const BotEquipmentCompatibility = invoke('GameServer/Bot/AI/BotEquipmentCompatibility');
 
 const GRADE_BANDS = [
@@ -328,7 +327,7 @@ function actorValue(value, key, fallback = null) {
 function characterState(character = {}) {
     const classId = Number(actorValue(character, 'classId', character.stats?.classId || 0)) || null;
     const level = Number(actorValue(character, 'level', character.level || 1)) || 1;
-    const role = LevelingRoutes.ECONOMIC_ROLES[classId] || BotRoles.inferRole(classId);
+    const role = BotRoles.inferRole({ classId, level });
     return { classId, level, role };
 }
 

--- a/src/GameServer/Bot/AI/LevelingRoutes.js
+++ b/src/GameServer/Bot/AI/LevelingRoutes.js
@@ -184,6 +184,7 @@ function classIdOf(state = {}) {
 
 function roleForState(state = {}) {
     const classId = classIdOf(state);
+    if (BotRoles.isSpoiler(state)) return 'spoiler';
     if (classId && ECONOMIC_ROLES[classId]) return ECONOMIC_ROLES[classId];
     if (state.party?.role) return state.party.role;
     if (state.stats?.routeRole) return state.stats.routeRole;

--- a/src/GameServer/Bot/AI/PartyAwareness.js
+++ b/src/GameServer/Bot/AI/PartyAwareness.js
@@ -1,6 +1,7 @@
 const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 const BotRaidSafety = invoke('GameServer/Bot/AI/BotRaidSafety');
 const EffectStore = invoke('GameServer/Effects/EffectStore');
+const NpcObjectIndex = require('../../World/NpcObjectIndex');
 
 const RECENT_INCOMING_THREAT_MS = 5000;
 // Hot companions are dispatched serially, but several services inside one
@@ -90,7 +91,7 @@ function recentIncomingNpc(session, npcRadius = 2500) {
     const threatAt = Number(session?.incomingThreatAt || 0);
     if (!threatId || Date.now() - threatAt > RECENT_INCOMING_THREAT_MS || !session?.actor) return null;
 
-    const npc = (world().npc?.spawns || []).find((spawn) => actorId(spawn) === threatId);
+    const npc = NpcObjectIndex.find(world(), threatId);
     if (!npc || !npc.fetchAttackable?.() || npc.isDead?.()) return null;
     if (distance2d(actorLoc(npc), actorLoc(session.actor)) > npcRadius) return null;
 
@@ -329,7 +330,7 @@ function leaderCombatTargetId(leaderSession, options = {}) {
     if (!targetId) return null;
     if (partyActorIds(leaderSession).has(targetId)) return null;
 
-    const npc = (world().npc?.spawns || []).find((spawn) => actorId(spawn) === targetId);
+    const npc = NpcObjectIndex.find(world(), targetId);
     if (npc) {
         const protectedRaidTarget = BotRaidSafety.isProtectedRaidEntity(npc);
         const allowedRaidTarget = options.allowPlayerRaid === true &&

--- a/src/GameServer/Bot/AI/PartyCombatState.js
+++ b/src/GameServer/Bot/AI/PartyCombatState.js
@@ -1,4 +1,5 @@
 const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
+const NpcObjectIndex = require('../../World/NpcObjectIndex');
 
 function world() {
     return invoke('GameServer/World/World');
@@ -36,7 +37,7 @@ function partySessions(leaderSession, { includeDead = false } = {}) {
 function npcById(id) {
     const numericId = Number(id || 0);
     if (!numericId) return null;
-    return (world().npc?.spawns || []).find((npc) => Number(npc?.fetchId?.()) === numericId) || null;
+    return NpcObjectIndex.find(world(), numericId);
 }
 
 function isHostileNpc(npc) {

--- a/src/GameServer/Bot/AI/PartyPulling.js
+++ b/src/GameServer/Bot/AI/PartyPulling.js
@@ -6,6 +6,7 @@ const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
 const PartyCombatState = invoke('GameServer/Bot/AI/PartyCombatState');
 const BotPartyChat = invoke('GameServer/Bot/AI/BotPartyChat');
 const BotRaidSafety = invoke('GameServer/Bot/AI/BotRaidSafety');
+const NpcObjectIndex = require('../../World/NpcObjectIndex');
 
 const PULL_SEARCH_RADIUS = 2200;
 const PULL_CONTACT_DISTANCE = 260;
@@ -105,7 +106,7 @@ function traceEncounter(leaderSession, event, details = {}) {
 
 function npcById(id) {
     if (!id) return null;
-    return (World.npc?.spawns || []).find((npc) => Number(npc.fetchId?.()) === Number(id)) || null;
+    return NpcObjectIndex.find(World, Number(id));
 }
 
 function clearFinishedTarget(leaderSession) {

--- a/src/GameServer/Bot/AI/States/FleeingState.js
+++ b/src/GameServer/Bot/AI/States/FleeingState.js
@@ -1,6 +1,7 @@
 const PartyAwareness = invoke('GameServer/Bot/AI/PartyAwareness');
 const BotRetreatPlanner = invoke('GameServer/Bot/AI/BotRetreatPlanner');
 const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
+const NpcObjectIndex = require('../../../World/NpcObjectIndex');
 
 const MIN_RETREAT_MS = 1000;
 const RETREAT_REPATH_COOLDOWN_MS = 750;
@@ -31,7 +32,7 @@ function activePursuer(session, bot) {
     if (threatId === null || threatId === undefined) return null;
 
     const World = invoke('GameServer/World/World');
-    const npc = (World.npc?.spawns || []).find((spawn) => Number(spawn.fetchId?.()) === Number(threatId));
+    const npc = NpcObjectIndex.find(World, Number(threatId));
     if (!npc || npc.fetchAttackable?.() !== true || npc.isDead?.() || npc.state?.fetchDead?.()) return null;
     if (Number(npc.fetchDestId?.()) !== Number(bot.fetchId())) return null;
     return distance2d(npc, bot) < NPC_CHASE_BREAK_DISTANCE ? npc : null;

--- a/src/GameServer/Bot/AI/States/FollowingState.js
+++ b/src/GameServer/Bot/AI/States/FollowingState.js
@@ -1567,7 +1567,12 @@ module.exports = {
                     targetId: pullAction.target?.fetchId?.() || pulling.target?.fetchId?.() || null,
                     phase: pulling.phase || null
                 });
-                return;
+                // An active party fight pauses selection/delivery of the next
+                // pull, but it must not consume the puller's combat tick. Let
+                // the ordinary party-assist branch below attack the current
+                // threat; once the last mob dies, tickBotPuller resumes from
+                // the preserved pull configuration on the following tick.
+                if (pullAction.paused !== 'party_under_attack' || !partyThreat?.actor) return;
             }
         }
 

--- a/src/GameServer/Bot/AI/States/HuntingState.js
+++ b/src/GameServer/Bot/AI/States/HuntingState.js
@@ -435,6 +435,8 @@ function reconcilePhysicalSpot(session, bot) {
 function assignTarget(session, bot, target) {
     const targetId = target.fetchId();
     if (session.currentTargetId !== targetId) {
+        session.spoilAttemptedTargetId = undefined;
+        session.sweepAttemptedTargetId = undefined;
         session.targetTrackId = targetId;
         session.targetAcquiredAt = Date.now();
         session.targetLastDistance = targetDistance(bot, target);
@@ -455,6 +457,8 @@ function clearTarget(session, bot, targetId, retryCooldown = false) {
     session.targetAcquiredAt = undefined;
     session.targetLastDistance = undefined;
     session.targetStallTicks = 0;
+    session.spoilAttemptedTargetId = undefined;
+    session.sweepAttemptedTargetId = undefined;
     bot.unselect();
     return true;
 }

--- a/src/GameServer/Bot/BotAI.js
+++ b/src/GameServer/Bot/BotAI.js
@@ -50,6 +50,8 @@ const CHAT_PHRASES = {
 // into a tight synchronous AI loop.
 const WAKEUP_THROTTLE_MS = 250;
 const REAL_PLAYER_CACHE_MS = 250;
+const SPOIL_SKILL_ID = 254;
+const SWEEP_SKILL_ID = 42;
 let realPlayerCache = { world: null, revision: -1, checkedAt: 0, sessions: [] };
 
 function getRandomPhrase(category, ...args) {
@@ -120,10 +122,80 @@ function clearTacticalState(session) {
     session.lastCombatDecision = undefined;
     session.lastPvpDecision = undefined;
     session.healingPotionEncounter = undefined;
+    session.spoilAttemptedTargetId = undefined;
+    session.sweepAttemptedTargetId = undefined;
 }
 
 function recordHotStage(name, startedAt) {
     HotActorLodPolicy.recordSubsystem(name, performance.now() - startedAt, 1);
+}
+
+function targetIdOf(target) {
+    return Number(target?.fetchId?.() || 0) || null;
+}
+
+function canPaySkill(actor, skill) {
+    const cost = Math.max(0, Number(skill?.fetchConsumedMp?.() || 0));
+    return Number(actor?.fetchMp?.() || 0) >= cost;
+}
+
+function targetIsDead(target) {
+    return target?.isDead?.() === true || target?.state?.fetchDead?.() === true;
+}
+
+function trySpoil(session, bot, npc, Generics) {
+    if (!session || !bot || !npc || !BotRoles.isSpoiler(bot) || targetIsDead(npc)) return false;
+    if (npc.fetchAttackable?.() !== true) return false;
+
+    const targetId = targetIdOf(npc);
+    if (!targetId || session.spoilAttemptedTargetId === targetId) return false;
+
+    const skill = bot.skillset?.fetchSkill?.(SPOIL_SKILL_ID);
+    if (!skill || !canPaySkill(bot, skill) || bot.canUseSkill?.(skill) === false
+        || typeof Generics?.skillExec !== 'function') return false;
+
+    // The attempt is encounter-scoped. Record it only after the transient
+    // preflight gates pass, so a bot that recovers MP or leaves reuse can try
+    // Spoil again before the same mob dies.
+    session.spoilAttemptedTargetId = targetId;
+    session.lastCombatDecision = {
+        action: 'cast_spoil',
+        role: 'spoiler',
+        skillId: Number(skill.fetchSelfId?.() || SPOIL_SKILL_ID),
+        skillName: skill.fetchName?.() || 'Spoil',
+        targetId,
+        at: Date.now()
+    };
+    Generics.skillExec(session, bot, { id: targetId, selfId: SPOIL_SKILL_ID, ctrl: true });
+    return true;
+}
+
+function trySweep(session, bot, npc, Generics) {
+    if (!session || !bot || !npc || !BotRoles.isSpoiler(bot) || !targetIsDead(npc)) return false;
+    if (npc.fetchAttackable?.() !== true) return false;
+
+    const spoil = npc.model?.spoil;
+    if (!spoil?.spoiled || spoil.swept) return false;
+    if (spoil.spoilerId && Number(spoil.spoilerId) !== targetIdOf(bot)) return false;
+
+    const targetId = targetIdOf(npc);
+    if (!targetId || session.sweepAttemptedTargetId === targetId) return false;
+    if (bot.state?.fetchCasts?.()) return false;
+    const skill = bot.skillset?.fetchSkill?.(SWEEP_SKILL_ID);
+    if (!skill || !canPaySkill(bot, skill) || bot.canUseSkill?.(skill) === false
+        || typeof Generics?.skillExec !== 'function') return false;
+
+    session.sweepAttemptedTargetId = targetId;
+    session.lastCombatDecision = {
+        action: 'cast_sweep',
+        role: 'spoiler',
+        skillId: Number(skill.fetchSelfId?.() || SWEEP_SKILL_ID),
+        skillName: skill.fetchName?.() || 'Sweeper',
+        targetId,
+        at: Date.now()
+    };
+    Generics.skillExec(session, bot, { id: targetId, selfId: SWEEP_SKILL_ID, ctrl: true });
+    return true;
 }
 
 const BotAI = {
@@ -614,11 +686,14 @@ const BotAI = {
             }
             return false;
         }
-        const role = BotRoles.inferRole(bot);
+        const role = BotRoles.combatRoleFor(bot);
         // A potion is a survival action for a fight already in progress, not
         // routine topping-off. The policy also blocks repeats for the same
         // target and while a previous potion HoT remains active.
         if (HealingPotionStock.tryUseInCombat(session, bot, npc, { role })) {
+            return true;
+        }
+        if (!options.basicAttackOnly && trySpoil(session, bot, npc, Generics)) {
             return true;
         }
         if (BotRangedCombatPositioning.reposition(session, bot, npc, { role })) {
@@ -799,6 +874,10 @@ const BotAI = {
 
     summarizeStatus(session) {
         return BotStatus.summarize(this.getStatus(session));
+    },
+
+    trySweep(session, bot, npc, Generics) {
+        return trySweep(session, bot, npc, Generics);
     }
 };
 

--- a/src/GameServer/Bot/Population/BackgroundDropResolver.js
+++ b/src/GameServer/Bot/Population/BackgroundDropResolver.js
@@ -1,5 +1,8 @@
 const DataCache = invoke('GameServer/DataCache');
 const ProgressionRates = invoke('GameServer/ProgressionRates');
+const NpcSkills = invoke('GameServer/Npc/NpcSkills');
+
+const npcRewardMaxHpMultiplierCache = new Map();
 
 function rewardDataForSpot(spot, rng, npcSelfId = 0) {
     const entries = spot?.npcEntries?.length
@@ -58,6 +61,25 @@ function sourceMobLevel(rewardData, spot, npcSelfId = 0) {
     return Math.max(0, Number(npc?.template?.level || spot?.avgLevel || 0));
 }
 
+function rewardMaxHpMultiplier(npc) {
+    const npcId = Number(npc?.selfId || 0);
+    if (!npcId) return 1;
+    if (npcRewardMaxHpMultiplierCache.has(npcId)) {
+        return npcRewardMaxHpMultiplierCache.get(npcId);
+    }
+
+    // Background combat has templates rather than live Npc instances. Build
+    // the narrow source-compatible view needed to resolve permanent NPC
+    // passive skills, including Strong Type's MAX_HP multiplier.
+    const npcReference = {
+        fetchSelfId: () => npcId,
+        fetchSummonSkillId: () => Number(npc?.summonSkillId || 0)
+    };
+    const multiplier = NpcSkills.maxHpMultiplierFor(npcReference);
+    npcRewardMaxHpMultiplierCache.set(npcId, multiplier);
+    return multiplier;
+}
+
 function progressionForFight({ spot, npcSelfId = 0, rng = Math.random } = {}) {
     const rewardData = rewardDataForSpot(spot, rng, npcSelfId);
     const npc = (DataCache.npcs || []).find((entry) => Number(entry.selfId) === Number(npcSelfId || rewardData?.selfId));
@@ -65,10 +87,11 @@ function progressionForFight({ spot, npcSelfId = 0, rng = Math.random } = {}) {
     const expModifier = Number(npc?.rewards?.exp);
     const sp = Number(npc?.rewards?.sp);
     if (npc && Number.isFinite(expModifier) && Number.isFinite(sp)) {
+        const maxHpMultiplier = rewardMaxHpMultiplier(npc);
         return {
             exact: true,
-            exp: Math.max(0, level * level * expModifier),
-            sp: Math.max(0, sp)
+            exp: Math.max(0, level * level * expModifier * maxHpMultiplier),
+            sp: Math.max(0, sp * maxHpMultiplier)
         };
     }
     return {

--- a/src/GameServer/Bot/Population/BackgroundPartyComposition.js
+++ b/src/GameServer/Bot/Population/BackgroundPartyComposition.js
@@ -2,13 +2,16 @@ const SUPPORT_ROLES = ['tank', 'healer', 'buffer'];
 const DEFAULT_LEVEL_RANGE = 4;
 const PartyAffinity = invoke('GameServer/Bot/Population/BackgroundPartyAffinity');
 const PersonaPartyPolicy = invoke('GameServer/Bot/Population/PersonaPartyPolicy');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 
 function levelOf(state) {
     return Math.max(1, Number(state?.level || 1));
 }
 
 function roleForState(state) {
-    return state?.party?.role || state?.stats?.role || 'dps';
+    if (BotRoles.isSpoiler(state)) return 'spoiler';
+    const role = state?.party?.role || state?.stats?.role;
+    return role === 'crafter' ? 'dps' : role || 'dps';
 }
 
 function clanIdForState(state) {

--- a/src/GameServer/Bot/Population/BackgroundPartyResolver.js
+++ b/src/GameServer/Bot/Population/BackgroundPartyResolver.js
@@ -5,6 +5,7 @@ const ColdCombatProfile = invoke('GameServer/Bot/Population/ColdCombatProfile');
 const PartyAffinity = invoke('GameServer/Bot/Population/BackgroundPartyAffinity');
 const PartyLootAllocator = invoke('GameServer/Bot/Population/PartyLootAllocator');
 const PartyRewardMath = invoke('GameServer/Actor/PartyRewardMath');
+const BotRoles = invoke('GameServer/Bot/AI/BotRoles');
 
 const MAX_DROPS_PER_RESOLVE = 4;
 
@@ -79,10 +80,7 @@ function distributeRewards({ members, spot, wins, defeatedNpcIds = [], pressure,
     const adenaPerMember = Math.floor(totalAdena / members.length);
     const adenaRemainder = totalAdena - (adenaPerMember * members.length);
     const loot = members.map(() => []);
-    const spoilerIndex = members.findIndex((state) => (
-        String(state.stats?.role || '') === 'spoiler'
-        || [54, 55].includes(Number(state.stats?.classId ?? state.classId))
-    ));
+    const spoilerIndex = members.findIndex((state) => BotRoles.isSpoiler(state));
     for (let win = 0; win < Math.min(wins, MAX_DROPS_PER_RESOLVE); win++) {
         const drops = rewardRolls[win]?.items || [];
         if (drops.length) {

--- a/src/GameServer/Bot/Population/BackgroundResolver.js
+++ b/src/GameServer/Bot/Population/BackgroundResolver.js
@@ -28,6 +28,14 @@ function botCombatStats(state, timestamp = Date.now()) {
     return ColdCombatProfile.profileFor(state, timestamp);
 }
 
+function combatRoleForState(state) {
+    if (BotRoles.isSpoiler(state)) return 'spoiler';
+    const persistedRole = state?.party?.role || state?.stats?.role;
+    return persistedRole === 'crafter'
+        ? BotRoles.combatRoleFor(state)
+        : persistedRole || BotRoles.combatRoleFor(state);
+}
+
 const ELEMENTAL_DAMAGE_TRAITS = new Set(['fire', 'water', 'wind', 'earth', 'holy', 'dark']);
 const PHYSICAL_RACE_STATS = Object.freeze({
     animal: 'pAtk-animals',
@@ -671,7 +679,7 @@ function resolveFight({ state, spot, pressure, targetNpcId = 0, rng, timestamp =
     const soloFighter = {
         state: fightState,
         profile: bot,
-        role: BotRoles.inferRole(fightState),
+        role: BotRoles.combatRoleFor(fightState),
         vitals,
         readyAt: 0,
         summonReadyAt: Number.POSITIVE_INFINITY,
@@ -855,8 +863,7 @@ function resolveFight({ state, spot, pressure, targetNpcId = 0, rng, timestamp =
         ? Math.round(randInt(rng, spot.rewards.adenaMin, spot.rewards.adenaMax) * rates.adena)
         : rolledRewards.adena;
     const loot = rolledRewards?.items || [];
-    if (String(state.stats?.role || '') === 'spoiler'
-        || [54, 55].includes(Number(state.stats?.classId ?? state.classId))) {
+    if (BotRoles.isSpoiler(state)) {
         loot.push(...BackgroundDropResolver.rollSpoilForFight({
             spot,
             killerLevel: Number(state.level || bot.level),
@@ -913,7 +920,7 @@ function resolvePartyFight({ members, spot, targetNpcId = 0, rng = Math.random, 
         return {
             state: fighterState,
             profile,
-            role: fighterState.party?.role || fighterState.stats?.role || 'dps',
+            role: combatRoleForState(fighterState),
             vitals: {
                 hp: Math.min(profile.maxHp, Math.max(0, Number(state.vitals?.hp ?? profile.maxHp))),
                 maxHp: profile.maxHp,

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -3097,6 +3097,9 @@ const BotLifeState = {
             if (publish) publish({ ...result, state: snapshot });
             notifyColdSnapshot(snapshot, 'clan_warehouse_equipment', { critical: true });
             return { ...result, state: snapshot };
+        }).catch((error) => {
+            utils.infoWarn('BotLife', 'failed clan warehouse exchange for %d: %s', id, error.message || error);
+            return { ok: false, reason: 'exchange_error', characterId: id, error };
         });
         const tracked = next.finally(() => {
             if (pendingWrites.get(id) === tracked) pendingWrites.delete(id);

--- a/src/GameServer/Bot/Population/BotLifeState.js
+++ b/src/GameServer/Bot/Population/BotLifeState.js
@@ -513,6 +513,7 @@ function recordFromSession(session, phase, reason = '') {
     const inventory = inventorySummaryFromItems(actor.backpack?.fetchItems ? actor.backpack.fetchItems() : []);
     const stats = {
         role: session.botStatus?.role || null,
+        clanGearExchangeRevision: Number(cache.get(characterId)?.stats?.clanGearExchangeRevision || 0),
         classId: actor.fetchClassId ? Number(actor.fetchClassId()) : null,
         // A freshly spawned bot may cool before it has gone through a cold
         // resolve. Persist the completed profile here so it is never picked
@@ -644,6 +645,14 @@ function preserveVersionedAppearanceForSave(row) {
 }
 
 function save(row) {
+    // An async lifecycle step may still hold the inventory from before an
+    // exchange. Reject it before its subsequent inventory sync restores gear.
+    const exchangeRevision = Number(cache.get(Number(row.characterId))?.stats?.clanGearExchangeRevision || 0);
+    if (exchangeRevision > Number(parseJson(row.statsJson, {}).clanGearExchangeRevision || 0)) {
+        const error = new Error(`stale inventory before clan equipment exchange for ${row.characterId}`);
+        error.code = 'BOT_LIFE_STATE_OWNERSHIP_CONFLICT';
+        return Promise.reject(error);
+    }
     preserveVersionedAppearanceForSave(row);
     return Database.execute([
         `INSERT INTO ${TABLE} (
@@ -3077,6 +3086,25 @@ const BotLifeState = {
             });
     },
 
+    applyClanWarehouseExchange(request, publish = null) {
+        const id = Number(request.characterId);
+        const previous = pendingWrites.get(id) || Promise.resolve();
+        const next = previous.then(() => Database.exchangeClanWarehouseEquipment(request)).then((result) => {
+            if (!result?.ok) return result;
+            const snapshot = normalize(result.state);
+            cache.set(id, snapshot);
+            // Publish the committed paperdoll before yielding back to hot AI.
+            if (publish) publish({ ...result, state: snapshot });
+            notifyColdSnapshot(snapshot, 'clan_warehouse_equipment', { critical: true });
+            return { ...result, state: snapshot };
+        });
+        const tracked = next.finally(() => {
+            if (pendingWrites.get(id) === tracked) pendingWrites.delete(id);
+        });
+        pendingWrites.set(id, tracked);
+        return tracked;
+    },
+
     applyWarehouseGearCleanup(characterId, selections = [], options = {}) {
         const id = Number(characterId);
         if (!Number.isSafeInteger(id) || id <= 0 || !Array.isArray(selections) || !selections.length) {
@@ -3423,6 +3451,7 @@ const BotLifeState = {
 
 BotLifeState.canonicalizeAreaState = canonicalizeAreaState;
 BotLifeState.inventorySummaryFromItems = inventorySummaryFromItems;
+BotLifeState.equipmentSummaryFromInventory = equipmentSummaryFromInventory;
 BotLifeState.marketPurchaseBlocker = marketPurchaseBlocker;
 BotLifeState.normalizeInventoryStackability = normalizeInventoryStackability;
 BotLifeState.preserveClanOwnedEquipmentState = preserveClanOwnedEquipmentState;

--- a/src/GameServer/Bot/Population/ColdSimulationCoordinator.js
+++ b/src/GameServer/Bot/Population/ColdSimulationCoordinator.js
@@ -394,6 +394,14 @@ class ColdSimulationCoordinator {
         case 'proposal_batch':
             this.handleProposalBatch(message);
             break;
+        case 'party_formation_proposal': {
+            const waiter = this.waiters.get(message.msgId);
+            if (waiter) {
+                this.waiters.delete(message.msgId);
+                waiter.resolve(payload);
+            }
+            break;
+        }
         case 'release_request':
             await this.handleReleaseRequest(message);
             break;
@@ -435,6 +443,38 @@ class ColdSimulationCoordinator {
             heartbeatMs: Math.max(250, Number(Config.coldWorkerHeartbeatMs) || 1000),
             loopIntervalMs: Math.max(5, Number(Config.coldWorkerLoopIntervalMs) || 20)
         };
+    }
+
+    async requestRequiredPartyFormation(options = {}) {
+        if (!this.worker || !this.ready || !this.snapshotsLoaded || this.stopping) {
+            return { ok: false, reason: 'worker_not_ready', candidates: [] };
+        }
+        const queue = this.queue.snapshot();
+        if (queue.depth > 0 || queue.flushing) {
+            return { ok: false, reason: 'commit_queue_busy', candidates: [] };
+        }
+        const timeoutMs = Math.max(50, Number(options.timeoutMs) || 500);
+        const msgId = this.post('party_formation_request', {
+            timestamp: Number(options.timestamp || Date.now()),
+            candidateLimit: Math.max(2, Math.min(64, Number(options.candidateLimit) || 12)),
+            minSize: Math.max(2, Number(options.minSize) || 2),
+            maxSize: Math.max(2, Number(options.maxSize) || 5),
+            levelRange: Math.max(0, Number(options.levelRange ?? PartyComposition.DEFAULT_LEVEL_RANGE))
+        });
+        if (!msgId) return { ok: false, reason: 'request_send_failed', candidates: [] };
+        let timer = null;
+        try {
+            const proposal = await new Promise((resolve, reject) => {
+                timer = setTimeout(() => reject(new Error('party_formation_worker_timeout')), timeoutMs);
+                this.waiters.set(msgId, { resolve, reject });
+            });
+            return { ok: true, ...proposal };
+        } catch (error) {
+            this.waiters.delete(msgId);
+            return { ok: false, reason: error.message, candidates: [] };
+        } finally {
+            clearTimeout(timer);
+        }
     }
 
     sendPlanningCatalog() {

--- a/src/GameServer/Bot/Population/ColdSimulationProtocol.js
+++ b/src/GameServer/Bot/Population/ColdSimulationProtocol.js
@@ -12,6 +12,7 @@ const MAIN_TYPES = new Set([
     'release_ack',
     'command_ack',
     'maintenance_ack',
+    'party_formation_request',
     'fence',
     'fence_ack',
     'pause',
@@ -27,6 +28,7 @@ const WORKER_TYPES = new Set([
     'release_request',
     'command_request',
     'maintenance_request',
+    'party_formation_proposal',
     'heartbeat',
     'fence_ack',
     'drained',
@@ -92,7 +94,8 @@ function validateEnvelope(message, direction, options = {}) {
         release_request: 'releases',
         release_ack: 'results',
         command_request: 'requests',
-        command_ack: 'results'
+        command_ack: 'results',
+        party_formation_proposal: 'candidates'
     };
     const batchField = batchFields[message.type];
     const batch = batchField ? message.payload[batchField] : null;

--- a/src/GameServer/Bot/Population/ColdSimulationWorker.js
+++ b/src/GameServer/Bot/Population/ColdSimulationWorker.js
@@ -54,6 +54,7 @@ const ColdCombatProfile = invoke('GameServer/Bot/Population/ColdCombatProfile');
 const SpotProfiles = invoke('GameServer/Bot/Population/SpotProfiles');
 const LevelingRoutes = invoke('GameServer/Bot/AI/LevelingRoutes');
 const Protocol = require('./ColdSimulationProtocol');
+const RequiredPartyFormation = require('./RequiredPartyFormation');
 const { ColdSimulationKernel, beginRouteTravelState } = require('./ColdSimulationKernel');
 const ColdNpcPlanningCatalog = require('./ColdNpcPlanningCatalog');
 const forbiddenLoaded = Object.keys(require.cache).filter((filename) => (
@@ -361,6 +362,13 @@ async function handle(message) {
     case 'command_ack':
         (payload.results || []).forEach((result) => kernel?.completeCommand(result));
         break;
+    case 'party_formation_request': {
+        const states = kernel
+            ? [...kernel.states.values()].map((entry) => entry?.state).filter(Boolean)
+            : [];
+        send('party_formation_proposal', RequiredPartyFormation.proposalFromStates(states, payload), message.msgId);
+        break;
+    }
     case 'fence': {
         const result = kernel?.fence(payload.characterId) || { characterId: Number(payload.characterId), proposal: null, token: null };
         send('fence_ack', result, message.msgId);

--- a/src/GameServer/Bot/Population/InventorySummary.js
+++ b/src/GameServer/Bot/Population/InventorySummary.js
@@ -1,13 +1,50 @@
 'use strict';
 
+// Cold progression owns counts; instances retain the identity and enchant of
+// copies already materialized. A purchase/drop can grow the count before a new
+// physical row exists. Never copy the old item's enchant onto that new copy.
+function completeInstances(item = {}) {
+    if (!Array.isArray(item.instances)) return item;
+    const amount = Math.max(0, Math.floor(Number(item.amount) || 0));
+    const slots = Array.isArray(item.equippedSlots)
+        ? [...new Set(item.equippedSlots.map(Number).filter((slot) => slot > 0))].slice(0, amount)
+        : item.instances.filter((instance) => instance.equipped && Number(instance.slot) > 0)
+            .map((instance) => Number(instance.slot)).slice(0, amount);
+    // When selling surplus, keep worn copies even if they are not first in
+    // instance order. Preserve the slot of each surviving equipped copy.
+    const instances = item.instances.map((instance) => ({
+        ...instance, enchant: Math.max(0, Number(instance.enchant ?? item.enchant ?? 0) || 0)
+    }))
+        .sort((a, b) => Number(b.equipped && slots.includes(Number(b.slot)))
+            - Number(a.equipped && slots.includes(Number(a.slot))))
+        .slice(0, amount);
+    while (instances.length < amount) instances.push({ id: null, amount: 1, enchant: 0, equipped: false, slot: 0 });
+    const remaining = new Set(slots);
+    for (const instance of instances) {
+        const slot = Number(instance.slot);
+        instance.equipped = !!instance.equipped && remaining.delete(slot);
+        instance.slot = instance.equipped ? slot : 0;
+        instance.amount = 1;
+    }
+    for (const instance of instances) {
+        if (instance.equipped || !remaining.size) continue;
+        instance.slot = remaining.values().next().value;
+        instance.equipped = true;
+        remaining.delete(instance.slot);
+    }
+    const enchants = [...new Set(instances.map((instance) => Number(instance.enchant || 0)))];
+    return { ...item, instances, enchant: enchants.length === 1 ? enchants[0] : null };
+}
+
 function canonicalize(inventory = {}) {
     return Object.entries(inventory || {}).reduce((summary, [key, item]) => {
         if (!item || !Number.isFinite(Number(item.amount)) || Number(item.amount) <= 0) return summary;
-        summary[key] = item;
+        summary[key] = completeInstances(item);
         return summary;
     }, {});
 }
 
 module.exports = {
-    canonicalize
+    canonicalize,
+    completeInstances
 };

--- a/src/GameServer/Bot/Population/PopulationConfig.js
+++ b/src/GameServer/Bot/Population/PopulationConfig.js
@@ -85,6 +85,14 @@ const DEFAULTS = {
     marketExpiryCleanupIntervalMs: 10000,
     marketExpiryCleanupBatchSize: 10,
     partyFormationIntervalMs: 45000,
+    // A protected player session may replenish only required parties. The
+    // worker finds candidates; the main loop performs one guarded atomic write.
+    protectedPartyFormationPollMs: 5000,
+    protectedPartyFormationIntervalMs: 30000,
+    protectedPartyFormationCandidateLimit: 12,
+    protectedPartyFormationLagAbortMs: 40,
+    protectedPartyFormationMainBudgetMs: 25,
+    protectedPartyFormationMaxBackoffMs: 120000,
     // Party requests are orthogonal to activity.  This is the slow safety
     // replan/review cadence, not a period during which the bot is blocked.
     partyWaitReplanMs: 5 * 60 * 1000,
@@ -276,6 +284,12 @@ const ENV_KEYS = {
     backgroundGovernorLagAbortMs: 'BOT_BACKGROUND_GOVERNOR_LAG_ABORT_MS',
     partyFormationIdleBudgetMs: 'BOT_POPULATION_PARTY_FORMATION_IDLE_BUDGET_MS',
     partyFormationPlayerBudgetMs: 'BOT_POPULATION_PARTY_FORMATION_PLAYER_BUDGET_MS',
+    protectedPartyFormationPollMs: 'BOT_POPULATION_PROTECTED_PARTY_POLL_MS',
+    protectedPartyFormationIntervalMs: 'BOT_POPULATION_PROTECTED_PARTY_INTERVAL_MS',
+    protectedPartyFormationCandidateLimit: 'BOT_POPULATION_PROTECTED_PARTY_CANDIDATE_LIMIT',
+    protectedPartyFormationLagAbortMs: 'BOT_POPULATION_PROTECTED_PARTY_LAG_ABORT_MS',
+    protectedPartyFormationMainBudgetMs: 'BOT_POPULATION_PROTECTED_PARTY_MAIN_BUDGET_MS',
+    protectedPartyFormationMaxBackoffMs: 'BOT_POPULATION_PROTECTED_PARTY_MAX_BACKOFF_MS',
     marketTradeChatEnabled: 'BOT_MARKET_TRADE_CHAT_ENABLED',
     marketTradeChatIntervalMs: 'BOT_MARKET_TRADE_CHAT_INTERVAL_MS',
     partyRecruitmentChatEnabled: 'BOT_PARTY_RECRUITMENT_CHAT_ENABLED',

--- a/src/GameServer/Bot/Population/PopulationService.js
+++ b/src/GameServer/Bot/Population/PopulationService.js
@@ -1649,7 +1649,8 @@ const PopulationService = {
             run: ({ job, deadlineAt }) => {
                 const limit = Math.max(1, Number(Config.maxWarehouseReleasesPerTick) || 8);
                 const releaseStartedAt = Date.now();
-                return this.releaseWarehouseMaterials(deadlineAt).then((results) => ({
+                return invoke('GameServer/Clan/ClanWarehouseEquipmentService').resolveBatch(deadlineAt)
+                    .then(() => this.releaseWarehouseMaterials(deadlineAt)).then((results) => ({
                     results,
                     continuation: results.length >= limit || Date.now() >= deadlineAt
                 })).finally(() => {

--- a/src/GameServer/Bot/Population/PopulationService.js
+++ b/src/GameServer/Bot/Population/PopulationService.js
@@ -1938,7 +1938,6 @@ const PopulationService = {
             return [];
         }).finally(() => {
             const durationMs = Date.now() - startedAt;
-            if (durationMs > mainBudgetMs) failed = true;
             this.nextProtectedPartyFormationAt = Date.now() + (retrySoon
                 ? Math.max(1000, Number(Config.protectedPartyFormationPollMs) || 5000)
                 : this.protectedPartyFormationDelay(failed));

--- a/src/GameServer/Bot/Population/PopulationService.js
+++ b/src/GameServer/Bot/Population/PopulationService.js
@@ -639,6 +639,9 @@ function hydratePartyCandidates(candidates = []) {
             if (!hydrated) return null;
             const projectedAt = Number(projection.updatedAt || 0);
             if (projectedAt > 0 && Number(hydrated.updatedAt || 0) !== projectedAt) return null;
+            const projectedRevision = Number(projection.simulation?.revision);
+            if (Number.isFinite(projectedRevision)
+                && Number(hydrated.simulation?.revision || 0) !== projectedRevision) return null;
             return hydrated;
         }).filter(Boolean);
     });
@@ -692,6 +695,85 @@ function commitPartyMembership(party, members = [], event = null) {
     });
 }
 
+function createAndCommitBackgroundParty(members = [], objectiveOverride = null) {
+    const leader = PartyComposition.chooseLeader(members);
+    if (!leader) return Promise.resolve(null);
+    const objectiveMember = members.find((member) => (
+        member.stats?.partyRequest?.status === 'open'
+        && member.stats?.partyRequest?.priority === 'required'
+    )) || members.find((member) => partyObjectiveForState(member)) || leader;
+    const objective = objectiveOverride || partyObjectiveForState(objectiveMember);
+    const partySpot = partySpotForLeader(leader, objective?.spotId || null);
+    const timestamp = Date.now();
+    const partyId = `bgp_${timestamp.toString(36)}_${leader.characterId}`;
+    const coverage = PartyComposition.roleCoverage(members);
+    const party = {
+        partyId,
+        leaderId: leader.characterId,
+        memberIds: members.map((state) => state.characterId),
+        spotId: partySpot?.id || leader.spotId,
+        startedAt: timestamp,
+        nextResolveAt: timestamp + 45000 + Math.round(Math.random() * 90000),
+        cohesion: 0.55 + Math.random() * 0.25,
+        risk: 0.18 + Math.random() * 0.22,
+        roleCoverage: coverage,
+        stats: {
+            formedAt: timestamp,
+            memberNames: members.map((state) => state.name),
+            personaFormation: Object.fromEntries(members.map((member) => [
+                member.characterId,
+                PersonaPartyPolicy.explain(member, members.filter((peer) => peer !== member), coverage)
+            ])),
+            route: partySpot?.route || null,
+            objective: objective || null,
+            acquisitionGoal: objectiveMember.stats?.equipmentPlan?.status === 'active'
+                ? objectiveMember.stats.equipmentPlan
+                : null
+        }
+    };
+    const partyEvent = {
+        characterId: leader.characterId,
+        eventType: 'party',
+        summary: `${leader.name} formed a party near ${party.spotId}`,
+        meta: {
+            partyId,
+            spotId: party.spotId,
+            memberIds: party.memberIds,
+            route: party.stats.route
+        },
+        weight: 2,
+        createdAt: timestamp
+    };
+
+    return commitPartyMembership(party, members, partyEvent).then(({ party: savedParty, assigned, failed, eventCommitted }) => {
+        if (!savedParty || failed.length || assigned.length !== members.length) {
+            return savedParty
+                ? dissolveBackgroundParty(savedParty, 'party_assignment_failed', assigned.length).then(() => null)
+                : null;
+        }
+        const eventWrite = eventCommitted
+            ? Promise.resolve()
+            : LifeEvents.record(
+                partyEvent.characterId,
+                partyEvent.eventType,
+                partyEvent.summary,
+                partyEvent.meta,
+                partyEvent.weight
+            );
+        return eventWrite.then(() => {
+            Metrics.recordPartyFormation();
+            console.info(
+                'BotPopulation :: formed background party %s spot=%s members=%d leader=%s',
+                savedParty.partyId,
+                savedParty.spotId || 'none',
+                savedParty.memberIds.length,
+                leader.name
+            );
+            return savedParty;
+        });
+    });
+}
+
 function syncPartyLeader(members = [], party, leaderId) {
     const nextLeaderId = Number(leaderId || 0);
     const staleMembers = (members || []).filter((member) => (
@@ -732,6 +814,7 @@ const PopulationService = {
     warehouseCleanupTimer: null,
     stateRetentionTimer: null,
     partyFormationTimer: null,
+    protectedPartyFormationTimer: null,
     partyRequestCleanupTimer: null,
     phasePolicyTimer: null,
     seedTimer: null,
@@ -770,6 +853,8 @@ const PopulationService = {
     stateRetentionRunning: false,
     partyFormationRunning: false,
     partyFormationPending: false,
+    nextProtectedPartyFormationAt: 0,
+    protectedPartyFormationFailures: 0,
     partyRequestCleanupRunning: false,
     phasePolicyRunning: false,
     clanActionRunning: false,
@@ -898,6 +983,14 @@ const PopulationService = {
             if (typeof this.partyFormationTimer.unref === 'function') {
                 this.partyFormationTimer.unref();
             }
+
+            this.protectedPartyFormationTimer = setInterval(() => {
+                this.formProtectedRequiredParty();
+            }, Math.max(1000, Number(Config.protectedPartyFormationPollMs) || 5000));
+
+            if (typeof this.protectedPartyFormationTimer.unref === 'function') {
+                this.protectedPartyFormationTimer.unref();
+            }
         }
 
         if (Config.phasePolicyEnabled !== false) {
@@ -964,6 +1057,12 @@ const PopulationService = {
             clearInterval(this.partyFormationTimer);
             this.partyFormationTimer = null;
         }
+        if (this.protectedPartyFormationTimer) {
+            clearInterval(this.protectedPartyFormationTimer);
+            this.protectedPartyFormationTimer = null;
+        }
+        this.nextProtectedPartyFormationAt = 0;
+        this.protectedPartyFormationFailures = 0;
         if (this.partyRequestCleanupTimer) {
             clearInterval(this.partyRequestCleanupTimer);
             this.partyRequestCleanupTimer = null;
@@ -1734,6 +1833,119 @@ const PopulationService = {
             });
     },
 
+    protectedPartyFormationDelay(failed = false) {
+        const base = Math.max(1000, Number(Config.protectedPartyFormationIntervalMs) || 30000);
+        if (failed) this.protectedPartyFormationFailures = Math.min(8, Number(this.protectedPartyFormationFailures || 0) + 1);
+        else this.protectedPartyFormationFailures = 0;
+        const delay = failed ? base * (2 ** this.protectedPartyFormationFailures) : base;
+        return Math.min(Math.max(base, delay), Math.max(base, Number(Config.protectedPartyFormationMaxBackoffMs) || 120000));
+    },
+
+    formProtectedRequiredParty(timestamp = Date.now()) {
+        if (Config.enabled === false || Config.backgroundPartyEnabled === false
+            || this.partyFormationRunning || this.resolving
+            || timestamp < Number(this.nextProtectedPartyFormationAt || 0)) {
+            return Promise.resolve([]);
+        }
+        const activity = this.playerActivityProfile(timestamp);
+        if (!activity.protected) return Promise.resolve([]);
+
+        const lagMs = Math.max(0, Number(Metrics.currentEventLoopLag()) || 0);
+        const lagLimit = Math.max(1, Number(Config.protectedPartyFormationLagAbortMs) || 40);
+        const database = Database.stats();
+        const cold = ColdSimulationCoordinator.snapshot();
+        if (lagMs >= lagLimit
+            || Number(database.pending || 0) > 0
+            || database.checkpoint?.inFlight
+            || !cold.ready
+            || !cold.snapshotsLoaded
+            || Number(cold.queue?.depth || 0) > 0
+            || cold.queue?.flushing) {
+            this.partyFormationPending = true;
+            Metrics.recordPartyFormationDeferral();
+            this.nextProtectedPartyFormationAt = timestamp + Math.max(1000, Number(Config.protectedPartyFormationPollMs) || 5000);
+            return Promise.resolve([]);
+        }
+
+        this.partyFormationRunning = true;
+        this.partyFormationPending = false;
+        const startedAt = Date.now();
+        const mainBudgetMs = Math.max(1, Number(Config.protectedPartyFormationMainBudgetMs) || 25);
+        let failed = false;
+        let retrySoon = false;
+        return ColdSimulationCoordinator.requestRequiredPartyFormation({
+            timestamp,
+            candidateLimit: Config.protectedPartyFormationCandidateLimit,
+            minSize: Config.partyMinSize,
+            maxSize: Config.partyMaxSize,
+            levelRange: PartyComposition.DEFAULT_LEVEL_RANGE
+        }).then((proposal) => {
+            if (!proposal?.ok) {
+                failed = true;
+                return [];
+            }
+            const projections = proposal.candidates || [];
+            if (!projections.length) return [];
+            const activeParties = Number(BackgroundPartyState.counts().active || 0);
+            if (activeParties >= maxBackgroundPartiesForBacklog(proposal.requiredCount)) return [];
+
+            return hydratePartyCandidates(projections).then((states) => {
+                const required = states.filter((state) => {
+                    const objective = partyObjectiveForState(state);
+                    const objectiveSpot = String(
+                        objective?.spotId
+                        || (state.stats?.equipmentPlan?.status === 'active' ? state.stats.equipmentPlan.next?.spotId : null)
+                        || state.spotId
+                        || ''
+                    );
+                    return objective?.status === 'open'
+                        && objective?.priority === 'required'
+                        && objectiveSpot === String(proposal.spotId || '');
+                });
+                const selected = PartyComposition.selectMembers(required, {
+                    minSize: proposal.minSize,
+                    maxSize: proposal.maxSize,
+                    levelRange: proposal.levelRange
+                });
+                if (selected.length < Number(proposal.minSize || Config.partyMinSize)) {
+                    failed = true;
+                    return [];
+                }
+                const currentLagMs = Math.max(0, Number(Metrics.currentEventLoopLag()) || 0);
+                const currentDatabase = Database.stats();
+                const currentCold = ColdSimulationCoordinator.snapshot();
+                if (currentLagMs >= lagLimit
+                    || Number(currentDatabase.pending || 0) > 0
+                    || currentDatabase.checkpoint?.inFlight
+                    || Number(currentCold.queue?.depth || 0) > 0
+                    || currentCold.queue?.flushing) {
+                    retrySoon = true;
+                    Metrics.recordPartyFormationDeferral();
+                    return [];
+                }
+                const objectiveMember = selected.find((state) => partyObjectiveForState(state)?.priority === 'required');
+                const commitStartedAt = Date.now();
+                return createAndCommitBackgroundParty(selected, partyObjectiveForState(objectiveMember)).then((party) => {
+                    if (!party) failed = true;
+                    if (Date.now() - commitStartedAt > mainBudgetMs) failed = true;
+                    return party ? [party] : [];
+                });
+            });
+        }).catch((error) => {
+            failed = true;
+            utils.infoWarn('BotPopulation', 'protected party formation failed: %s', error?.message || error);
+            return [];
+        }).finally(() => {
+            const durationMs = Date.now() - startedAt;
+            if (durationMs > mainBudgetMs) failed = true;
+            this.nextProtectedPartyFormationAt = Date.now() + (retrySoon
+                ? Math.max(1000, Number(Config.protectedPartyFormationPollMs) || 5000)
+                : this.protectedPartyFormationDelay(failed));
+            Metrics.recordPartyFormationDuration(durationMs);
+            this.partyFormationRunning = false;
+        });
+    },
+
     formBackgroundParties() {
         // Formation rewrites party membership.  It must not overlap with the
         // scheduler after that scheduler has already selected solo candidates.
@@ -1886,81 +2098,9 @@ const PopulationService = {
                     }
                     return timedStage('candidate_hydration', () => hydratePartyCandidates(selectedMembers)).then((members) => {
                         if (members.length !== selectedMembers.length) return null;
-                        const leader = PartyComposition.chooseLeader(members);
-                        const objectiveMember = members.find((member) => (
-                            member.stats?.partyRequest?.status === 'open'
-                            && member.stats?.partyRequest?.priority === 'required'
-                        )) || members.find((member) => partyObjectiveForState(member)) || leader;
-                        const objective = partyObjectiveForState(objectiveMember);
-                        const partySpot = partySpotForLeader(leader, objective?.spotId || null);
-                        const partyId = `bgp_${Date.now().toString(36)}_${leader.characterId}`;
-                        const nextResolveAt = Date.now() + 45000 + Math.round(Math.random() * 90000);
-                        const coverage = PartyComposition.roleCoverage(members);
-                        const party = {
-                            partyId,
-                            leaderId: leader.characterId,
-                            memberIds: members.map((state) => state.characterId),
-                            spotId: partySpot?.id || leader.spotId,
-                            startedAt: Date.now(),
-                            nextResolveAt,
-                            cohesion: 0.55 + Math.random() * 0.25,
-                            risk: 0.18 + Math.random() * 0.22,
-                            roleCoverage: coverage,
-                            stats: {
-                                formedAt: Date.now(),
-                                memberNames: members.map((state) => state.name),
-                                personaFormation: Object.fromEntries(members.map((member) => [
-                                    member.characterId,
-                                    PersonaPartyPolicy.explain(member, members.filter((peer) => peer !== member), coverage)
-                                ])),
-                                route: partySpot?.route || null,
-                                objective: objective || null,
-                                acquisitionGoal: objectiveMember.stats?.equipmentPlan?.status === 'active'
-                                    ? objectiveMember.stats.equipmentPlan
-                                    : null
-                            }
-                        };
-                        const partyEvent = {
-                            characterId: leader.characterId,
-                            eventType: 'party',
-                            summary: `${leader.name} formed a party near ${party.spotId}`,
-                            meta: {
-                                partyId,
-                                spotId: party.spotId,
-                                memberIds: party.memberIds,
-                                route: party.stats.route
-                            },
-                            weight: 2,
-                            createdAt: Date.now()
-                        };
-
-                        return timedStage('party_commit', () => commitPartyMembership(party, members, partyEvent)).then(({ party: savedParty, assigned, failed, eventCommitted }) => {
-                            if (!savedParty || failed.length || assigned.length !== members.length) {
-                                return savedParty
-                                    ? dissolveBackgroundParty(savedParty, 'party_assignment_failed', assigned.length).then(() => null)
-                                    : null;
-                            }
-                            const eventWrite = eventCommitted
-                                ? Promise.resolve()
-                                : LifeEvents.record(
-                                    partyEvent.characterId,
-                                    partyEvent.eventType,
-                                    partyEvent.summary,
-                                    partyEvent.meta,
-                                    partyEvent.weight
-                                );
-                            return eventWrite.then(() => {
-                                Metrics.recordPartyFormation();
-                                created.push(savedParty);
-                                console.info(
-                                    'BotPopulation :: formed background party %s spot=%s members=%d leader=%s',
-                                    savedParty.partyId,
-                                    savedParty.spotId || 'none',
-                                    savedParty.memberIds.length,
-                                    leader.name
-                                );
-                                return savedParty;
-                            });
+                        return timedStage('party_commit', () => createAndCommitBackgroundParty(members)).then((savedParty) => {
+                            if (savedParty) created.push(savedParty);
+                            return savedParty;
                         });
                     });
                 }), Promise.resolve()).then(() => created);

--- a/src/GameServer/Bot/Population/RequiredPartyFormation.js
+++ b/src/GameServer/Bot/Population/RequiredPartyFormation.js
@@ -69,49 +69,46 @@ function proposalFromStates(states = [], options = {}) {
     ));
 
     for (const selectedGroup of ordered) {
-        const anchor = [...selectedGroup.group].sort((left, right) => (
+        const anchors = [...selectedGroup.group].sort((left, right) => (
             Number(left.objective.requestedAt || left.state.updatedAt || timestamp)
             - Number(right.objective.requestedAt || right.state.updatedAt || timestamp)
             || Number(left.state.characterId) - Number(right.state.characterId)
-        ))[0];
-        const clanEquipment = anchor.objective.clanOperation === 'equipment'
-            && Number(anchor.objective.clanId || 0) > 0;
-        const maxSize = clanEquipment
-            ? Math.max(defaultMinSize, Math.min(9, Number(anchor.objective.maxPartySize) || defaultMaxSize))
-            : defaultMaxSize;
-        const minSize = clanEquipment
-            ? Math.max(2, Math.min(maxSize, Number(anchor.objective.minPartySize) || defaultMinSize))
-            : defaultMinSize;
-        const levelRange = clanEquipment
-            ? Math.max(defaultLevelRange, Number(anchor.objective.levelRange) || 99)
-            : defaultLevelRange;
-        const anchorLevel = Number(anchor.state.level || 1);
-        const compatible = selectedGroup.group
-            .filter(({ state }) => Math.abs(Number(state.level || 1) - anchorLevel) <= levelRange)
-            .sort((left, right) => (
-                Number(left.objective.requestedAt || left.state.updatedAt || timestamp)
-                - Number(right.objective.requestedAt || right.state.updatedAt || timestamp)
-                || Number(left.state.characterId) - Number(right.state.characterId)
-            ))
-            .slice(0, candidateLimit)
-            .map(({ state }) => state);
-        if (PartyComposition.selectMembers(compatible, { minSize, maxSize, levelRange }).length < minSize) continue;
-        return {
-            requiredCount,
-            spotId: selectedGroup.spotId,
-            oldestAt: selectedGroup.oldestAt,
-            minSize,
-            maxSize,
-            levelRange,
-            candidates: compatible.map((state) => ({
-                characterId: Number(state.characterId),
-                updatedAt: Number(state.updatedAt || 0),
-                simulation: {
-                    ownerId: state.simulation?.ownerId || 'legacy_main',
-                    revision: Math.max(0, Number(state.simulation?.revision || 0))
-                }
-            }))
-        };
+        ));
+        for (const anchor of anchors) {
+            const clanEquipment = anchor.objective.clanOperation === 'equipment'
+                && Number(anchor.objective.clanId || 0) > 0;
+            const maxSize = clanEquipment
+                ? Math.max(defaultMinSize, Math.min(9, Number(anchor.objective.maxPartySize) || defaultMaxSize))
+                : defaultMaxSize;
+            const minSize = clanEquipment
+                ? Math.max(2, Math.min(maxSize, Number(anchor.objective.minPartySize) || defaultMinSize))
+                : defaultMinSize;
+            const levelRange = clanEquipment
+                ? Math.max(defaultLevelRange, Number(anchor.objective.levelRange) || 99)
+                : defaultLevelRange;
+            const anchorLevel = Number(anchor.state.level || 1);
+            const compatible = anchors
+                .filter(({ state }) => Math.abs(Number(state.level || 1) - anchorLevel) <= levelRange)
+                .slice(0, candidateLimit)
+                .map(({ state }) => state);
+            if (PartyComposition.selectMembers(compatible, { minSize, maxSize, levelRange }).length < minSize) continue;
+            return {
+                requiredCount,
+                spotId: selectedGroup.spotId,
+                oldestAt: selectedGroup.oldestAt,
+                minSize,
+                maxSize,
+                levelRange,
+                candidates: compatible.map((state) => ({
+                    characterId: Number(state.characterId),
+                    updatedAt: Number(state.updatedAt || 0),
+                    simulation: {
+                        ownerId: state.simulation?.ownerId || 'legacy_main',
+                        revision: Math.max(0, Number(state.simulation?.revision || 0))
+                    }
+                }))
+            };
+        }
     }
     return { requiredCount, candidates: [] };
 }

--- a/src/GameServer/Bot/Population/RequiredPartyFormation.js
+++ b/src/GameServer/Bot/Population/RequiredPartyFormation.js
@@ -1,0 +1,119 @@
+const PartyComposition = invoke('GameServer/Bot/Population/BackgroundPartyComposition');
+const PartyRequestPlanner = invoke('GameServer/Bot/Population/PartyRequestPlanner');
+
+const ELIGIBLE_ACTIVITIES = new Set(['hunting', 'resting', 'party_wait']);
+
+function objectiveFor(state) {
+    const objective = PartyRequestPlanner.partyObjectiveForState(state);
+    return objective?.status === 'open' && objective?.priority === 'required' ? objective : null;
+}
+
+function spotFor(state, objective = null) {
+    return String(
+        objective?.spotId
+        || (state?.stats?.equipmentPlan?.status === 'active' ? state.stats.equipmentPlan.next?.spotId : null)
+        || state?.spotId
+        || ''
+    );
+}
+
+function eligible(state) {
+    return Boolean(
+        Number(state?.characterId || 0) > 0
+        && state.phase === 'cold'
+        && ELIGIBLE_ACTIVITIES.has(state.activity)
+        && String(state.simulation?.ownerId || 'legacy_main') === 'legacy_main'
+        && !state.party?.partyId
+        && !state.partyId
+        && spotFor(state)
+    );
+}
+
+function proposalFromStates(states = [], options = {}) {
+    const timestamp = Number(options.timestamp || Date.now());
+    const candidateLimit = Math.max(2, Math.min(64, Number(options.candidateLimit) || 12));
+    const defaultMinSize = Math.max(2, Number(options.minSize) || 2);
+    const defaultMaxSize = Math.max(defaultMinSize, Number(options.maxSize) || 5);
+    const defaultLevelRange = Math.max(0, Number(options.levelRange ?? PartyComposition.DEFAULT_LEVEL_RANGE));
+    const rows = (states || []).filter(eligible);
+    const activePartyIdsBySpot = new Map();
+    (states || []).forEach((state) => {
+        const partyId = String(state?.party?.partyId || state?.partyId || '');
+        const spotId = String(state?.spotId || '');
+        if (!partyId || !spotId) return;
+        if (!activePartyIdsBySpot.has(spotId)) activePartyIdsBySpot.set(spotId, new Set());
+        activePartyIdsBySpot.get(spotId).add(partyId);
+    });
+
+    const groups = new Map();
+    rows.forEach((state) => {
+        const objective = objectiveFor(state);
+        if (!objective) return;
+        const spotId = spotFor(state, objective);
+        if (!spotId) return;
+        if (!groups.has(spotId)) groups.set(spotId, []);
+        groups.get(spotId).push({ state, objective });
+    });
+    const requiredCount = [...groups.values()].reduce((sum, group) => sum + group.length, 0);
+    const ordered = [...groups.entries()].map(([spotId, group]) => ({
+        spotId,
+        group,
+        oldestAt: Math.min(...group.map(({ state, objective }) => Number(
+            objective.requestedAt || state.timing?.activityStartedAt || state.updatedAt || timestamp
+        ))),
+        activeParties: Number(activePartyIdsBySpot.get(spotId)?.size || 0)
+    })).sort((left, right) => (
+        (right.group.length / (1 + right.activeParties)) - (left.group.length / (1 + left.activeParties))
+        || left.oldestAt - right.oldestAt
+        || left.spotId.localeCompare(right.spotId)
+    ));
+
+    for (const selectedGroup of ordered) {
+        const anchor = [...selectedGroup.group].sort((left, right) => (
+            Number(left.objective.requestedAt || left.state.updatedAt || timestamp)
+            - Number(right.objective.requestedAt || right.state.updatedAt || timestamp)
+            || Number(left.state.characterId) - Number(right.state.characterId)
+        ))[0];
+        const clanEquipment = anchor.objective.clanOperation === 'equipment'
+            && Number(anchor.objective.clanId || 0) > 0;
+        const maxSize = clanEquipment
+            ? Math.max(defaultMinSize, Math.min(9, Number(anchor.objective.maxPartySize) || defaultMaxSize))
+            : defaultMaxSize;
+        const minSize = clanEquipment
+            ? Math.max(2, Math.min(maxSize, Number(anchor.objective.minPartySize) || defaultMinSize))
+            : defaultMinSize;
+        const levelRange = clanEquipment
+            ? Math.max(defaultLevelRange, Number(anchor.objective.levelRange) || 99)
+            : defaultLevelRange;
+        const anchorLevel = Number(anchor.state.level || 1);
+        const compatible = selectedGroup.group
+            .filter(({ state }) => Math.abs(Number(state.level || 1) - anchorLevel) <= levelRange)
+            .sort((left, right) => (
+                Number(left.objective.requestedAt || left.state.updatedAt || timestamp)
+                - Number(right.objective.requestedAt || right.state.updatedAt || timestamp)
+                || Number(left.state.characterId) - Number(right.state.characterId)
+            ))
+            .slice(0, candidateLimit)
+            .map(({ state }) => state);
+        if (PartyComposition.selectMembers(compatible, { minSize, maxSize, levelRange }).length < minSize) continue;
+        return {
+            requiredCount,
+            spotId: selectedGroup.spotId,
+            oldestAt: selectedGroup.oldestAt,
+            minSize,
+            maxSize,
+            levelRange,
+            candidates: compatible.map((state) => ({
+                characterId: Number(state.characterId),
+                updatedAt: Number(state.updatedAt || 0),
+                simulation: {
+                    ownerId: state.simulation?.ownerId || 'legacy_main',
+                    revision: Math.max(0, Number(state.simulation?.revision || 0))
+                }
+            }))
+        };
+    }
+    return { requiredCount, candidates: [] };
+}
+
+module.exports = { eligible, objectiveFor, spotFor, proposalFromStates };

--- a/src/GameServer/Clan/ClanSimulationPolicy.js
+++ b/src/GameServer/Clan/ClanSimulationPolicy.js
@@ -65,8 +65,8 @@ function isStaticService(candidate = {}) {
 
 function rosterRole(candidate = {}) {
     const classId = number(candidate.classId ?? candidate.stats?.classId, -1);
+    if (BotRoles.isSpoiler(candidate)) return 'spoiler';
     if ([56, 57].includes(classId)) return 'crafter';
-    if ([54, 55].includes(classId)) return 'spoiler';
     return BotRoles.inferRole(candidate);
 }
 

--- a/src/GameServer/Clan/ClanWarehouseEquipmentPolicy.js
+++ b/src/GameServer/Clan/ClanWarehouseEquipmentPolicy.js
@@ -33,6 +33,20 @@ function equipmentSignature(rows) {
     ].join(':')).sort().join('|');
 }
 
+function inventoryMatches(rows, inventory) {
+    // An unmaterialized cold copy must not look like an empty paperdoll slot.
+    // Wait for normal inventory synchronization rather than consume clan gear
+    // which the cold optimizer would immediately discard as surplus.
+    return Object.values(inventory).every((entry) => {
+        if (!materialize(entry)?.isWearable()) return true;
+        const physical = rows.filter((row) => Number(row.selfId) === Number(entry.selfId));
+        if (physical.reduce((sum, row) => sum + Number(row.amount), 0) !== Number(entry.amount)) return false;
+        const slots = invoke('GameServer/Bot/AI/GearAcquisitionPlanner').equippedSlotsFor(entry, entry.slot);
+        const actual = physical.filter((row) => row.equipped).map((row) => Number(row.slot)).sort((a, b) => a - b);
+        return JSON.stringify(slots) === JSON.stringify(actual);
+    });
+}
+
 function plan(member, rows, stock) {
     if (Number(stock.amount) - Number(stock.reservedAmount || 0) < 1) return null;
     // Warehouse and inventory object IDs belong to different tables.
@@ -62,4 +76,4 @@ function plan(member, rows, stock) {
     return { slot, returned, score: upgrade.score };
 }
 
-module.exports = { plan, materialize, equipmentSignature };
+module.exports = { plan, materialize, equipmentSignature, inventoryMatches };

--- a/src/GameServer/Clan/ClanWarehouseEquipmentPolicy.js
+++ b/src/GameServer/Clan/ClanWarehouseEquipmentPolicy.js
@@ -1,0 +1,65 @@
+const DataCache = invoke('GameServer/DataCache');
+const Item = invoke('GameServer/Item/Item');
+const BackpackModel = invoke('GameServer/Model/Backpack');
+const Upgrade = invoke('GameServer/Bot/AI/BotEquipmentUpgrade');
+const EnchantRules = invoke('GameServer/Items/C4EnchantRules');
+let templateSource = null;
+let templateIndex = new Map();
+
+function materialize(row, scored = false) {
+    if (templateSource !== DataCache.items) {
+        templateSource = DataCache.items;
+        templateIndex = new Map((templateSource || []).map((item) => [Number(item.selfId), utils.crushOb(item)]));
+    }
+    const template = templateIndex.get(Number(row.selfId));
+    if (!template) return null;
+    const details = template;
+    const item = new Item(Number(row.id), {
+        ...details, ...row, name: row.name || details.name, kind: row.kind || details.kind, equipped: !!row.equipped,
+        slot: row.equipped && Number(row.slot) > 0 ? Number(row.slot) : Number(details.slot || 0)
+    });
+    if (scored) {
+        for (const [method, stat] of [['fetchPAtk', 'pAtk'], ['fetchMAtk', 'mAtk'], ['fetchPDef', 'pDef'], ['fetchMDef', 'mDef']]) {
+            const value = Number(item[method]()) + EnchantRules.statBonus(item, stat);
+            item[method] = () => value;
+        }
+    }
+    return item;
+}
+
+function equipmentSignature(rows) {
+    return rows.filter((row) => row.equipped).map((row) => [
+        Number(row.id), Number(row.selfId), Number(row.amount), Number(row.enchant || 0), Number(row.slot)
+    ].join(':')).sort().join('|');
+}
+
+function plan(member, rows, stock) {
+    if (Number(stock.amount) - Number(stock.reservedAmount || 0) < 1) return null;
+    // Warehouse and inventory object IDs belong to different tables.
+    const candidate = materialize({ ...stock, id: -1, amount: 1, equipped: false }, true);
+    if (!candidate?.isWearable()) return null;
+    const backpack = new BackpackModel(Array.from({ length: 16 }, () => ({})));
+    backpack.items = rows.filter((row) => row.equipped).map((row) => materialize(row, true)).filter(Boolean);
+    for (const item of backpack.items) backpack.equipPaperdoll(item.fetchSlot(), item.fetchId(), item.fetchSelfId());
+    if (candidate.fetchSlot() === 8 && backpack.items.some((item) => item.fetchSlot() === 14)) return null;
+    backpack.items.push(candidate);
+    const actor = {
+        backpack,
+        fetchLevel: () => Number(member.level),
+        fetchClassId: () => Number(member.classId)
+    };
+    const upgrade = Upgrade.findBestUpgrades({ actor }).find((entry) => entry.item === candidate);
+    if (!upgrade) return null;
+    const slot = upgrade.slot;
+    const conflicts = new Set([slot]);
+    if (slot === 7 || slot === 8) conflicts.add(14);
+    if (slot === 14) { conflicts.add(7); conflicts.add(8); }
+    if (slot === 15) { conflicts.add(10); conflicts.add(11); }
+    if (slot === 10 || slot === 11) conflicts.add(15);
+    const returned = rows.filter((row) => row.equipped && conflicts.has(Number(row.slot)));
+    // Malformed old equipment must be repaired before exchanging it.
+    if (returned.some((row) => Number(row.amount) !== 1)) return null;
+    return { slot, returned, score: upgrade.score };
+}
+
+module.exports = { plan, materialize, equipmentSignature };

--- a/src/GameServer/Clan/ClanWarehouseEquipmentService.js
+++ b/src/GameServer/Clan/ClanWarehouseEquipmentService.js
@@ -1,0 +1,156 @@
+const Database = invoke('Database');
+const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
+const Policy = invoke('GameServer/Clan/ClanWarehouseEquipmentPolicy');
+const Identity = invoke('GameServer/Bot/AI/BotServiceIdentity');
+
+const running = new Map();
+const itemCursors = new Map();
+const memberCursors = new Map();
+let clanCursor = 0;
+let nextScanAt = 0;
+
+function liveRows(actor) {
+    return actor.backpack.fetchItems().map((item) => ({
+        id: item.fetchId(), selfId: item.fetchSelfId(), amount: item.fetchAmount(),
+        enchant: item.fetchEnchantLevel(), equipped: item.fetchEquipped(), slot: item.fetchSlot()
+    }));
+}
+
+function available(session, clanId) {
+    const actor = session?.actor;
+    return !!actor?.backpack && Number(actor.fetchClanId()) === Number(clanId)
+        && !actor.isDead() && !actor.state?.fetchHits?.() && !actor.state?.fetchCasts?.()
+        && !session.activeTrade && !session.trade && !session.activeNegotiation && !session.botTradeReservations?.size
+        && !actor.fetchPrivateStoreType?.() && !Identity.isStaticService(session);
+}
+
+function publish(session, result) {
+    const actor = session.actor;
+    const backpack = actor.backpack;
+    const ids = new Set(result.returned.map((item) => Number(item.id)));
+    for (const item of result.returned) backpack.unequipPaperdoll(Number(item.slot));
+    backpack.items = backpack.fetchItems().filter((item) => !ids.has(Number(item.fetchId())));
+    const received = Policy.materialize(result.received);
+    backpack.items.push(received);
+    backpack.equipPaperdoll(result.slot, received.fetchId(), received.fetchSelfId());
+    if (session.coldLifeState) session.coldLifeState = result.state;
+    // Persistence already committed both sides of the exchange. Only runtime
+    // stats, item skills, toggles, and client appearance need refreshing here.
+    invoke(path.actor).calculateStats(session, actor);
+    invoke('GameServer/Skills/ToggleSkills').syncEquipment(session, actor);
+    const response = invoke('GameServer/Network/Response');
+    session.dataSendToMe?.(response.itemsList(backpack.fetchItems()));
+    session.dataSendToOthers?.(response.charInfo(actor), actor);
+    const shots = invoke('GameServer/Inventory/ShotStock');
+    shots.ensureActorStock(actor).then(() => shots.enableAutoShot(actor))
+        .catch((error) => utils.infoWarn('ClanGear', 'shot refresh failed: %s', error.message));
+}
+
+function coldAvailable(characterId) {
+    const population = invoke('GameServer/Bot/Population/PopulationService');
+    const coordinator = invoke('GameServer/Bot/Population/ColdSimulationCoordinator');
+    return !population.resolving && !population.partyFormationRunning
+        && !coordinator.commandInflight.has(Number(characterId));
+}
+
+async function exchangeCold(request) {
+    const coordinator = invoke('GameServer/Bot/Population/ColdSimulationCoordinator');
+    const owner = invoke('GameServer/Bot/Population/ColdSimulationOwner');
+    // Fence and flush any worker proposal before changing the physical gear.
+    // The member keeps its party; the new revision invalidates stale proposals.
+    try {
+        const fence = await coordinator.fenceBot(request.characterId);
+        if (!fence.ok || !coldAvailable(request.characterId)) return { ok: false, code: 'member_busy' };
+        const state = await LifeState.findByCharacterId(request.characterId);
+        const handoff = await owner.handoffToMain(state, { allowParty: true, allowLifecycle: true });
+        if (!handoff.ok) return { ok: false, code: 'member_busy' };
+        return await LifeState.applyClanWarehouseExchange({ ...request, validateCold: () => coldAvailable(request.characterId) });
+    } finally {
+        const current = LifeState.cachedState(request.characterId);
+        if (current?.phase === 'cold') await coordinator.acceptColdState(current);
+    }
+}
+
+async function resolve(clanId, options) {
+    const deadlineAt = options.deadlineAt ?? Date.now() + 100;
+    const rows = await Database.fetchClanWarehouseItems(clanId);
+    const preferred = new Set(options.preferredIds || []);
+    const cursor = itemCursors.get(clanId) || 0;
+    const stock = rows.filter((row) => Number(row.amount) > Number(row.reservedAmount || 0)
+        && Policy.materialize(row)?.isWearable()).sort((a, b) =>
+        Number(preferred.has(b.id)) - Number(preferred.has(a.id))
+        || Number(a.id <= cursor) - Number(b.id <= cursor) || a.id - b.id).slice(0, 32);
+    if (!stock.length) return { exchanged: 0 };
+    const members = await Database.execute([`SELECT c.id, c.classId, c.level, c.name,
+        l.phase, l.activity, l.partyId, l.simulationOwner, l.statsJson
+        FROM characters c JOIN bot_life_state l ON l.characterId = c.id
+        WHERE c.clanId = ? ORDER BY c.id`, [clanId]], 'clan-gear:members');
+    const manager = invoke('GameServer/Bot/BotManager');
+    let exchanged = 0;
+    let inspected = 0;
+    for (const item of stock) {
+        if ((inspected > 0 && Date.now() >= deadlineAt) || exchanged >= 8) break;
+        let completed = true;
+        const memberCursor = memberCursors.get(clanId);
+        const memberStart = memberCursor?.itemId === item.id ? memberCursor.memberId : 0;
+        const orderedMembers = [...members].sort((a, b) => Number(a.id <= memberStart) - Number(b.id <= memberStart) || a.id - b.id);
+        for (const member of orderedMembers) {
+            if (inspected > 0 && Date.now() >= deadlineAt) { completed = false; break; }
+            memberCursors.set(clanId, { itemId: item.id, memberId: member.id });
+            const session = manager.findSessionById(Number(member.id));
+            if (member.phase === 'hot' ? !available(session, clanId)
+                : member.phase !== 'cold' || !['hunting', 'resting', 'grouped'].includes(member.activity)
+                    || !coldAvailable(member.id)) continue;
+            if (Identity.isStaticService({ ...member, stats: JSON.parse(member.statsJson || '{}') })) continue;
+            const inventory = member.phase === 'hot' ? liveRows(session.actor) : await Database.fetchItems(member.id);
+            inspected += 1;
+            if (!Policy.plan(member, inventory, item)) continue;
+            const actor = session?.actor;
+            const request = {
+                clanId, characterId: member.id, warehouseId: item.id, expectedPhase: member.phase,
+                validateLive: (current, persisted) => session?.actor === actor && available(session, clanId)
+                    && manager.findSessionById(Number(member.id)) === session
+                    && Number(actor.fetchLevel()) === Number(current.level)
+                    && Number(actor.fetchClassId()) === Number(current.classId)
+                    && Policy.equipmentSignature(liveRows(actor)) === Policy.equipmentSignature(persisted)
+            };
+            const result = member.phase === 'hot'
+                ? await LifeState.applyClanWarehouseExchange(request, (result) => publish(session, result))
+                : await exchangeCold(request);
+            if (result.ok) {
+                exchanged += 1;
+                console.info('ClanGear :: %s exchanged warehouse item %d, returned %s', member.name, item.selfId,
+                    result.returned.map((old) => `${old.selfId}+${old.enchant}`).join(', ') || 'empty slot');
+                break;
+            }
+        }
+        if (completed) {
+            itemCursors.set(clanId, Number(item.id));
+            memberCursors.delete(clanId);
+        }
+        await new Promise((resolve) => setImmediate(resolve));
+    }
+    return { exchanged };
+}
+
+function resolveClan(clanId, options = {}) {
+    const id = Number(clanId);
+    if (running.has(id)) return running.get(id);
+    const work = resolve(id, options).finally(() => running.delete(id));
+    running.set(id, work);
+    return work;
+}
+
+async function resolveBatch(deadlineAt) {
+    if (!Database.isReady() || Date.now() < nextScanAt || Date.now() >= deadlineAt) return;
+    nextScanAt = Date.now() + 5000;
+    const clans = await Database.execute([`SELECT DISTINCT clanId FROM clan_warehouse_items
+        WHERE clanId > ? AND amount > reservedAmount AND (kind LIKE 'Weapon.%' OR kind LIKE 'Armor.%')
+        ORDER BY clanId LIMIT 1`, [clanCursor]], 'clan-gear:candidates');
+    if (!clans.length) { clanCursor = 0; return; }
+    if (Date.now() >= deadlineAt) return;
+    clanCursor = Number(clans[0].clanId);
+    return resolveClan(clanCursor, { deadlineAt });
+}
+
+module.exports = { resolveClan, resolveBatch, available, publish };

--- a/src/GameServer/Item/ItemSlot.js
+++ b/src/GameServer/Item/ItemSlot.js
@@ -1,0 +1,29 @@
+const DataCache = invoke('GameServer/DataCache');
+
+function validSlot(value) {
+    const slot = Number(value);
+    return Number.isInteger(slot) && slot >= 0 && slot <= 31 ? slot : null;
+}
+
+function canonicalSlot(selfId, fallback = 0) {
+    const template = (DataCache.items || []).find((item) => Number(item.selfId) === Number(selfId));
+    if (template) {
+        const flattened = utils.crushOb(template);
+        const slot = validSlot(flattened.slot ?? template.etc?.slot);
+        if (slot !== null) return slot;
+    }
+    return validSlot(fallback) ?? 0;
+}
+
+function slotFor(item, fallback = 0) {
+    const current = validSlot(item?.fetchSlot?.() ?? item?.slot);
+    if (item?.fetchEquipped?.()) return current ?? canonicalSlot(item.fetchSelfId?.(), fallback);
+    return canonicalSlot(item?.fetchSelfId?.() ?? item?.selfId, current ?? fallback);
+}
+
+function bodyPart(item) {
+    if (!item?.isWearable?.()) return 0;
+    return 2 ** slotFor(item);
+}
+
+module.exports = { canonicalSlot, slotFor, bodyPart };

--- a/src/GameServer/Items/C4DualSwordCombinations.js
+++ b/src/GameServer/Items/C4DualSwordCombinations.js
@@ -32,7 +32,9 @@ const STATIONS = Object.freeze({
 // C4 multisell 1001 plus the Wilbert and Helton dual-sword lists.  Only the
 // two weapon inputs are retained here: cold bots use the native blacksmith
 // journey, but their population progression intentionally waives crystals,
-// stones, stamps, taxes, and service Adena.
+// stones, stamps, taxes, and service Adena.  The A/S entries below are the
+// C4 Blacksmith of Mammon exchanges; source item 5704 is catalogued separately
+// because its C4 source page has no exchange listing.
 const COMBINATIONS = Object.freeze([
     [2516, 123, 123, 'pushkin'],
     [2517, 123, 69, 'pushkin'],
@@ -143,7 +145,11 @@ const COMBINATIONS = Object.freeze([
     [2618, 76, 134, 'helton'],
     [2619, 76, 77, 'helton'],
     [2616, 132, 135, 'helton'],
-    [2620, 76, 135, 'helton']
+    [2620, 76, 135, 'helton'],
+    [5233, 142, 142, 'pushkin'],
+    [5705, 142, 79, 'pushkin'],
+    [5706, 79, 79, 'pushkin'],
+    [6580, 80, 2500, 'pushkin']
 ]);
 
 let itemSource = null;

--- a/src/GameServer/Network/Response/ItemsList.js
+++ b/src/GameServer/Network/Response/ItemsList.js
@@ -1,5 +1,6 @@
 const SendPacket = invoke('Packet/Send');
 const WireD = invoke('Packet/WireD');
+const ItemSlot = invoke('GameServer/Item/ItemSlot');
 
 function itemsList(items, popup = false) {
     const packet = new SendPacket(0x1b);
@@ -25,7 +26,7 @@ function itemsList(items, popup = false) {
             .writeH(item.fetchClass2())
             .writeH(0x00)  // ?
             .writeH(item.fetchEquipped())
-            .writeD(WireD.bounded(item.fetchEquipped() ? 2 ** item.fetchSlot() : 0))
+            .writeD(WireD.bounded(ItemSlot.bodyPart(item)))
             .writeH(item.fetchEnchantLevel?.() || 0)  // Enchant level
             .writeH(0x00); // ?
     });

--- a/src/GameServer/Network/Response/WareHouseDepositList.js
+++ b/src/GameServer/Network/Response/WareHouseDepositList.js
@@ -1,7 +1,8 @@
 const SendPacket = invoke('Packet/Send');
+const ItemSlot = invoke('GameServer/Item/ItemSlot');
 
 function bodyPart(item) {
-    return item.isWearable?.() ? 2 ** item.fetchSlot() : 0;
+    return ItemSlot.bodyPart(item);
 }
 
 // C4 0x41: warehouse type 1 is private, type 2 is clan.

--- a/src/GameServer/Network/Response/WareHouseWithdrawalList.js
+++ b/src/GameServer/Network/Response/WareHouseWithdrawalList.js
@@ -1,7 +1,8 @@
 const SendPacket = invoke('Packet/Send');
+const ItemSlot = invoke('GameServer/Item/ItemSlot');
 
 function bodyPart(item) {
-    return item.isWearable?.() ? 2 ** item.fetchSlot() : 0;
+    return ItemSlot.bodyPart(item);
 }
 
 // C4 0x42: warehouse type 1 is private, type 2 is clan.

--- a/src/GameServer/Npc/Npc.js
+++ b/src/GameServer/Npc/Npc.js
@@ -538,6 +538,22 @@ class Npc extends NpcModel {
         return effectAdjusted(super.fetchMaxHp(), this, 'maxHp');
     }
 
+    // C4/Lisvus calculates an attackable NPC's reward from MAX_HP. Permanent
+    // Strong Type skills therefore scale both the effective HP and the full
+    // XP/SP reward. Damage and party sharing apply their proportional split
+    // after this total reward has been calculated.
+    fetchRewardMaxHpMultiplier() {
+        return EffectStats.multiplier(this, 'maxHpMul');
+    }
+
+    fetchAcquiredExp() {
+        return super.fetchAcquiredExp() * this.fetchRewardMaxHpMultiplier();
+    }
+
+    fetchRewardSp() {
+        return super.fetchRewardSp() * this.fetchRewardMaxHpMultiplier();
+    }
+
     fetchCollectiveMAtk() {
         return effectAdjusted(super.fetchCollectiveMAtk(), this, 'mAtk');
     }

--- a/src/GameServer/Npc/NpcSkills.js
+++ b/src/GameServer/Npc/NpcSkills.js
@@ -168,8 +168,16 @@ function passiveSkillsFor(npc) {
     return forNpc(npc).filter((skill) => skill.fetchPassive?.() === true);
 }
 
+function maxHpMultiplierFor(npc) {
+    return passiveSkillsFor(npc).reduce((total, skill) => {
+        const value = Number(skill.fetchSemantic?.().stats?.maxHpMul);
+        return Number.isFinite(value) && value > 0 ? total * value : total;
+    }, 1);
+}
+
 module.exports = {
     forNpc,
     combatSkillsFor,
-    passiveSkillsFor
+    passiveSkillsFor,
+    maxHpMultiplierFor
 };

--- a/src/GameServer/Npc/SpoilSweep.js
+++ b/src/GameServer/Npc/SpoilSweep.js
@@ -7,6 +7,7 @@ const EffectStore = invoke('GameServer/Effects/EffectStore');
 const EffectTicker = invoke('GameServer/Effects/EffectTicker');
 const Formulas = invoke('GameServer/Formulas');
 const HotPartyCastTracker = invoke('GameServer/Bot/AI/HotPartyCastTracker');
+const NpcObjectIndex = require('../World/NpcObjectIndex');
 
 const SPOIL_SKILL_ID = 254;
 const SPOIL_FESTIVAL_SKILL_ID = 302;
@@ -253,6 +254,7 @@ const SpoilSweep = {
 
             session.dataSendToMeAndOthers(ServerResponse.deleteOb(npc.fetchId()), npc);
             const World = invoke('GameServer/World/World');
+            NpcObjectIndex.remove(World, npc);
             World.npc.spawns = World.npc.spawns.filter((ob) => ob.fetchId() !== npc.fetchId());
         });
     }

--- a/src/GameServer/Warehouse/ClanWarehouse.js
+++ b/src/GameServer/Warehouse/ClanWarehouse.js
@@ -1,6 +1,7 @@
 const Database = invoke('Database');
 const DataCache = invoke('GameServer/DataCache');
 const Item = invoke('GameServer/Item/Item');
+const ItemSlot = invoke('GameServer/Item/ItemSlot');
 const PersonalWarehouse = invoke('GameServer/Warehouse/PersonalWarehouse');
 const ClanService = invoke('GameServer/Clan/ClanService');
 const ClanRules = invoke('GameServer/Clan/ClanRules');
@@ -16,13 +17,14 @@ function templateFor(selfId) {
 function warehouseItem(row) {
     const template = templateFor(row.selfId);
     if (!template) return null;
+    const details = utils.crushOb(template);
     return new Item(Number(row.id), {
-        ...utils.crushOb(template),
+        ...details,
         amount: Number(row.amount),
         enchant: Number(row.enchant || 0),
         petData: row.petData,
         equipped: false,
-        slot: 0
+        slot: ItemSlot.canonicalSlot(row.selfId, details.slot)
     });
 }
 

--- a/src/GameServer/Warehouse/ClanWarehouse.js
+++ b/src/GameServer/Warehouse/ClanWarehouse.js
@@ -115,6 +115,9 @@ async function deposit(session, lines) {
             source.setAmount(transferred.inventoryAmount);
         }
     });
+    await invoke('GameServer/Clan/ClanWarehouseEquipmentService').resolveClan(clan.id, {
+        preferredIds: results.flatMap((result) => result.warehouseIds || [result.warehouseId])
+    }).catch((error) => utils.infoWarn('ClanGear', 'exchange deferred: %s', error.message));
     return list(clan.id);
 }
 

--- a/src/GameServer/Warehouse/PersonalWarehouse.js
+++ b/src/GameServer/Warehouse/PersonalWarehouse.js
@@ -1,6 +1,7 @@
 const Database = invoke('Database');
 const DataCache = invoke('GameServer/DataCache');
 const Item = invoke('GameServer/Item/Item');
+const ItemSlot = invoke('GameServer/Item/ItemSlot');
 const World = invoke('GameServer/World/World');
 const CharacterWriteQueue = invoke('GameServer/Persistence/CharacterWriteQueue');
 
@@ -25,13 +26,14 @@ function templateFor(selfId) {
 function warehouseItem(row) {
     const template = templateFor(row.selfId);
     if (!template) return null;
+    const details = utils.crushOb(template);
     return new Item(Number(row.id), {
-        ...utils.crushOb(template),
+        ...details,
         amount: Number(row.amount),
         enchant: Number(row.enchant || 0),
         petData: row.petData,
         equipped: false,
-        slot: 0
+        slot: ItemSlot.canonicalSlot(row.selfId, details.slot)
     });
 }
 

--- a/src/GameServer/World/Generics/FetchNpc.js
+++ b/src/GameServer/World/Generics/FetchNpc.js
@@ -1,6 +1,8 @@
+const NpcObjectIndex = require('../NpcObjectIndex');
+
 function fetchNpc(id) {
     return new Promise((success, fail) => {
-        let npc = this.npc.spawns.find(ob => ob.fetchId() === id);
+        const npc = NpcObjectIndex.find(this, id);
         return npc ? success(npc) : fail();
     });
 }

--- a/src/GameServer/World/NpcObjectIndex.js
+++ b/src/GameServer/World/NpcObjectIndex.js
@@ -1,0 +1,41 @@
+'use strict';
+
+// Maintained by the world's spawn/grid lifecycle, plus legacy direct removals
+// (Sweep and summon death). Whole-world replacement uses indexSpawnsInGrid;
+// normal corpse batches can replace the array after removing each member.
+// Object IDs are immutable for the lifetime of an NPC. Keep the actual actor,
+// not a combat snapshot: HP, target and death checks still read live state.
+const indexes = new WeakMap();
+
+function reset(world) {
+    if (!world?.npc) return;
+    indexes.set(world.npc, { byId: new Map(), ids: new WeakMap() });
+}
+
+function add(world, npc) {
+    const index = indexes.get(world?.npc);
+    if (!index || !npc?.fetchId) return;
+    const id = npc.fetchId();
+    index.byId.set(id, npc);
+    index.ids.set(npc, id);
+}
+
+function remove(world, npc) {
+    const index = indexes.get(world?.npc);
+    if (!index || !npc || !index.ids.has(npc)) return;
+    const id = index.ids.get(npc);
+    // A delayed corpse cleanup must not evict a replacement object.
+    if (index.byId.get(id) === npc) index.byId.delete(id);
+    index.ids.delete(npc);
+}
+
+function find(world, id) {
+    if (id === null || id === undefined) return null;
+    const index = indexes.get(world?.npc);
+    if (index) return index.byId.get(id) || null;
+    // Lightweight worlds which do not run the grid lifecycle retain the
+    // original lookup. Never rebuild or scan on a live indexed cache miss.
+    return (world?.npc?.spawns || []).find((npc) => npc?.fetchId?.() === id) || null;
+}
+
+module.exports = { reset, add, remove, find };

--- a/src/GameServer/World/World.js
+++ b/src/GameServer/World/World.js
@@ -6,6 +6,7 @@ const DayNightSpawnManager = invoke('GameServer/World/DayNightSpawnManager');
 const RaidBossState = invoke('GameServer/World/RaidBossState');
 const RaidBossMinionManager = invoke('GameServer/World/RaidBossMinionManager');
 const RaidEntityIndex = invoke('GameServer/World/RaidEntityIndex');
+const NpcObjectIndex = require('./NpcObjectIndex');
 
 function actorLoc(actor) {
     return {
@@ -562,6 +563,7 @@ const World = {
 
     addNpcToGrid(npc) {
         if (!npc) return false;
+        NpcObjectIndex.add(this, npc);
         const raidIndexed = RaidEntityIndex.add(this, npc);
         if (!npc.fetchLocX || !npc.fetchLocY) return raidIndexed;
         if (!(this.npc.gridKeys instanceof WeakMap)) this.npc.gridKeys = new WeakMap();
@@ -581,6 +583,7 @@ const World = {
 
     removeNpcFromGrid(npc) {
         if (!npc) return false;
+        NpcObjectIndex.remove(this, npc);
         const raidRemoved = RaidEntityIndex.remove(this, npc);
         if (!npc.fetchLocX || !npc.fetchLocY) return raidRemoved;
         if (!(this.npc.gridKeys instanceof WeakMap)) this.npc.gridKeys = new WeakMap();
@@ -606,6 +609,7 @@ const World = {
     indexSpawnsInGrid() {
         this.npc.grid = {};
         this.npc.gridKeys = new WeakMap();
+        NpcObjectIndex.reset(this);
         RaidEntityIndex.reset(this);
         this.npc.spawns.forEach((npc) => {
             this.addNpcToGrid(npc);

--- a/src/NodeL2.js
+++ b/src/NodeL2.js
@@ -68,7 +68,7 @@ Database.init(() => {
     const stackableItemIds = (DataCache.items || [])
         .filter((item) => item.etc?.stackable === true)
         .map((item) => Number(item.selfId));
-    Database.compactStackableInventory(stackableItemIds).then((result) => {
+    Database.compactStackableInventory(stackableItemIds, 'compact-stackable-inventory-v2').then((result) => {
         if (!result.skipped && result.rowsRemoved > 0) {
             utils.infoSuccess('DB', 'compacted stackable inventory groups=%d rows=%d', result.groups, result.rowsRemoved);
             return Database.reclaimUnusedSpace();

--- a/tests/test_bot_background_party_composition.js
+++ b/tests/test_bot_background_party_composition.js
@@ -44,5 +44,9 @@ const recruits = PartyComposition.selectRecruits([
     bot(25, 23, 'buffer')
 ], { maxSize: 5 });
 assert.deepStrictEqual(recruits.map((state) => state.characterId), [24, 23]);
+assert.strictEqual(PartyComposition.roleForState({ characterId: 30, level: 39, stats: { classId: 56, role: 'crafter' } }), 'spoiler',
+    'a sub-40 dwarf must fill the spoiler role even on the future crafting branch');
+assert.strictEqual(PartyComposition.roleForState({ characterId: 31, level: 40, stats: { classId: 57, role: 'crafter' } }), 'dps',
+    'a post-40 non-spoiler dwarf must fill a DPS combat slot');
 
 console.log('Bot background party composition checks passed');

--- a/tests/test_bot_class_progression.js
+++ b/tests/test_bot_class_progression.js
@@ -99,6 +99,11 @@ try {
         assert.strictEqual(BotRoles.className(100), 'Sword Muse', 'list presentation must use a human-readable profession');
         assert.strictEqual(BotRoles.inferRole({ classId: 30 }), 'healer', 'persisted character rows must resolve roles from classId');
         assert.strictEqual(BotRoles.presentation(null).classId, null, 'a missing profession must not be mistaken for Human Fighter');
+        assert.strictEqual(BotRoles.inferRole({ classId: 53, level: 1 }), 'spoiler', 'a pre-profession dwarf should follow the spoiler track');
+        assert.strictEqual(BotRoles.inferRole({ classId: 56, level: 39 }), 'spoiler', 'a sub-40 dwarf should use the spoiler track while leveling');
+        assert.strictEqual(BotRoles.inferRole(55), 'spoiler', 'Bounty Hunter must be recognized as a spoiler');
+        assert.strictEqual(BotRoles.inferRole(117), 'spoiler', 'Fortune Seeker must be recognized as a spoiler');
+        assert.strictEqual(BotRoles.combatRoleFor({ classId: 57, level: 40 }), 'dps', 'a non-spoiler dwarf branch should remain DPS in combat for now');
         assert.strictEqual(BotRoles.inferRole(118), 'crafter', 'Maestro must retain its crafter role');
         console.log('Bot class progression checks passed');
     }).catch((error) => {

--- a/tests/test_bot_cold_combat.js
+++ b/tests/test_bot_cold_combat.js
@@ -393,7 +393,7 @@ const gigantSpot = {
 const gigantProgression = BackgroundDropResolver.progressionForFight({ spot: gigantSpot, npcSelfId: 1187, rng: () => 0 });
 assert.deepStrictEqual(
     { exact: gigantProgression.exact, exp: Math.round(gigantProgression.exp), sp: gigantProgression.sp },
-    { exact: true, exp: 594, sp: 27 },
+    { exact: true, exp: 2376, sp: 108 },
     'cold rewards must use the defeated NPC progression instead of the synthetic spot average'
 );
 assert.strictEqual(
@@ -438,8 +438,8 @@ const strongSoloResult = BackgroundResolver.resolveSolo({
     rng: () => 0.1
 });
 assert.deepStrictEqual(strongSoloResult.debug.foughtNpcIds, [1187]);
-assert.strictEqual(strongSoloResult.materialize.exp, Math.round(594 * ProgressionRates.profile().exp));
-assert.strictEqual(strongSoloResult.materialize.sp, 27 * ProgressionRates.profile().sp);
+assert.strictEqual(strongSoloResult.materialize.exp, Math.round(2376 * ProgressionRates.profile().exp));
+assert.strictEqual(strongSoloResult.materialize.sp, 108 * ProgressionRates.profile().sp);
 assert.strictEqual(strongSoloResult.materialize.adena, 0);
 
 const strongPartyResult = BackgroundPartyResolver.resolve({
@@ -451,7 +451,7 @@ const strongPartyResult = BackgroundPartyResolver.resolve({
     timestamp,
     rng: () => 0.1
 });
-const expectedPartyShares = PartyRewardMath.sharesForLevels([30, 30], 594, 27);
+const expectedPartyShares = PartyRewardMath.sharesForLevels([30, 30], 2376, 108);
 assert.deepStrictEqual(
     strongPartyResult.memberResults.map((entry) => entry.result.materialize.exp),
     expectedPartyShares.map((share) => Math.round(share.exp * ProgressionRates.profile().exp)),

--- a/tests/test_bot_combat_skill_selection.js
+++ b/tests/test_bot_combat_skill_selection.js
@@ -7,6 +7,7 @@ const C4SkillRules = invoke('GameServer/Skills/C4SkillRules');
 const EffectStore = invoke('GameServer/Effects/EffectStore');
 const SummonerTactics = invoke('GameServer/Bot/AI/SummonerTactics');
 const World = invoke('GameServer/World/World');
+const NpcDied = invoke('GameServer/Actor/Generics/NpcDied');
 
 function skill(selfId, options = {}) {
     return {
@@ -73,10 +74,85 @@ function generics() {
 
 const originalRandom = Math.random;
 const originalFetchNpcsInRadius = World.fetchNpcsInRadius;
+const originalWorldUser = World.user;
 
 try {
     Math.random = () => 0;
     World.fetchNpcsInRadius = () => [];
+
+    const spoilSkill = skill(254, {
+        name: 'Spoil',
+        type: C4SkillRules.SPOIL,
+        mp: 5,
+        target: 'enemy'
+    });
+    const spoiler = bot(55, [spoilSkill], 100);
+    spoiler.fetchId = () => 11000;
+    const spoilTarget = {
+        ...npc(11001),
+        fetchAttackable: () => true,
+        isDead: () => false
+    };
+    const spoilSession = {};
+    const spoilGenerics = generics();
+    BotAI.executeCombat(spoilSession, spoiler, spoilTarget, spoilGenerics);
+    assert.deepStrictEqual(spoilGenerics.skills[0], { id: 11001, selfId: 254, ctrl: true },
+        'a spoiler must make one Spoil attempt before starting its damage rotation');
+    assert.strictEqual(spoilSession.lastCombatDecision.action, 'cast_spoil',
+        'the Spoil attempt must be visible in hot combat telemetry');
+    BotAI.executeCombat(spoilSession, spoiler, spoilTarget, spoilGenerics);
+    assert.strictEqual(spoilGenerics.skills.filter((entry) => entry.selfId === 254).length, 1,
+        'a spoiler must not retry Spoil on the same encounter');
+
+    const drySpoiler = bot(55, [spoilSkill], 0);
+    const drySession = {};
+    const dryGenerics = generics();
+    BotAI.executeCombat(drySession, drySpoiler, {
+        ...npc(11004), fetchAttackable: () => true, isDead: () => false
+    }, dryGenerics);
+    assert.strictEqual(dryGenerics.skills.length, 0, 'a spoiler without enough MP must skip Spoil');
+    assert.strictEqual(dryGenerics.attacks.length, 1, 'skipping Spoil must not block the normal damage rotation');
+
+    const pvpGenerics = generics();
+    BotAI.executePvPCombat({}, spoiler, { ...npc(11005), isDead: () => false }, pvpGenerics);
+    assert.strictEqual(pvpGenerics.skills.some((entry) => entry.selfId === 254), false,
+        'a spoiler must never try Spoil against a player target');
+
+    const sweeper = bot(55, [skill(42, {
+        name: 'Sweeper',
+        type: C4SkillRules.SWEEP,
+        target: 'corpse_mob',
+        mp: 0
+    })], 100);
+    sweeper.fetchId = () => 11002;
+    const spoiledCorpse = {
+        ...npc(11003),
+        fetchAttackable: () => true,
+        isDead: () => true,
+        state: { fetchDead: () => true },
+        model: { spoil: { spoiled: true, swept: false, spoilerId: 11002 } }
+    };
+    const sweepSession = {};
+    const sweepGenerics = generics();
+    assert.strictEqual(BotAI.trySweep(sweepSession, sweeper, spoiledCorpse, sweepGenerics), true,
+        'a spoiler must queue Sweeper after its marked mob dies');
+    assert.deepStrictEqual(sweepGenerics.skills[0], { id: 11003, selfId: 42, ctrl: true });
+    assert.strictEqual(BotAI.trySweep(sweepSession, sweeper, spoiledCorpse, sweepGenerics), false,
+        'a spoiler must not queue duplicate Sweeper casts for one corpse');
+
+    const automaticCorpse = {
+        ...npc(11006),
+        fetchAttackable: () => true,
+        isDead: () => true,
+        state: { fetchDead: () => true },
+        model: { spoil: { spoiled: true, swept: false, spoilerId: 11002 } }
+    };
+    const automaticSession = { accountId: 'bot_automatic_sweeper', actor: sweeper };
+    World.user = { sessions: [automaticSession] };
+    const automaticGenerics = generics();
+    assert.strictEqual(NpcDied.autoSweepSpoiledCorpse(automaticCorpse, automaticGenerics), true,
+        'the authoritative NPC death path must queue Sweeper for the bot that owns the spoil mark');
+    assert.deepStrictEqual(automaticGenerics.skills[0], { id: 11006, selfId: 42, ctrl: true });
 
     const mage = bot(10, []);
     const mageGenerics = generics();
@@ -581,4 +657,5 @@ try {
 } finally {
     Math.random = originalRandom;
     World.fetchNpcsInRadius = originalFetchNpcsInRadius;
+    World.user = originalWorldUser;
 }

--- a/tests/test_bot_dual_sword_combine.js
+++ b/tests/test_bot_dual_sword_combine.js
@@ -20,7 +20,11 @@ const saberRevolution = DualSwords.resolveByProductId(2523);
 const saberSaber = DualSwords.resolveByProductId(2516);
 const shamshirCaliburs = DualSwords.resolveByProductId(2576);
 const stormbringerCaliburs = DualSwords.resolveByProductId(2566);
-assert.strictEqual(DualSwords.loadRecipes().length, 110, 'every C4 blacksmith dual-sword result must be represented');
+const keshanberkKeshanberk = DualSwords.resolveByProductId(5233);
+const keshanberkDamascus = DualSwords.resolveByProductId(5705);
+const damascusDamascus = DualSwords.resolveByProductId(5706);
+const tallumDarkLegion = DualSwords.resolveByProductId(6580);
+assert.strictEqual(DualSwords.loadRecipes().length, 114, 'every C4 blacksmith dual-sword result must be represented');
 assert(DualSwords.loadRecipes().every((recipe) => (
     recipe.materials.reduce((sum, material) => sum + Number(material.amount || 0), 0) === 2
 )), 'bot dual-sword exchanges must contain exactly two swords and no crystals, stones, stamps, or Adena');
@@ -34,6 +38,18 @@ assert.deepStrictEqual(saberSaber.materials, [
 assert.strictEqual(saberSaber.station.id, 'blacksmith_pushkin', 'generic multisell 1001 combinations must use a standard blacksmith');
 assert.strictEqual(shamshirCaliburs.station.id, 'blacksmith_wilbert', 'Wilbert-specific combinations must retain their native smith');
 assert.strictEqual(stormbringerCaliburs.station.id, 'blacksmith_helton', 'Helton-specific combinations must retain their native smith');
+assert.deepStrictEqual(keshanberkKeshanberk.materials, [{ selfId: 142, amount: 2 }],
+    'Keshanberk*Keshanberk must consume two Keshanberks');
+assert.deepStrictEqual(keshanberkDamascus.materials, [
+    { selfId: 142, amount: 1 },
+    { selfId: 79, amount: 1 }
+], 'Keshanberk*Damascus must consume its two source swords');
+assert.deepStrictEqual(damascusDamascus.materials, [{ selfId: 79, amount: 2 }],
+    'Damascus*Damascus must consume two Swords of Damascus');
+assert.deepStrictEqual(tallumDarkLegion.materials, [
+    { selfId: 80, amount: 1 },
+    { selfId: 2500, amount: 1 }
+], 'Tallum Blade*Dark Legion\'s Edge must consume its two source swords');
 
 function stateFor(recipe, inventory) {
     return {

--- a/tests/test_bot_equipment_compatibility.js
+++ b/tests/test_bot_equipment_compatibility.js
@@ -56,8 +56,18 @@ assert.deepStrictEqual(BotEquipmentCompatibility.weaponKindsFor('buffer', 34), [
 assert.deepStrictEqual(BotEquipmentCompatibility.weaponKindsFor('dps', 46), ['Weapon.GreatSword', 'Weapon.Blunt', 'Weapon.Pole']);
 assert.deepStrictEqual(BotEquipmentCompatibility.weaponKindsFor('dps', 55), ['Weapon.Blunt', 'Weapon.Pole']);
 
+for (const [level, rank, selfId] of [[61, 'a', 5233], [76, 's', 6580]]) {
+    const gladiatorPlan = BotGear.planFor({ classId: 2, level });
+    const gladiatorWeapon = plannedItem(gladiatorPlan, [7, 14]);
+    assert.strictEqual(gladiatorPlan.rank, rank, `Gladiator level ${level} must enter ${rank.toUpperCase()} grade`);
+    assert.strictEqual(gladiatorWeapon?.selfId, selfId, `Gladiator level ${level} must use the source ${rank.toUpperCase()} dual`);
+    assert.strictEqual(gladiatorWeapon?.template?.kind, 'Weapon.Dual', 'Gladiator must never fall back to a one-handed weapon');
+    assert.strictEqual(gladiatorPlan.items.some((item) => Number(item.slot) === 8), false,
+        'Gladiator dual-sword plans must never add a shield');
+}
+
 const secondClassGroups = [
-    { ids: [2], weapons: ['Weapon.Dual', 'Weapon.Sword', 'Weapon.Blunt'], armor: 'heavy', shield: true },
+    { ids: [2], weapons: ['Weapon.Dual'], armor: 'heavy', shield: false },
     { ids: [3], weapons: ['Weapon.Pole'], armor: 'heavy', shield: false },
     { ids: [5, 6, 20, 33], weapons: ['Weapon.Sword', 'Weapon.Blunt'], armor: 'heavy', shield: true },
     { ids: [8, 23, 36], weapons: ['Weapon.Knife'], armor: 'light', shield: false },

--- a/tests/test_bot_equipment_compatibility.js
+++ b/tests/test_bot_equipment_compatibility.js
@@ -28,7 +28,7 @@ const profiles = [
     { classId: 45, role: 'dps', armor: 'heavy', weapon: 'Weapon.Blunt', shield: true },
     { classId: 46, role: 'dps', armor: 'heavy', weapon: 'Weapon.GreatSword', shield: false },
     { classId: 47, role: 'dps', armor: 'light', weapon: 'Weapon.DualFist', shield: false },
-    { classId: 55, role: 'dps', armor: 'heavy', weapon: 'Weapon.Blunt', shield: true },
+    { classId: 55, role: 'spoiler', armor: 'heavy', weapon: 'Weapon.Blunt', shield: true },
     { classId: 57, role: 'crafter', armor: 'heavy', weapon: 'Weapon.Blunt', shield: true }
 ];
 

--- a/tests/test_bot_leveling_routes.js
+++ b/tests/test_bot_leveling_routes.js
@@ -83,6 +83,13 @@ assert.strictEqual(best.spot.id, 'lizard_spoil', 'Bounty Hunters should prefer s
 assert.strictEqual(best.route.reason, 'spoiler_materials');
 
 best = LevelingRoutes.bestSpot(spots, {
+    level: 39,
+    stats: { classId: 56, role: 'crafter' }
+}, { mode: 'solo' });
+assert.strictEqual(best.spot.id, 'lizard_spoil', 'all sub-40 dwarves should prefer spoil material routes');
+assert.strictEqual(best.route.reason, 'spoiler_materials');
+
+best = LevelingRoutes.bestSpot(spots, {
     level: 42,
     stats: { classId: 54 }
 }, { mode: 'solo' });

--- a/tests/test_bot_protected_party_formation.js
+++ b/tests/test_bot_protected_party_formation.js
@@ -1,0 +1,135 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const Config = invoke('GameServer/Bot/Population/PopulationConfig');
+const Metrics = invoke('GameServer/Bot/Population/PopulationMetrics');
+const Database = invoke('Database');
+const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
+const PartyState = invoke('GameServer/Bot/Population/BackgroundPartyState');
+const PopulationService = invoke('GameServer/Bot/Population/PopulationService');
+const ColdCoordinator = invoke('GameServer/Bot/Population/ColdSimulationCoordinator');
+const RequiredPartyFormation = require('../src/GameServer/Bot/Population/RequiredPartyFormation');
+
+function candidate(characterId, options = {}) {
+    const requestedAt = Number(options.requestedAt || 1000);
+    return {
+        characterId,
+        name: `Required${characterId}`,
+        level: Number(options.level || 40),
+        phase: 'cold',
+        activity: 'party_wait',
+        spotId: options.spotId || 'cruma_tower',
+        party: { partyId: null, role: options.role || 'dps', leaderId: null },
+        stats: {
+            role: options.role || 'dps',
+            partyRequest: {
+                status: 'open', priority: 'required', requestedAt,
+                spotId: options.spotId || 'cruma_tower', npcId: 20001
+            }
+        },
+        timing: { activityStartedAt: requestedAt },
+        simulation: { ownerId: 'legacy_main', revision: Number(options.revision || 3) },
+        updatedAt: Number(options.updatedAt || 5000)
+    };
+}
+
+const crowded = Array.from({ length: 20 }, (_, index) => candidate(index + 1, {
+    requestedAt: 1000 + index,
+    role: index === 1 ? 'tank' : 'dps'
+}));
+const proposal = RequiredPartyFormation.proposalFromStates(crowded, { candidateLimit: 12 });
+assert.strictEqual(proposal.requiredCount, 20, 'worker must report the complete required backlog');
+assert.strictEqual(proposal.candidates.length, 12, 'worker response must obey the candidate cap');
+assert.strictEqual(proposal.candidates[0].characterId, 1, 'the oldest compatible request must lead the bounded window');
+
+const incompatible = [candidate(101, { level: 10 }), candidate(102, { level: 25 })];
+assert.deepStrictEqual(
+    RequiredPartyFormation.proposalFromStates(incompatible, { candidateLimit: 12 }).candidates,
+    [],
+    'a level-incompatible pair must not reach the main-thread hydration path'
+);
+
+const originals = {
+    activity: PopulationService.playerActivityProfile,
+    lag: Metrics.currentEventLoopLag,
+    stats: Database.stats,
+    ready: Database.isReady,
+    statesByIds: LifeState.statesByIds,
+    counts: PartyState.counts,
+    snapshot: ColdCoordinator.snapshot,
+    request: ColdCoordinator.requestRequiredPartyFormation,
+    interval: Config.protectedPartyFormationIntervalMs,
+    poll: Config.protectedPartyFormationPollMs,
+    maxBackoff: Config.protectedPartyFormationMaxBackoffMs,
+    mainBudget: Config.protectedPartyFormationMainBudgetMs
+};
+
+(async () => {
+    Config.protectedPartyFormationIntervalMs = 1000;
+    Config.protectedPartyFormationPollMs = 100;
+    Config.protectedPartyFormationMaxBackoffMs = 4000;
+    Config.protectedPartyFormationMainBudgetMs = 1000;
+    PopulationService.playerActivityProfile = () => ({ protected: true, realPlayers: 1, mode: 'player' });
+    Metrics.currentEventLoopLag = () => 0;
+    Database.stats = () => ({ pending: 0, checkpoint: { inFlight: false } });
+    Database.isReady = () => true;
+    PartyState.counts = () => ({ active: 0 });
+    ColdCoordinator.snapshot = () => ({ ready: true, snapshotsLoaded: true, queue: { depth: 0, flushing: false } });
+    ColdCoordinator.requestRequiredPartyFormation = async () => ({
+        ok: true,
+        requiredCount: 2,
+        spotId: 'cruma_tower',
+        minSize: 2,
+        maxSize: 5,
+        levelRange: 4,
+        candidates: [candidate(201), candidate(202)]
+    });
+    LifeState.statesByIds = async () => [
+        candidate(201, { updatedAt: 5001 }),
+        candidate(202, { revision: 4 })
+    ];
+    PopulationService.resolving = false;
+    PopulationService.partyFormationRunning = false;
+    PopulationService.nextProtectedPartyFormationAt = 0;
+    PopulationService.protectedPartyFormationFailures = 0;
+
+    const before = Date.now();
+    assert.deepStrictEqual(await PopulationService.formProtectedRequiredParty(before), [],
+        'stale worker candidates must be rejected before party creation');
+    assert.strictEqual(PopulationService.protectedPartyFormationFailures, 1,
+        'a stale proposal must engage protected-path backoff');
+    assert(PopulationService.nextProtectedPartyFormationAt >= before + 1900,
+        'the first failed attempt must wait roughly two base intervals');
+
+    let requests = 0;
+    ColdCoordinator.requestRequiredPartyFormation = async () => { requests += 1; return { ok: true, candidates: [] }; };
+    Database.stats = () => ({ pending: 1, checkpoint: { inFlight: false } });
+    PopulationService.nextProtectedPartyFormationAt = 0;
+    PopulationService.protectedPartyFormationFailures = 0;
+    await PopulationService.formProtectedRequiredParty(Date.now());
+    assert.strictEqual(requests, 0, 'a busy DB queue must stop before worker selection');
+    assert.strictEqual(PopulationService.protectedPartyFormationFailures, 0,
+        'transient pressure must poll again without escalating failure backoff');
+
+    console.log('Protected required-party worker selection, stale validation, limits and backoff checks passed');
+})().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+}).finally(() => {
+    PopulationService.playerActivityProfile = originals.activity;
+    Metrics.currentEventLoopLag = originals.lag;
+    Database.stats = originals.stats;
+    Database.isReady = originals.ready;
+    LifeState.statesByIds = originals.statesByIds;
+    PartyState.counts = originals.counts;
+    ColdCoordinator.snapshot = originals.snapshot;
+    ColdCoordinator.requestRequiredPartyFormation = originals.request;
+    Config.protectedPartyFormationIntervalMs = originals.interval;
+    Config.protectedPartyFormationPollMs = originals.poll;
+    Config.protectedPartyFormationMaxBackoffMs = originals.maxBackoff;
+    Config.protectedPartyFormationMainBudgetMs = originals.mainBudget;
+    PopulationService.partyFormationRunning = false;
+    PopulationService.nextProtectedPartyFormationAt = 0;
+    PopulationService.protectedPartyFormationFailures = 0;
+});

--- a/tests/test_bot_protected_party_formation.js
+++ b/tests/test_bot_protected_party_formation.js
@@ -50,6 +50,18 @@ assert.deepStrictEqual(
     'a level-incompatible pair must not reach the main-thread hydration path'
 );
 
+const laterCompatibleCluster = [
+    candidate(111, { level: 10, requestedAt: 1000 }),
+    candidate(112, { level: 20, requestedAt: 1001 }),
+    candidate(113, { level: 20, requestedAt: 1002 })
+];
+assert.deepStrictEqual(
+    RequiredPartyFormation.proposalFromStates(laterCompatibleCluster, { candidateLimit: 12, levelRange: 4 })
+        .candidates.map((entry) => entry.characterId),
+    [112, 113],
+    'an isolated oldest request must not hide a later compatible level cluster'
+);
+
 const originals = {
     activity: PopulationService.playerActivityProfile,
     lag: Metrics.currentEventLoopLag,
@@ -111,6 +123,19 @@ const originals = {
     assert.strictEqual(requests, 0, 'a busy DB queue must stop before worker selection');
     assert.strictEqual(PopulationService.protectedPartyFormationFailures, 0,
         'transient pressure must poll again without escalating failure backoff');
+
+    Database.stats = () => ({ pending: 0, checkpoint: { inFlight: false } });
+    Config.protectedPartyFormationMainBudgetMs = 1;
+    ColdCoordinator.requestRequiredPartyFormation = () => new Promise((resolve) => setTimeout(() => resolve({
+        ok: true,
+        requiredCount: 0,
+        candidates: []
+    }), 10));
+    PopulationService.nextProtectedPartyFormationAt = 0;
+    PopulationService.protectedPartyFormationFailures = 0;
+    await PopulationService.formProtectedRequiredParty(Date.now());
+    assert.strictEqual(PopulationService.protectedPartyFormationFailures, 0,
+        'worker IPC latency must not consume the protected main-thread budget');
 
     console.log('Protected required-party worker selection, stale validation, limits and backoff checks passed');
 })().catch((error) => {

--- a/tests/test_bot_spoil_retry.js
+++ b/tests/test_bot_spoil_retry.js
@@ -1,0 +1,80 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const BotAI = invoke('GameServer/Bot/BotAI');
+const C4SkillRules = invoke('GameServer/Skills/C4SkillRules');
+
+function skill(selfId, options = {}) {
+    return {
+        selfId,
+        fetchSelfId: () => selfId,
+        fetchName: () => options.name || `skill_${selfId}`,
+        fetchConsumedMp: () => options.mp ?? 5,
+        fetchPassive: () => false,
+        fetchSemantic: () => options.semantic || {},
+        fetchSkillType: () => options.type || C4SkillRules.SPOIL,
+        fetchTargetKind: () => options.target || 'enemy',
+        fetchDistance: () => options.range ?? 600,
+        fetchPower: () => options.power ?? 20,
+        fetchSpell: () => true
+    };
+}
+
+function bot(classId, spoilSkill, mpRef) {
+    return {
+        fetchClassId: () => classId,
+        fetchLevel: () => 40,
+        fetchHp: () => 100,
+        fetchMaxHp: () => 100,
+        fetchMp: () => mpRef.value,
+        fetchMaxMp: () => 100,
+        fetchCollectivePAtk: () => 100,
+        fetchLocX: () => 0,
+        fetchLocY: () => 0,
+        skillset: {
+            fetchSkill(selfId) {
+                return selfId === spoilSkill.selfId ? spoilSkill : null;
+            }
+        },
+        backpack: {
+            fetchTotalWeaponKind: () => '',
+            fetchTotalWeaponPAtkRnd: () => 0,
+            fetchEquippedArmors: () => []
+        }
+    };
+}
+
+const mpRef = { value: 0 };
+const spoilSkill = skill(254, { name: 'Spoil', mp: 5 });
+const spoiler = bot(55, spoilSkill, mpRef);
+const target = {
+    fetchId: () => 22001,
+    fetchHp: () => 1000,
+    fetchCollectivePDef: () => 100,
+    fetchLocX: () => 400,
+    fetchLocY: () => 0,
+    fetchAttackable: () => true,
+    isDead: () => false
+};
+const session = {};
+const generics = {
+    skills: [],
+    attacks: [],
+    skillExec(_session, _bot, data) {
+        this.skills.push(data);
+    },
+    attackExec(_session, _bot, data) {
+        this.attacks.push(data);
+    }
+};
+
+BotAI.executeCombat(session, spoiler, target, generics);
+assert.strictEqual(generics.skills.length, 0, 'insufficient MP must defer Spoil');
+
+mpRef.value = 100;
+BotAI.executeCombat(session, spoiler, target, generics);
+assert.deepStrictEqual(generics.skills[0], { id: 22001, selfId: 254, ctrl: true },
+    'Spoil must be retried after MP recovers during the same encounter');
+
+console.log('test_bot_spoil_retry: ok');

--- a/tests/test_bot_sweep_retry.js
+++ b/tests/test_bot_sweep_retry.js
@@ -1,0 +1,68 @@
+const assert = require('assert');
+
+require('../src/Global');
+
+const NpcDied = invoke('GameServer/Actor/Generics/NpcDied');
+const World = invoke('GameServer/World/World');
+
+const originalWorldUser = World.user;
+const originalSetTimeout = global.setTimeout;
+
+let busy = true;
+const sweeper = {
+    fetchClassId: () => 55,
+    fetchLevel: () => 40,
+    fetchId: () => 22002,
+    fetchMp: () => 100,
+    state: { fetchCasts: () => busy },
+    skillset: {
+        fetchSkill(selfId) {
+            if (selfId !== 42) return null;
+            return {
+                selfId: 42,
+                fetchSelfId: () => 42,
+                fetchName: () => 'Sweeper',
+                fetchConsumedMp: () => 0
+            };
+        }
+    }
+};
+const session = { accountId: 'bot_sweep_retry', actor: sweeper };
+const corpse = {
+    fetchId: () => 22003,
+    fetchAttackable: () => true,
+    isDead: () => true,
+    state: { fetchDead: () => true },
+    model: { spoil: { spoiled: true, swept: false, spoilerId: 22002 } }
+};
+const generics = {
+    skills: [],
+    skillExec(_session, _actor, data) {
+        this.skills.push(data);
+    }
+};
+const pendingTimers = [];
+
+try {
+    World.user = { sessions: [session] };
+    global.setTimeout = (callback, delay) => {
+        const timer = { callback, delay, unref() {} };
+        pendingTimers.push(timer);
+        return timer;
+    };
+
+    assert.strictEqual(NpcDied.autoSweepSpoiledCorpse(corpse, generics), false,
+        'a busy spoiler must defer Sweep instead of consuming the attempt');
+    assert.strictEqual(pendingTimers.length, 1, 'a busy spoiler must receive a delayed retry');
+    assert.strictEqual(pendingTimers[0].delay, 250);
+
+    busy = false;
+    pendingTimers.shift().callback();
+    assert.deepStrictEqual(generics.skills[0], { id: 22003, selfId: 42, ctrl: true },
+        'the deferred retry must queue Sweep after the cast finishes');
+} finally {
+    global.setTimeout = originalSetTimeout;
+    World.user = originalWorldUser;
+}
+
+console.log('test_bot_sweep_retry: ok');

--- a/tests/test_bot_sweep_retry.js
+++ b/tests/test_bot_sweep_retry.js
@@ -35,6 +35,11 @@ const corpse = {
     state: { fetchDead: () => true },
     model: { spoil: { spoiled: true, swept: false, spoilerId: 22002 } }
 };
+const secondCorpse = {
+    ...corpse,
+    fetchId: () => 22004,
+    model: { spoil: { spoiled: true, swept: false, spoilerId: 22002 } }
+};
 const generics = {
     skills: [],
     skillExec(_session, _actor, data) {
@@ -53,13 +58,20 @@ try {
 
     assert.strictEqual(NpcDied.autoSweepSpoiledCorpse(corpse, generics), false,
         'a busy spoiler must defer Sweep instead of consuming the attempt');
-    assert.strictEqual(pendingTimers.length, 1, 'a busy spoiler must receive a delayed retry');
+    assert.strictEqual(NpcDied.autoSweepSpoiledCorpse(secondCorpse, generics), false,
+        'each corpse must retain its own deferred Sweep');
+    assert.strictEqual(pendingTimers.length, 2, 'busy Sweep retries must be tracked per corpse');
     assert.strictEqual(pendingTimers[0].delay, 250);
 
     busy = false;
     pendingTimers.shift().callback();
+    pendingTimers.shift().callback();
     assert.deepStrictEqual(generics.skills[0], { id: 22003, selfId: 42, ctrl: true },
         'the deferred retry must queue Sweep after the cast finishes');
+    assert.deepStrictEqual(generics.skills[1], { id: 22004, selfId: 42, ctrl: true },
+        'a second corpse must not be dropped behind the first retry timer');
+    assert.strictEqual(session.sweepRetriesByNpcId, undefined,
+        'completed corpse retries must release their per-session tracking map');
 } finally {
     global.setTimeout = originalSetTimeout;
     World.user = originalWorldUser;

--- a/tests/test_c4_necropolis_of_sacrifice.js
+++ b/tests/test_c4_necropolis_of_sacrifice.js
@@ -135,6 +135,10 @@ expectedCombatSkills.forEach((skillIds, npcId) => {
 const gigant = npcInstance(npcs.find((npc) => npc.selfId === 1187), 9981187);
 assert.strictEqual(EffectStats.multiplier(gigant, 'maxHpMul'), 4,
     'Strong Type must retain its exact four-times HP multiplier');
+assert.strictEqual(Math.round(gigant.fetchAcquiredExp()), 2376,
+    'Strong Type must apply its four-times multiplier to the full XP reward');
+assert.strictEqual(Math.round(gigant.fetchRewardSp()), 108,
+    'Strong Type must apply its four-times multiplier to the full SP reward');
 assert.strictEqual(EffectStats.multiplier(gigant, 'darkVuln'), 1.2,
     'Dark Attack Weak Point level three must retain its exact source multiplier');
 

--- a/tests/test_c4_protocol_packets.js
+++ b/tests/test_c4_protocol_packets.js
@@ -427,6 +427,24 @@ const inventoryList = ServerResponse.itemsList([oversizedInventoryItem]);
 assert.strictEqual(inventoryList.readUInt32LE(15), 0xffffffff,
     'C4 ItemsList should saturate an oversized inventory stack instead of crashing the server');
 
+const unequippedAspis = {
+    fetchClass1: () => 1,
+    fetchId: () => 7627001,
+    fetchSelfId: () => 627,
+    fetchAmount: () => 1,
+    fetchClass2: () => 1,
+    fetchEquipped: () => false,
+    fetchSlot: () => 0,
+    fetchEnchantLevel: () => 0,
+    isWearable: () => true
+};
+const aspisInventoryList = ServerResponse.itemsList([unequippedAspis]);
+assert.strictEqual(aspisInventoryList.readUInt32LE(25), 2 ** 8,
+    'C4 ItemsList should advertise an unequipped shield body part from its item template');
+const aspisWarehouseList = ServerResponse.wareHouseDepositList([unequippedAspis], 0);
+assert.strictEqual(aspisWarehouseList.readUInt32LE(27), 2 ** 8,
+    'C4 warehouse lists should advertise an unequipped shield body part from its item template');
+
 const sellListWithOversizedWallet = ServerResponse.sellList(
     [{ item: oversizedInventoryItem, amount: 1, price: 20 }],
     111614128261

--- a/tests/test_clan_gear_stall_and_spoil.js
+++ b/tests/test_clan_gear_stall_and_spoil.js
@@ -53,6 +53,14 @@ async function main() {
         const spoilSources = GearPlanner.sourceForItem(99101, spots, state, { spoilCapable: true });
         assert.strictEqual(spoilSources.length, 1);
         assert.strictEqual(spoilSources[0].kind, 'spoil');
+        const classResolvedSpoilerSources = GearPlanner.sourceForItem(99101, spots, {
+            level: 40,
+            stats: { classId: 54, role: 'dps' },
+            inventory: {},
+            adena: 0
+        });
+        assert.strictEqual(classResolvedSpoilerSources.length, 1,
+            'a Scavenger must unlock spoil sources from its class even when persisted role is stale');
         const spoilLoot = BackgroundDropResolver.rollSpoilForFight({
             spot: spots[0], killerLevel: 40, npcSelfId: 99001, rng: () => 0
         });

--- a/tests/test_clan_warehouse_equipment_exchange.js
+++ b/tests/test_clan_warehouse_equipment_exchange.js
@@ -128,7 +128,28 @@ async function main() {
         await execute('DROP TRIGGER fail_exchange');
         const request = { clanId:71, characterId:22, warehouseId:reserved.id, expectedPhase:'cold' };
         const staleState = await LifeState.findByCharacterId(22);
-        const race = await Promise.all([LifeState.applyClanWarehouseExchange(request), LifeState.applyClanWarehouseExchange(request)]);
+        const originalExchange = Database.exchangeClanWarehouseEquipment;
+        let releaseRejectedExchange;
+        const rejectedExchangeGate = new Promise((resolve) => { releaseRejectedExchange = resolve; });
+        let exchangeCalls = 0;
+        Database.exchangeClanWarehouseEquipment = async (...args) => {
+            exchangeCalls += 1;
+            if (exchangeCalls === 1) {
+                await rejectedExchangeGate;
+                throw new Error('queued exchange rejection probe');
+            }
+            return originalExchange.apply(Database, args);
+        };
+        const rejectedExchange = LifeState.applyClanWarehouseExchange(request);
+        const queuedExchange = LifeState.applyClanWarehouseExchange(request);
+        releaseRejectedExchange();
+        let race;
+        try {
+            race = await Promise.all([rejectedExchange, queuedExchange]);
+        } finally {
+            Database.exchangeClanWarehouseEquipment = originalExchange;
+        }
+        assert.strictEqual(race[0].reason, 'exchange_error', 'database rejection must become a normal exchange result');
         assert.strictEqual(race.filter((result) => result.ok).length, 1, 'one warehouse object may be consumed only once');
         assert.strictEqual((await execute('SELECT enchant FROM items WHERE characterId = 22 AND equipped = 1'))[0].enchant, 9);
         assert.strictEqual((await LifeState.findByCharacterId(22)).inventory[swordId].amount, 1, 'same-ID swaps must not duplicate summary counts');

--- a/tests/test_clan_warehouse_equipment_exchange.js
+++ b/tests/test_clan_warehouse_equipment_exchange.js
@@ -1,0 +1,181 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { DatabaseSync } = require('node:sqlite');
+require('../src/Global');
+const Database = invoke('Database');
+const DataCache = invoke('GameServer/DataCache');
+const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
+const ClanService = invoke('GameServer/Clan/ClanService');
+const Warehouse = invoke('GameServer/Warehouse/ClanWarehouse');
+const Exchange = invoke('GameServer/Clan/ClanWarehouseEquipmentService');
+const Policy = invoke('GameServer/Clan/ClanWarehouseEquipmentPolicy');
+const Manager = invoke('GameServer/Bot/BotManager');
+const Backpack = invoke('GameServer/Model/Backpack');
+const World = invoke('GameServer/World/World');
+
+async function main() {
+    DataCache.init();
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'clan-gear-exchange-'));
+    const databasePath = path.join(directory, 'test.sqlite');
+    const seed = new DatabaseSync(databasePath);
+    seed.exec(fs.readFileSync(path.resolve(__dirname, '../database/sql/sqlite.sql'), 'utf8'));
+    seed.exec(`INSERT INTO accounts(username,password) VALUES ('player','test'),('bot_gear','test');
+        INSERT INTO clans(id,name,level,leaderId) VALUES (71,'ExchangeClan',1,11),(72,'OtherClan',1,24);`);
+    for (const [id, classId, clanId, account] of [[11,4,71,'player'], [21,10,71,'bot_gear'], [22,4,71,'bot_gear'], [24,4,72,'bot_gear']]) {
+        seed.prepare(`INSERT INTO characters(id,username,name,classId,race,level,maxHp,maxMp,sex,face,hair,hairColor,locX,locY,locZ,clanId)
+            VALUES (?,?,?, ?,0,20,500,250,0,0,0,0,0,0,0,?)`).run(id, account, `Gear${id}`, classId, clanId);
+        if (account !== 'player') seed.prepare(`INSERT INTO bot_life_state
+            (characterId,accountName,characterName,level,activity,phase,inventorySummary,statsJson,updatedAt)
+            VALUES (?,? ,?,20,'hunting','cold','{}',?,1)`).run(id, account, `Gear${id}`, JSON.stringify({ classId, coldCombat: { charges: 2 } }));
+    }
+    seed.close();
+    options.default.Database.path = databasePath;
+    Database.init();
+    await LifeState.init();
+    await ClanService.init();
+    const sword = DataCache.items.find((item) => item.etc?.rank === 'd' && item.template?.kind === 'Weapon.Sword' && item.etc?.slot === 7);
+    assert(sword);
+    const swordId = Number(sword.selfId);
+    const execute = (sql, params = []) => Database.execute([sql, params]);
+    const insert = async (id, owner, enchant, equipped = 0, selfId = swordId, slot = 7) => {
+        await execute('INSERT INTO items(id,characterId,selfId,name,amount,enchant,equipped,slot) VALUES (?,?,?, ?,1,?,?,?)',
+            [id, owner, selfId, 'Exchange gear', enchant, equipped, equipped ? slot : 0]);
+    };
+    const player = {
+        fetchId: () => 11, fetchClanId: () => 71, fetchClanPrivileges: () => 2047,
+        fetchLocX: () => 0, fetchLocY: () => 0,
+        backpack: { items: [], fetchItems() { return this.items; } }
+    };
+    World.npc = { spawns: [{ fetchId: () => 900, fetchSelfId: () => 30001,
+        fetchTitle: () => 'Warehouse Keeper', fetchLocX: () => 0, fetchLocY: () => 0 }] };
+    const session = { actor: player, activeNpcTalk: { objectId: 900, selfId: 30001, title: 'Warehouse Keeper' },
+        activeWarehouse: { type: 'clan', clanId: 71, mode: 'deposit' } };
+    async function deposit(id, enchant) {
+        await insert(id, 11, enchant);
+        player.backpack.items.push(Policy.materialize({ id, selfId: swordId, amount: 1, enchant, equipped: false }));
+        await Warehouse.deposit(session, [{ objectId: id, amount: 1 }]);
+    }
+    const originals = [];
+    function stub(object, name, replacement) {
+        const original = object[name];
+        originals.push(() => { object[name] = original; });
+        object[name] = replacement;
+    }
+    try {
+        await insert(101, 22, 0, 1);
+        await deposit(102, 3);
+        let equipped = await execute('SELECT * FROM items WHERE characterId = 22 AND equipped = 1');
+        assert.strictEqual(equipped.length, 1);
+        assert.strictEqual(equipped[0].enchant, 3, 'native player deposit must immediately exchange a cold clan member');
+        let stock = await Database.fetchClanWarehouseItems(71);
+        assert.strictEqual(stock.length, 1);
+        assert.strictEqual(stock[0].enchant, 0, 'the replaced item must return to the clan warehouse');
+        assert.strictEqual((await execute('SELECT * FROM items WHERE characterId IN (21,24)')).length, 0,
+            'incompatible mage and foreign-clan bot must not receive the sword');
+        let cached = await LifeState.findByCharacterId(22);
+        assert.strictEqual(cached.inventory[swordId].amount, 1);
+        assert.strictEqual(cached.stats.equipment[0].enchant, 3);
+        assert.strictEqual(cached.stats.coldCombat.charges, 2, 'exchange must preserve combat state');
+        const firstLedger = await execute('SELECT * FROM clan_warehouse_ledger WHERE characterId = 22');
+        assert.deepStrictEqual(firstLedger.map((row) => row.operation).sort(), ['deposit', 'withdraw']);
+        assert.strictEqual((await Exchange.resolveClan(71)).exchanged, 0, 'equal or weaker stock must not churn');
+
+        await execute("UPDATE bot_life_state SET phase = 'hot' WHERE characterId = 22");
+        const backpack = new Backpack(Array.from({ length: 16 }, () => ({})));
+        backpack.items = equipped.map((row) => Policy.materialize(row));
+        backpack.equipPaperdoll(7, equipped[0].id, swordId);
+        let hitting = true;
+        let statRefreshes = 0;
+        let appearances = 0;
+        const actor = { backpack, fetchId: () => 22, fetchClanId: () => 71, fetchLevel: () => 20, fetchClassId: () => 4,
+            fetchName: () => 'Gear22', isDead: () => false, state: { fetchHits: () => hitting, fetchCasts: () => false } };
+        const botSession = { actor, accountId: 'bot_gear', dataSendToMe() {}, dataSendToOthers() { appearances++; } };
+        Manager.sessions.push(botSession);
+        stub(invoke(global.path.actor), 'calculateStats', () => { statRefreshes++; });
+        stub(invoke('GameServer/Skills/ToggleSkills'), 'syncEquipment', () => {});
+        stub(invoke('GameServer/Network/Response'), 'itemsList', () => Buffer.alloc(0));
+        stub(invoke('GameServer/Network/Response'), 'charInfo', () => Buffer.alloc(0));
+        stub(invoke('GameServer/Inventory/ShotStock'), 'ensureActorStock', () => Promise.resolve());
+        stub(invoke('GameServer/Inventory/ShotStock'), 'enableAutoShot', () => {});
+        await deposit(103, 6);
+        assert.strictEqual(backpack.fetchEquippedWeapon().fetchEnchantLevel(), 3, 'an active swing must defer the exchange');
+        hitting = false;
+        await Exchange.resolveBatch(Date.now() + 2000);
+        assert.strictEqual(backpack.fetchEquippedWeapon().fetchEnchantLevel(), 6);
+        assert.strictEqual(backpack.items.length, 1, 'live backpack must remove the old object');
+        assert.strictEqual(statRefreshes, 1);
+        assert.strictEqual(appearances, 1);
+        stock = await Database.fetchClanWarehouseItems(71);
+        assert.deepStrictEqual(stock.map((row) => row.enchant).sort(), [0,3]);
+        equipped = await execute('SELECT * FROM items WHERE characterId = 22 AND equipped = 1');
+        assert.strictEqual(equipped[0].id, backpack.fetchEquippedWeapon().fetchId());
+
+        await execute("UPDATE bot_life_state SET phase = 'cold' WHERE characterId = 22");
+        Manager.sessions = Manager.sessions.filter((entry) => entry !== botSession);
+        await execute(`INSERT INTO clan_warehouse_items(clanId,selfId,name,kind,amount,enchant,reservedAmount)
+            VALUES (71,?,'Reserved','Weapon.Sword',1,9,1)`, [swordId]);
+        const reserved = (await Database.fetchClanWarehouseItems(71)).find((row) => row.enchant === 9);
+        assert.strictEqual((await Database.exchangeClanWarehouseEquipment({ clanId:71, characterId:22, warehouseId:reserved.id, expectedPhase:'cold' })).ok, false);
+        await execute('UPDATE clan_warehouse_items SET reservedAmount = 0 WHERE id = ?', [reserved.id]);
+        await execute(`CREATE TRIGGER fail_exchange BEFORE INSERT ON items WHEN NEW.characterId = 22 AND NEW.enchant = 9
+            BEGIN SELECT RAISE(ABORT, 'exchange rollback probe'); END`);
+        await assert.rejects(Database.exchangeClanWarehouseEquipment({ clanId:71, characterId:22, warehouseId:reserved.id, expectedPhase:'cold' }), /rollback probe/);
+        assert.strictEqual((await execute('SELECT enchant FROM items WHERE characterId = 22 AND equipped = 1'))[0].enchant, 6);
+        assert((await Database.fetchClanWarehouseItems(71)).some((row) => row.id === reserved.id));
+        assert(!(await Database.fetchClanWarehouseItems(71)).some((row) => row.enchant === 6), 'rollback must undo the return too');
+        await execute('DROP TRIGGER fail_exchange');
+        const request = { clanId:71, characterId:22, warehouseId:reserved.id, expectedPhase:'cold' };
+        const staleState = await LifeState.findByCharacterId(22);
+        const race = await Promise.all([LifeState.applyClanWarehouseExchange(request), LifeState.applyClanWarehouseExchange(request)]);
+        assert.strictEqual(race.filter((result) => result.ok).length, 1, 'one warehouse object may be consumed only once');
+        assert.strictEqual((await execute('SELECT enchant FROM items WHERE characterId = 22 AND equipped = 1'))[0].enchant, 9);
+        assert.strictEqual((await LifeState.findByCharacterId(22)).inventory[swordId].amount, 1, 'same-ID swaps must not duplicate summary counts');
+        assert.strictEqual(await LifeState.upsertState(staleState, 'stale_exchange_probe'), null,
+            'a delayed legacy save must not resurrect the returned equipment');
+
+        cached = await LifeState.findByCharacterId(22);
+        cached = await LifeState.upsertState({ ...cached, activity: 'grouped', party: { partyId: 'exchange-party' } }, 'test_group');
+        const owner = invoke('GameServer/Bot/Population/ColdSimulationOwner');
+        const lease = await owner.claim(cached, { allowParty: true, allowLifecycle: true });
+        assert(lease.ok, JSON.stringify(lease));
+        await deposit(104, 12);
+        const afterWorkerExchange = await LifeState.findByCharacterId(22);
+        assert.strictEqual(afterWorkerExchange.stats.equipment[0].enchant, 12, 'a worker-owned party member must also exchange gear');
+        assert.strictEqual(afterWorkerExchange.party.partyId, 'exchange-party', 'exchange must preserve party membership');
+        assert.strictEqual((await owner.commit(lease, cached, { allowParty: true, allowLifecycle: true })).ok, false,
+            'a pre-exchange worker proposal cannot restore the returned item');
+
+        // Use small explicit equipment templates to cover layout decisions.
+        const originalItems = DataCache.items;
+        const fixture = (selfId, kind, slot, pDef, mDef = 0) => ({ selfId,
+            template: { name: `Gear fixture ${selfId}`, kind, price: 100 },
+            etc: { slot, rank: 'd', stackable: false }, stats: { pDef, mDef } });
+        DataCache.items = [...originalItems,
+            fixture(990001, 'Armor.Chain', 10, 40), fixture(990002, 'Armor.Chain', 11, 30),
+            fixture(990003, 'Armor.Chain', 15, 100), fixture(990004, 'Armor.Jewel', 4, 0, 20)];
+        try {
+            const tank = { level: 20, classId: 4 };
+            const row = (id, selfId, slot, enchant = 0) => ({ id, selfId, slot, amount: 1, equipped: true, enchant });
+            const full = { id: 1000, selfId: 990003, amount: 1, enchant: 0 };
+            const torso = Policy.plan(tank, [row(1,990001,10), row(2,990002,11)], full);
+            assert.deepStrictEqual(torso.returned.map((item) => item.id), [1,2]);
+            assert.strictEqual(Policy.plan(tank, [row(1,990003,15)], { ...full, selfId:990001 }), null,
+                'a lone top must not replace a full-body layout');
+            const ring = { id:1001, selfId:990004, amount:1, enchant:3 };
+            const jewelry = Policy.plan(tank, [row(3,990004,4,6), row(4,990004,5,0)], ring);
+            assert.strictEqual(jewelry.slot, 5);
+            assert.deepStrictEqual(jewelry.returned.map((item) => item.id), [4], 'return only the weaker ring');
+            assert.strictEqual(Policy.plan({level:19,classId:4}, [], ring), null, 'grade must respect level');
+            assert.strictEqual(Policy.plan(tank, [row(3,990004,4,6), row(4,990004,5,6)], ring), null,
+                'enchanted equipment must not be replaced with a weaker copy');
+        } finally { DataCache.items = originalItems; }
+        console.log('Clan warehouse equipment exchange checks passed');
+    } finally {
+        originals.reverse().forEach((restore) => restore());
+        await Database.close();
+        fs.rmSync(directory, { recursive: true, force: true });
+    }
+}
+main().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/tests/test_cold_inventory_instance_sync.js
+++ b/tests/test_cold_inventory_instance_sync.js
@@ -1,0 +1,111 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { DatabaseSync } = require('node:sqlite');
+require('../src/Global');
+const Database = invoke('Database');
+const DataCache = invoke('GameServer/DataCache');
+const LifeState = invoke('GameServer/Bot/Population/BotLifeState');
+const Planner = invoke('GameServer/Bot/AI/GearAcquisitionPlanner');
+const Summary = invoke('GameServer/Bot/Population/InventorySummary');
+
+async function main() {
+    DataCache.init();
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'cold-instances-'));
+    const databasePath = path.join(directory, 'test.sqlite');
+    const seed = new DatabaseSync(databasePath);
+    seed.exec(fs.readFileSync(path.resolve(__dirname, '../database/sql/sqlite.sql'), 'utf8'));
+    seed.exec(`INSERT INTO accounts(username,password) VALUES ('bot_instances','test');
+        INSERT INTO clans(id,name,level,leaderId) VALUES (71,'InstancesClan',1,21);
+        INSERT INTO characters(id,username,name,classId,race,level,maxHp,maxMp,sex,face,hair,hairColor,locX,locY,locZ,clanId)
+        VALUES (21,'bot_instances','InstanceProbe',50,3,31,500,500,0,0,0,0,0,0,0,71);
+        INSERT INTO bot_life_state(characterId,accountName,characterName,level,activity,phase,inventorySummary,statsJson,updatedAt)
+        VALUES (21,'bot_instances','InstanceProbe',31,'hunting','cold','{}','{"classId":50,"role":"buffer"}',1);
+        INSERT INTO items(id,characterId,selfId,name,amount,enchant,equipped,slot)
+        VALUES (101,21,881,'Elven Ring',1,6,1,4);
+        INSERT INTO clan_warehouse_items(id,clanId,selfId,name,kind,amount,enchant)
+        VALUES (201,71,879,'Enchanted Ring','Armor.Jewel',1,0);`);
+    seed.close();
+    options.default.Database.path = databasePath;
+    Database.init();
+    await LifeState.init();
+    const execute = (sql, params = []) => Database.execute([sql, params]);
+    const rings = async () => (await Database.fetchItems(21)).filter((item) => item.selfId === 881);
+    try {
+        const inventory = LifeState.inventorySummaryFromItems(await Database.fetchItems(21));
+        inventory['57'] = { selfId: 57, name: 'Adena', amount: 1000000, stackable: true };
+        let state = await LifeState.upsertState({ ...(await LifeState.findByCharacterId(21)), inventory, adena: 1000000 }, 'instance_test_seed');
+        const purchased = await LifeState.applyMarketPurchase(state, { selfId: 881, price: 62300, sourceType: 'npc' }, 1);
+        assert(purchased, 'a second ring purchase must succeed');
+        assert.strictEqual(purchased.inventory['881'].amount, 2);
+        assert.strictEqual(purchased.inventory['881'].instances.length, 2, 'purchase must add an instance as well as increase amount');
+        let rows = await rings();
+        assert.strictEqual(rows.length, 2, 'both paid-for rings must materialize');
+        assert.deepStrictEqual(rows.map((row) => row.enchant).sort(), [0, 6], 'new ring must not inherit +6');
+        assert.deepStrictEqual(rows.map((row) => row.slot).sort(), [4, 5]);
+        const ids = rows.map((row) => row.id).sort();
+        await Database.syncInventorySummary(21, purchased.inventory);
+        await Database.syncInventorySummary(21, purchased.inventory);
+        assert.deepStrictEqual((await rings()).map((row) => row.id).sort(), ids, 'pending instance IDs must not churn physical objects');
+
+        // Recreate an existing incomplete snapshot: count=2, one instance and
+        // one physical ring, while the cold paperdoll claims both slots.
+        await execute('DELETE FROM items WHERE characterId = 21 AND selfId = 881 AND id != 101');
+        const broken = structuredClone(purchased.inventory);
+        broken['881'].instances = [broken['881'].instances.find((instance) => instance.id === 101)];
+        await execute('UPDATE bot_life_state SET inventorySummary = ?, activity = ? WHERE characterId = 21', [JSON.stringify(broken), 'hunting']);
+        const request = { clanId: 71, characterId: 21, warehouseId: 201, expectedPhase: 'cold' };
+        const refused = await Database.exchangeClanWarehouseEquipment(request);
+        assert.strictEqual(refused.code, 'inventory_not_materialized', 'warehouse must not fill a phantom empty slot');
+        assert.strictEqual((await Database.fetchClanWarehouseItems(71)).length, 1);
+        assert.strictEqual((await execute('SELECT * FROM clan_warehouse_ledger')).length, 0, 'guard must not return/withdraw anything');
+
+        state = { ...purchased, activity: 'hunting', inventory: broken };
+        const refreshed = await LifeState.refreshInventory(state, { equip: true });
+        assert.strictEqual(refreshed.inventory['881'].instances.length, 2, 'normal refresh must heal an older incomplete snapshot');
+        assert.strictEqual((await rings()).length, 2);
+        await LifeState.upsertState(refreshed, 'instance_refresh');
+        assert.strictEqual((await Database.exchangeClanWarehouseEquipment(request)).code, 'not_an_upgrade');
+
+        // An identity captured before another sync must reuse its corresponding
+        // unclaimed row, preserving enchant, rather than insert/delete forever.
+        const staleIds = structuredClone(refreshed.inventory);
+        staleIds['881'].instances[1].id = 999999;
+        const beforeStale = (await rings()).map((row) => row.id).sort();
+        await Database.syncInventorySummary(21, staleIds);
+        await Database.syncInventorySummary(21, staleIds);
+        assert.deepStrictEqual((await rings()).map((row) => row.id).sort(), beforeStale);
+
+        await execute(`INSERT INTO clan_warehouse_items(id,clanId,selfId,name,kind,amount,enchant)
+            VALUES (202,71,881,'Elven Ring','Armor.Jewel',1,3)`);
+        const exchanged = await LifeState.applyClanWarehouseExchange({ ...request, warehouseId: 202 });
+        assert(exchanged.ok, JSON.stringify(exchanged));
+        assert.deepStrictEqual(exchanged.returned.map((row) => row.enchant), [0], 'exchange must return the weaker real copy');
+        const afterExchange = await LifeState.refreshInventory(exchanged.state, { equip: true });
+        const afterSale = await LifeState.applyNpcLiquidation(afterExchange, [{ selfId: 881, count: 2, npcPrice: 100 }]);
+        assert.strictEqual(afterSale.adena, afterExchange.adena, 'received/worn rings must not become NPC sale surplus');
+        rows = await rings();
+        assert.deepStrictEqual(rows.map((row) => row.enchant).sort(), [3, 6]);
+        assert.deepStrictEqual(rows.map((row) => row.slot).sort(), [4, 5]);
+        const returned = (await Database.fetchClanWarehouseItems(71)).filter((row) => row.selfId === 881);
+        assert.deepStrictEqual(returned.map((row) => row.enchant), [0]);
+
+        // Selling surplus must retain the equipped identity even if listed last.
+        const sold = { selfId: 881, amount: 1, equippedSlots: [5], instances: [
+            { id: 777, amount: 1, enchant: 0, equipped: false, slot: 0 },
+            { id: 101, amount: 1, enchant: 6, equipped: true, slot: 5 }
+        ] };
+        const retained = Summary.completeInstances(sold);
+        assert.deepStrictEqual(retained.instances.map((instance) => [instance.id, instance.enchant, instance.slot]), [[101, 6, 5]]);
+        assert.strictEqual(sold.instances.length, 2, 'normalization must not mutate the input');
+        const grown = Planner.equipInventoryUpgrades(state, broken);
+        assert.strictEqual(grown['881'].instances.length, 2, 'cold optimizer must complete instances before physical persistence');
+        assert.deepStrictEqual(grown['881'].instances.map((instance) => instance.enchant).sort(), [0, 6]);
+        console.log('Cold inventory instance synchronization checks passed');
+    } finally {
+        await Database.close();
+        fs.rmSync(directory, { recursive: true, force: true });
+    }
+}
+main().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/tests/test_cold_worker_party_coordinator.js
+++ b/tests/test_cold_worker_party_coordinator.js
@@ -52,6 +52,42 @@ async function createMember(index, spot, dueAt) {
     return Number(character.id);
 }
 
+async function createRequiredMember(index, spot, timestamp) {
+    const accountName = `worker_required_${index}`;
+    const name = `WorkerRequired${index}`;
+    await Database.createAccount(accountName, 'secret');
+    await Database.createCharacter(accountName, {
+        name, race: 0, classId: 0, maxHp: 300, maxMp: 120,
+        sex: 0, face: 0, hair: 0, hairColor: 0,
+        locX: spot.center.locX, locY: spot.center.locY, locZ: spot.center.locZ
+    });
+    const character = (await Database.fetchCharacters(accountName))[0];
+    const stats = {
+        classId: 0,
+        role: index === 1 ? 'tank' : 'dps',
+        partyRequest: {
+            status: 'open', priority: 'required', requestedAt: timestamp - 60000,
+            spotId: spot.id, npcId: 1
+        }
+    };
+    await Database.execute([
+        `INSERT INTO bot_life_state (
+            characterId, accountName, characterName, level, exp, sp, adena,
+            homeRegion, currentRegion, spotId, activity, phase,
+            activityStartedAt, nextResolveAt, lastResolvedAt,
+            locX, locY, locZ, hp, maxHp, mp, maxMp, partyId,
+            statsJson, inventorySummary, updatedAt
+        ) VALUES (?, ?, ?, ?, 1000, 100, 500, ?, ?, ?, 'party_wait', 'cold',
+            ?, ?, ?, ?, ?, ?, 300, 300, 120, 120, NULL, ?, '{}', ?)`,
+        [Number(character.id), accountName, name, Math.max(8, Number(spot.minLevel || 8)),
+            spot.region || spot.name, spot.region || spot.name, spot.id,
+            timestamp - 60000, timestamp + 600000, timestamp - 60000,
+            spot.center.locX, spot.center.locY, spot.center.locZ,
+            JSON.stringify(stats), timestamp]
+    ]);
+    return Number(character.id);
+}
+
 let coordinator = null;
 (async () => {
     const spot = {
@@ -64,6 +100,10 @@ let coordinator = null;
     SpotProfiles.ensure = () => [spot];
     const dueAt = Date.now() - 60000;
     const memberIds = [await createMember(1, spot, dueAt), await createMember(2, spot, dueAt)];
+    const requiredIds = [
+        await createRequiredMember(1, spot, Date.now()),
+        await createRequiredMember(2, spot, Date.now())
+    ];
     await Database.execute([
         `INSERT INTO bot_background_parties (
             partyId, leaderId, memberIdsJson, spotId, startedAt, nextResolveAt,
@@ -109,6 +149,13 @@ let coordinator = null;
         await wait(50);
         snapshot = coordinator.snapshot();
     }
+    const formationProposal = await coordinator.requestRequiredPartyFormation({ candidateLimit: 12 });
+    assert.strictEqual(formationProposal.ok, true, 'main must receive a required-party proposal from the worker');
+    assert.deepStrictEqual(
+        formationProposal.candidates.map((candidate) => Number(candidate.characterId)).sort((a, b) => a - b),
+        [...requiredIds].sort((a, b) => a - b),
+        'worker proposal must contain the compatible unassigned required requests'
+    );
     assert.strictEqual(mainCommands, 0, 'party combat must never execute on the main lifecycle command bridge');
     assert(Number(snapshot.worker.resolved || 0) >= 2, 'worker must resolve every claimed party member');
     assert(Number(snapshot.queue.committed || 0) >= 2, 'main DB gateway must commit every party member');

--- a/tests/test_npc_object_index.js
+++ b/tests/test_npc_object_index.js
@@ -1,0 +1,196 @@
+const assert = require('assert');
+const { performance } = require('perf_hooks');
+
+require('../src/Global');
+
+const World = invoke('GameServer/World/World');
+const Index = require('../src/GameServer/World/NpcObjectIndex');
+const Awareness = invoke('GameServer/Bot/AI/PartyAwareness');
+const Combat = invoke('GameServer/Bot/AI/PartyCombatState');
+const Decay = invoke('GameServer/World/Generics/NpcDecay');
+const Spawn = invoke('GameServer/World/Generics/SpawnNpcs');
+const BotManager = invoke('GameServer/Bot/BotManager');
+
+function actor(id) {
+    return {
+        id, dead: false, targetId: 0, x: 0,
+        fetchId() { return this.id; },
+        fetchDestId() { return this.targetId; },
+        fetchLocX() { return this.x; },
+        fetchLocY: () => 0,
+        fetchLocZ: () => 0,
+        fetchIsOnline: () => true,
+        fetchAttackable: () => true,
+        fetchClassId: () => 0,
+        fetchSelfId: () => 1,
+        isDead() { return this.dead; },
+        state: { fetchDead: () => false, fetchHits: () => false, fetchCasts: () => false },
+        backpack: { fetchEquippedArmors: () => [] }
+    };
+}
+
+(async () => {
+    const original = { npc: World.npc, user: World.user, bots: BotManager.sessions };
+    try {
+        const leader = { actor: actor(2000001) };
+        const companion = { actor: actor(2000002), partyCompanion: true, followPlayerSession: leader };
+        const target = actor(1037566);
+        const add = actor(1037567);
+        let fillerReads = 0;
+        const filler = Array.from({ length: 37565 }, (_, i) => ({
+            fetchId() { fillerReads++; return 1000000 + i; }
+        }));
+        World.npc = { spawns: [...filler, target, add], grid: {}, gridKeys: new WeakMap() };
+        World.user = { sessions: [leader, companion] };
+        BotManager.sessions = [companion];
+        leader.actor.targetId = target.id;
+        companion.incomingThreatId = add.id;
+        companion.incomingThreatAt = Date.now();
+        const expectedTarget = Awareness.leaderCombatTargetId(leader);
+        const expectedIncoming = Awareness.recentIncomingNpc(companion);
+        assert.strictEqual(expectedTarget, target.id);
+        assert.strictEqual(expectedIncoming, add);
+
+        World.indexSpawnsInGrid();
+        fillerReads = 0;
+        // Catch an accidental fallback on both hits and misses, independently
+        // of machine speed. A missing/just-despawned target must stay O(1).
+        const originalFind = World.npc.spawns.find;
+        World.npc.spawns.find = () => { throw new Error('full NPC scan in indexed lookup'); };
+        assert.strictEqual(Awareness.leaderCombatTargetId(leader), expectedTarget);
+        assert.strictEqual(Awareness.recentIncomingNpc(companion), expectedIncoming);
+        assert.strictEqual(await World.fetchNpc(target.id), target);
+        assert.strictEqual(Index.find(World, -1), null);
+        assert.strictEqual(Index.find(World, String(target.id)), null, 'strict lookup must not coerce IDs');
+        let rejected = false;
+        await World.fetchNpc(-1).catch(() => { rejected = true; });
+        assert(rejected, 'async lookup must retain its missing-NPC rejection');
+        assert.strictEqual(fillerReads, 0, 'hot lookup must not read unrelated NPC IDs');
+        World.npc.spawns.find = originalFind;
+
+        add.targetId = companion.actor.id;
+        Awareness.invalidateThreatProjection(leader);
+        assert.strictEqual(Combat.combatState(leader).target, add, 'incoming add still interrupts party work');
+        add.dead = true;
+        assert.strictEqual(Awareness.recentIncomingNpc(companion), null, 'death is read immediately, without cache expiry');
+        target.dead = true;
+        assert.strictEqual(Awareness.leaderCombatTargetId(leader), null, 'dead targets remain forbidden');
+        target.dead = false;
+        assert.strictEqual(Awareness.leaderCombatTargetId(leader), target.id, 'live state is not copied into the index');
+        leader.actor.targetId = -1;
+        assert.strictEqual(Awareness.leaderCombatTargetId(leader), null, 'target switching is immediate');
+
+        Decay.decay(World, add);
+        assert.strictEqual(Index.find(World, add.id), null, 'corpse decay removes the object');
+        assert.strictEqual(Awareness.recentIncomingNpc(companion), null, 'removed incoming targets stay absent');
+        const respawn = actor(1037568);
+        World.npc.spawns.push(respawn);
+        World.addNpcToGrid(respawn);
+        assert.strictEqual(Index.find(World, respawn.id), respawn, 'respawn is available immediately under its new ID');
+        leader.actor.targetId = respawn.id;
+        assert.strictEqual(Awareness.leaderCombatTargetId(leader), respawn.id);
+        respawn.x = 6500;
+        World.addNpcToGrid(respawn);
+        assert.strictEqual(Index.find(World, respawn.id), respawn, 'movement preserves object identity');
+
+        const quest = actor(1037569);
+        World.npc.spawns.push(quest);
+        World.addNpcToGrid(quest);
+        assert(Spawn.despawnQuestNpc(World, quest));
+        assert.strictEqual(Index.find(World, quest.id), null, 'quest despawn removes the object');
+        const summon = actor(1037570);
+        summon.fetchIsSummon = () => true;
+        World.npc.spawns.push(summon);
+        World.addNpcToGrid(summon);
+        invoke('GameServer/Actor/Generics/NpcDied')({}, leader.actor, summon);
+        assert.strictEqual(Index.find(World, summon.id), null, 'legacy summon death removes the indexed object');
+        Decay.decayMany(World, [target, respawn]);
+        assert.strictEqual(Index.find(World, target.id), null, 'batch decay removes every indexed corpse');
+        assert.strictEqual(Index.find(World, respawn.id), null, 'array filtering does not strand indexed actors');
+
+        const replacement = actor(target.id);
+        World.npc.spawns.push(replacement);
+        World.addNpcToGrid(replacement);
+        World.removeNpcFromGrid(target);
+        assert.strictEqual(Index.find(World, target.id), replacement, 'late cleanup cannot evict a replacement');
+        World.npc.spawns = [replacement];
+        World.indexSpawnsInGrid();
+        assert.strictEqual(Index.find(World, 1000000), null, 'explicit world rebuild drops old objects');
+        assert.strictEqual(Index.find(World, target.id), replacement);
+
+        World.npc.nextId = 4000000;
+        World.user = { sessions: [] };
+        const definition = {
+            npc: require('../data/Npcs/npcs.json')[0],
+            spawn: { coords: [{ locX: 0, locY: 0, locZ: 0, head: 0 }], respawn: 60 },
+            bounds: []
+        };
+        const spawned = Spawn.spawnNpc(World, definition);
+        assert.strictEqual(Index.find(World, spawned.fetchId()), spawned, 'real spawn path registers its new actor');
+        const oldSpawnId = spawned.fetchId();
+        Decay.decay(World, spawned);
+        const respawned = Spawn.spawnNpc(World, definition);
+        assert.notStrictEqual(respawned.fetchId(), oldSpawnId);
+        assert.strictEqual(Index.find(World, oldSpawnId), null);
+        assert.strictEqual(Index.find(World, respawned.fetchId()), respawned, 'real respawn path does not reuse a stale actor');
+        Decay.decay(World, respawned);
+
+        const DataCache = invoke('GameServer/DataCache');
+        const Rates = invoke('GameServer/ProgressionRates');
+        const originalRewards = DataCache.fetchNpcRewardsFromSelfId;
+        const originalRoll = Rates.rewardGroupRoll;
+        try {
+            DataCache.fetchNpcRewardsFromSelfId = (_id, callback) => callback({ spoils: [{ items: [{ selfId: 57 }] }] });
+            Rates.rewardGroupRoll = () => ({ hit: false });
+            const corpse = actor(4000002);
+            corpse.dead = true;
+            corpse.model = { spoil: { spoiled: true, swept: false } };
+            World.npc.spawns.push(corpse);
+            World.addNpcToGrid(corpse);
+            const sweeper = actor(2000003);
+            Object.assign(sweeper, {
+                fetchMp: () => 100, setMp() {}, statusUpdateVitals() {},
+                automation: { replenishVitals() {} },
+                attack: { queueTimer(effect) { effect(); } }
+            });
+            sweeper.state.setCasts = () => {};
+            const sweepSkill = new (invoke('GameServer/Model/Skill'))({
+                selfId: 42, name: 'Sweeper', level: 1, mp: 0, hitTime: 0, reuse: 0
+            });
+            invoke('GameServer/Npc/SpoilSweep').castSweep({ dataSendToMe() {}, dataSendToMeAndOthers() {} }, sweeper, corpse, sweepSkill);
+            assert.strictEqual(corpse.model.spoil.swept, true);
+            assert.strictEqual(Index.find(World, corpse.id), null, 'legacy Sweep path removes its indexed corpse');
+            Decay.decay(World, corpse);
+            assert.strictEqual(Index.find(World, corpse.id), null, 'later corpse timer remains harmless after Sweep');
+        } finally {
+            DataCache.fetchNpcRewardsFromSelfId = originalRewards;
+            Rates.rewardGroupRoll = originalRoll;
+        }
+
+        // Measure identical exact-ID lookups, not end-to-end server latency.
+        World.npc.spawns = [...filler, replacement];
+        World.indexSpawnsInGrid();
+        const iterations = 2000;
+        let result;
+        let started = performance.now();
+        for (let i = 0; i < iterations; i++) result = World.npc.spawns.find((npc) => npc.fetchId() === target.id);
+        const linearMs = performance.now() - started;
+        assert.strictEqual(result, replacement);
+        fillerReads = 0;
+        started = performance.now();
+        for (let i = 0; i < iterations; i++) result = Index.find(World, target.id);
+        const indexedMs = performance.now() - started;
+        assert.strictEqual(result, replacement);
+        assert.strictEqual(fillerReads, 0);
+        console.log(`NPC lookup benchmark: ${iterations} lookups / ${World.npc.spawns.length} NPCs: linear=${linearMs.toFixed(2)}ms indexed=${indexedMs.toFixed(2)}ms`);
+
+        World.npc = { spawns: [quest] };
+        assert.strictEqual(Index.find(World, quest.id), quest, 'unindexed lightweight worlds retain legacy lookup');
+        assert.strictEqual(Index.find(World, target.id), null, 'world replacement cannot retain the old index');
+    } finally {
+        World.npc = original.npc;
+        World.user = original.user;
+        BotManager.sessions = original.bots;
+    }
+    console.log('NPC object index lifecycle, combat parity and bounded lookup checks passed');
+})().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/tests/test_party_companion_rest_follow.js
+++ b/tests/test_party_companion_rest_follow.js
@@ -2514,9 +2514,10 @@ try {
     assert(!companionHtml.includes('bgcolor=333333'), 'companion cards should avoid the flat grey card background');
 
     const activeAdd = {
+        dead: false,
         fetchId: () => 3012,
         fetchAttackable: () => true,
-        isDead: () => false,
+        isDead() { return this.dead; },
         fetchLevel: () => 26,
         fetchDestId: () => partyHudLeader.fetchId(),
         fetchLocX: () => 300,
@@ -2537,12 +2538,23 @@ try {
     partyHudBotA.moves = [];
     partyHudLeaderSession.partyPullState = {};
     CompanionControl(partyHudLeaderSession, ['companion-control', 'member-pull', 'on', partyHudBotA.fetchName()]);
+    let pullingBotAssistId = null;
     FollowingState.tick(partyHudBotASession, partyHudBotA, {}, {
-        say() {}, executeCombat() { throw new Error('puller must not start a new pull while the party is fighting an add'); }, executePvPCombat() {}
+        say() {},
+        executeCombat(_session, _bot, npc) { pullingBotAssistId = npc.fetchId(); },
+        executePvPCombat() {}
     });
     assert.strictEqual(partyHudBotASession.roleDecision.reason, 'party_under_attack', 'an unrelated incoming threat must pause bot pulling');
     assert.strictEqual(partyHudLeaderSession.partyPullState.targetId, undefined, 'a live party threat must not be replaced with a new pull target');
     assert.strictEqual(partyHudBotA.moves.length, 0, 'a paused puller must stay with the party during an active fight');
+    assert.strictEqual(pullingBotAssistId, activeAdd.fetchId(), 'a paused puller must join ordinary party combat against the active add');
+
+    activeAdd.dead = true;
+    partyHudLeader.destId = undefined;
+    FollowingState.tick(partyHudBotASession, partyHudBotA, {}, {
+        say() {}, executeCombat() {}, executePvPCombat() {}
+    });
+    assert.strictEqual(partyHudLeaderSession.partyPullState.targetId, freePullTarget.fetchId(), 'pulling must resume with a new target after the party clears every active mob');
     World.npc = { spawns: [pulledMob] };
     World.fetchNpcsInRadius = () => [pulledMob];
 

--- a/tests/test_personal_warehouse.js
+++ b/tests/test_personal_warehouse.js
@@ -14,6 +14,11 @@ const GameRequest = invoke('GameServer/Network/Request');
 DataCache.items = [{
     selfId: 1000, name: 'Warehouse Test Item', kind: 'Other', stackable: true,
     class1: 4, class2: 5, mass: 1, price: 100
+}, {
+    selfId: 627,
+    template: { kind: 'Armor.Shield', name: 'Aspis', class1: 1, class2: 1, mass: 1350, price: 35000 },
+    stats: { pDef: 114 },
+    etc: { slot: 8, rank: 'd' }
 }];
 
 function item(id, amount) {
@@ -90,6 +95,13 @@ Warehouse.deposit(session, [{ objectId: 10, amount: 7 }]).then(async () => {
     assert.deepStrictEqual(calls, ['inventory-insert', 'warehouse-delete'], 'withdraw must persist destination inventory before deleting warehouse state');
     assert.strictEqual(persistedWarehouse.length, 0, 'withdraw must persist warehouse removal immediately');
     assert.strictEqual(session.actor.backpack.items[0].fetchAmount(), 7, 'withdraw should materialize the stored item in inventory');
+
+    persistedWarehouse.push({ id: 501, selfId: 627, name: 'Aspis', amount: 1, enchant: 0, petData: null });
+    const listedAspis = (await Warehouse.list(123)).find((entry) => entry.fetchSelfId() === 627);
+    assert.strictEqual(listedAspis.fetchSlot(), 8, 'warehouse gear should use its canonical equipment slot in memory');
+    await Warehouse.withdraw(session, [{ objectId: 501, amount: 1 }]);
+    const restoredAspis = session.actor.backpack.items.find((entry) => entry.fetchSelfId() === 627);
+    assert.strictEqual(restoredAspis.fetchSlot(), 8, 'warehouse withdrawal should materialize a shield in the shield slot');
 
     session.activeNpcTalk.objectId = 999999;
     await assert.rejects(

--- a/tests/test_stackable_inventory_persistence.js
+++ b/tests/test_stackable_inventory_persistence.js
@@ -26,14 +26,22 @@ DataCache.init();
     await Database.setItem(characterId, { selfId: 1835, name: 'Soulshot: No Grade', amount: 2 });
     await Database.setItem(characterId, { selfId: 1835, name: 'Soulshot: No Grade', amount: 3 });
     await Database.setItem(characterId, { selfId: 1835, name: 'Soulshot: No Grade', amount: 5 });
+    await Database.setItem(characterId, { selfId: 2155, name: 'Recipe: Elven Ring', amount: 1 });
+    await Database.setItem(characterId, { selfId: 2155, name: 'Recipe: Elven Ring', amount: 1 });
     await Database.setItem(characterId, { selfId: 1, name: 'Short Sword', amount: 1 });
     await Database.setItem(characterId, { selfId: 1, name: 'Short Sword', amount: 1 });
 
+    const recipeTemplate = DataCache.items.find((item) => Number(item.selfId) === 2155);
+    assert.strictEqual(recipeTemplate?.etc?.stackable, true, 'recipe items must be marked stackable in the datapack');
+
     const rawSummary = BotLifeState.inventorySummaryFromItems([
         { selfId: 1835, name: 'Soulshot: No Grade', amount: 10, equipped: 0, slot: 0 },
+        { selfId: 2155, name: 'Recipe: Elven Ring', amount: 2, equipped: 0, slot: 0 },
         { selfId: 1, name: 'Short Sword', amount: 1, equipped: 0, slot: 0 }
     ]);
     assert.strictEqual(rawSummary['1835'].stackable, true, 'raw SQLite rows must inherit stackability from the datapack');
+    assert.strictEqual(rawSummary['2155'].stackable, true, 'recipe rows must inherit stackability from the datapack');
+    assert.strictEqual(rawSummary['2155'].amount, 2, 'identical recipe rows must aggregate into one inventory summary stack');
     assert.strictEqual(rawSummary['1'].stackable, false, 'equipment rows must remain non-stackable');
 
     const legacySummary = BotLifeState.normalizeInventoryStackability({
@@ -47,13 +55,16 @@ DataCache.init();
     assert.strictEqual(legacySummary['2'], undefined, 'zero-amount inventory entries must not survive normalization');
     assert.strictEqual(legacySummary['3'], undefined, 'negative inventory entries must not survive normalization');
 
-    const result = await Database.compactStackableInventory([1835], 'test-stackable-compaction-v1');
-    assert.strictEqual(result.rowsRemoved, 2, 'one-time maintenance must remove duplicate stackable rows');
+    const result = await Database.compactStackableInventory([1835, 2155], 'test-stackable-compaction-v1');
+    assert.strictEqual(result.rowsRemoved, 3, 'one-time maintenance must remove duplicate stackable rows');
     const rows = await Database.fetchItems(characterId);
     const shots = rows.filter((item) => Number(item.selfId) === 1835);
+    const recipes = rows.filter((item) => Number(item.selfId) === 2155);
     const swords = rows.filter((item) => Number(item.selfId) === 1);
     assert.strictEqual(shots.length, 1, 'stackable inventory must use one physical row');
     assert.strictEqual(Number(shots[0].amount), 10, 'stackable compaction must preserve the total amount');
+    assert.strictEqual(recipes.length, 1, 'stackable recipes must use one physical row');
+    assert.strictEqual(Number(recipes[0].amount), 2, 'recipe compaction must preserve the total amount');
     assert.strictEqual(swords.length, 2, 'non-stackable inventory must preserve separate object rows');
 
     const repeated = await Database.compactStackableInventory([1835], 'test-stackable-compaction-v1');

--- a/tests/test_world_observer_knowledge_base.js
+++ b/tests/test_world_observer_knowledge_base.js
@@ -18,7 +18,7 @@ const service = createKnowledgeBaseService({
 try {
     process.env.L2NODE_PROGRESSION_RATE = 'x1';
     const meta = service.meta();
-    assert.strictEqual(meta.counts.items, 5062);
+    assert.strictEqual(meta.counts.items, 5067);
     assert.strictEqual(meta.counts.mobs, 2068);
     assert.strictEqual(meta.rateProfile.drop, 1);
     assert.deepStrictEqual(meta.npcFilters.weaknesses.map(({ key }) => key), [
@@ -26,7 +26,7 @@ try {
     ]);
     assert.deepStrictEqual(meta.npcFilters.hpMultipliers.map(({ value }) => value), [0.5, 2, 3, 4, 5, 6, 9]);
     const weaponDirectory = meta.itemDirectory.find((entry) => entry.key === 'weapons');
-    assert.strictEqual(weaponDirectory.total, 511);
+    assert.strictEqual(weaponDirectory.total, 516);
     assert.strictEqual(weaponDirectory.grades.find((grade) => grade.key === 'd').count, 121);
     assert.deepStrictEqual(meta.itemDirectory.find((entry) => entry.key === 'materials').grades, [
         { key: 'no-grade', count: 606 }


### PR DESCRIPTION
## Summary

- speed up protected party formation and NPC lookup with bounded, lifecycle-managed indexing
- improve party combat, autonomous retreat routing, and dwarf Spoil/Sweep behavior
- extend equipment progression with C4 A/S dual swords and automatic clan warehouse exchanges
- keep recipe stacking, HP-scaled rewards, warehouse slots, and cold inventory state consistent

## Validation

- `npm test`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new dual-sword weapons and Blacksmith of Mammon combinations.
  * Added automatic Spoil and Sweep support for eligible bots.
  * Added clan warehouse equipment exchanges for bot members.
  * Added protected party formation for required party requests.
  * Added canonical equipment-slot handling across inventory and warehouses.
  * Improved NPC targeting performance and retreat behavior.

* **Bug Fixes**
  * Corrected inventory synchronization, equipment preservation, and stale-save conflicts.
  * NPC HP scaling now correctly affects experience and SP rewards.
  * Improved puller combat continuation and corpse-sweep retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->